### PR TITLE
Helm: Configurable OSD directory or devices

### DIFF
--- a/examples/helm/ceph/templates/osd/daemonset_devices.yaml
+++ b/examples/helm/ceph/templates/osd/daemonset_devices.yaml
@@ -1,0 +1,133 @@
+{{- if not .Values.osd_directory.enabled }}
+{{ range $index, $value := $.Values.osd_devices -}}
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: ceph-osd-{{ $value.device }}-{{ $value.type }}
+  labels:
+    version: {{ $.Chart.Version }}
+    app: ceph
+    daemon: osd
+    release: {{ $.Release.Name }}
+    device_{{ $value.device }}: {{ $value.type }}
+spec:
+  template:
+    metadata:
+      labels:
+        version: {{ $.Chart.Version }}
+        app: ceph
+        daemon: osd
+        release: {{ $.Release.Name }}
+        device_{{ $value.device }}: {{ $value.type }}
+    spec:
+      nodeSelector:
+        {{ $.Values.labels.node_selector_key }}: {{ $.Values.labels.node_selector_value | quote }}
+        device_{{ $value.device }}: {{ $value.type }}
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: osd-pod
+          image: {{ $.Values.images.daemon }}
+          imagePullPolicy: {{ $.Values.image_policy.pull }}
+          volumeMounts:
+            - name: devices
+              mountPath: /dev
+            - name: ceph-conf
+              mountPath: /etc/ceph/ceph.conf
+              subPath: ceph.conf
+              readOnly: true
+            - name: ceph
+              mountPath: /var/lib/ceph
+            - name: ceph-client-admin-keyring
+              mountPath: /etc/ceph/ceph.client.admin.keyring
+              subPath: ceph.client.admin.keyring
+              readOnly: true
+            - name: ceph-mon-keyring
+              mountPath: /etc/ceph/ceph.mon.keyring
+              subPath: ceph.mon.keyring
+              readOnly: true
+            - name: ceph-bootstrap-osd-keyring
+              mountPath: /var/lib/ceph/bootstrap-osd/ceph.keyring
+              subPath: ceph.keyring
+              readOnly: false
+            - name: ceph-bootstrap-mds-keyring
+              mountPath: /var/lib/ceph/bootstrap-mds/ceph.keyring
+              subPath: ceph.keyring
+              readOnly: false
+            - name: ceph-bootstrap-rgw-keyring
+              mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
+              subPath: ceph.keyring
+              readOnly: false
+          securityContext:
+            privileged: true
+          env:
+            - name: CEPH_DAEMON
+              value: osd
+            - name: KV_TYPE
+              value: k8s
+            - name: CLUSTER
+              value: {{ $.Values.ceph.cluster }}
+            - name: CEPH_GET_ADMIN_KEY
+              value: "1"
+            - name: OSD_DEVICE
+              value: /dev/{{ $value.device }}
+            {{ if index $value "journal" }}
+            - name: JOURNAL
+              value: /dev/{{ $value.journal }}
+            {{ end }}
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{ if index $value "crush_location" }}
+            - name: CRUSH_LOCATION
+              value: {{ $value.crush_location }}
+            {{ end }}
+          livenessProbe:
+            tcpSocket:
+              port: 6800
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 6800
+            timeoutSeconds: 5
+          resources:
+            requests:
+              memory: {{ $.Values.resources.osd.requests.memory | quote }}
+              cpu: {{ $.Values.resources.osd.requests.cpu | quote }}
+            limits:
+              memory: {{ $.Values.resources.osd.limits.memory | quote }}
+              cpu: {{ $.Values.resources.osd.limits.cpu | quote }}
+      volumes:
+        - name: devices
+          hostPath:
+            path: /dev
+        - name: ceph-conf
+          configMap:
+            name: ceph-conf
+        - name: ceph
+          # emptyDir: {}
+          hostPath:
+            path: {{ $.Values.ceph.storage.var_directory }}
+        - name: ceph-client-admin-keyring
+          secret:
+            secretName: {{ $.Values.secrets.keyrings.admin }}
+        - name: ceph-mon-keyring
+          secret:
+            secretName: {{ $.Values.secrets.keyrings.mon }}
+        - name: ceph-bootstrap-osd-keyring
+          secret:
+            secretName: {{ $.Values.secrets.keyrings.osd }}
+        - name: ceph-bootstrap-mds-keyring
+          secret:
+            secretName: {{ $.Values.secrets.keyrings.mds }}
+        - name: ceph-bootstrap-rgw-keyring
+          secret:
+            secretName: {{ $.Values.secrets.keyrings.rgw }}
+        - name: ceph-disk-init
+          configMap:
+            name: ceph-disk-init
+{{ end }}
+{{ end }}

--- a/examples/helm/ceph/templates/osd/daemonset_dir.yaml
+++ b/examples/helm/ceph/templates/osd/daemonset_dir.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.osd_directory.enabled }}
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -114,3 +115,4 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: {{ .Values.secrets.keyrings.rgw }}
+{{ end }}

--- a/examples/helm/ceph/values.yaml
+++ b/examples/helm/ceph/values.yaml
@@ -125,3 +125,31 @@ storageclass:
   admin_secret_name: pvc-ceph-conf-combined-storageclass
   user_id: admin
   user_secret_name: pvc-ceph-client-key
+
+## osd_devices defines the osd layout for each node. Each
+## item will create a DaemonSet for the given configuration
+## but will not activate the OSDs yet. To activate the OSD,
+## the node should be labeled with `device_{device}={type}`,
+## eg. `device_sdb=hdd`. This will activate `/dev/sdb` to
+## become an OSD daemon.
+##
+## Devices need to have a GPT partition or activation may fail
+##
+## the format for an OSD item is:
+##   device: {the block storage. eg. `/dev/sdb` should just be `sdb`}
+##   type: {osd classification. typically `hdd` and `ssd` but can be anything}
+##   crush_location: {optional. updates the crush location of the osd}
+##   journal: {optional. if specified, will not prepare the disk and will not collocate the journal}
+##
+osd_directory:
+  enabled: true
+osd_devices:
+  - device: sdb
+    type: hdd
+    # crush_location: "root=standard host=$(HOSTNAME)-standard"
+  - device: sdc
+    type: hdd
+  - device: sdd1
+    type: hdd
+    # crush_location: "root=default host=$(HOSTNAME)"
+    # journal: sdx1


### PR DESCRIPTION
I thought I'd raise this PR to get some discussion going on the best way to handle multiple OSDs in a cluster. There has been some discussion in [various](https://github.com/att-comdev/openstack-helm/pull/158) places about real disk support.

We've been using an approach with daemonsets per device across a cluster. It gives more control to the OSD lifecycle with drive types, crush location and rolling restarts. Its served us reasonable well for clusters with identical servers/disks but may be difficult to manage in a varied cluster.

It may be that the best solution is a ThirdPartyResources/Operator but for now this does allow the use of real devices with Helm. Please jump in with thoughts, alternatives and ideas