### PR TITLE
Kubernetes example compatibility improvements

### DIFF
--- a/examples/kubernetes/ceph-mds-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mds-v1-dp.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
         - name: ceph-mds
           image: ceph/daemon:latest
+          #image: ceph/daemon:tag-build-master-kraken-centos-7
           ports:
             - containerPort: 6800
           env:

--- a/examples/kubernetes/ceph-mon-check-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-check-v1-dp.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: ceph-mon
           image: ceph/daemon:latest
+          #image: ceph/daemon:tag-build-master-kraken-centos-7
           imagePullPolicy: Always
           ports:
             - containerPort: 6789

--- a/examples/kubernetes/ceph-mon-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-v1-dp.yaml
@@ -50,7 +50,8 @@ spec:
       containers:
         - name: ceph-mon
           image: ceph/daemon:latest
-#          imagePullPolicy: Always
+          #image: ceph/daemon:tag-build-master-kraken-centos-7
+          imagePullPolicy: Always
           lifecycle:
             preStop:
                 exec:

--- a/examples/kubernetes/ceph-osd-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-v1-ds.yaml
@@ -43,6 +43,7 @@ spec:
       containers:
         - name: osd-pod
           image: ceph/daemon:latest
+          #image: ceph/daemon:tag-build-master-kraken-centos-7
           imagePullPolicy: Always
           volumeMounts:
             - name: devices

--- a/examples/kubernetes/ceph-osd-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-v1-ds.yaml
@@ -17,9 +17,12 @@ spec:
       nodeSelector:
         node-type: storage
       volumes:
-        - name: devices
-          hostPath:
-            path: /dev
+# Comment back in to use direct device access.
+# Note that this will also require enabling privileged access and
+# the appropriate volumeMount below.
+#        - name: devices
+#          hostPath:
+#            path: /dev
         - name: ceph
           emptyDir: {}
 #          hostPath:
@@ -46,8 +49,8 @@ spec:
           #image: ceph/daemon:tag-build-master-kraken-centos-7
           imagePullPolicy: Always
           volumeMounts:
-            - name: devices
-              mountPath: /dev
+#            - name: devices
+#              mountPath: /dev
             - name: ceph
               mountPath: /var/lib/ceph
             - name: ceph-conf
@@ -60,8 +63,10 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-rgw
             - name: osd-directory
               mountPath: /var/lib/ceph/osd
-          securityContext:
-            privileged: true
+# Privileged access is required if you operate on raw devices.
+# Remember to add the /dev volume and mount above.
+#         securityContext:
+#           privileged: true
           env:
             - name: CEPH_DAEMON
               value: osd_directory

--- a/examples/kubernetes/ceph-rgw-v1-dp.yaml
+++ b/examples/kubernetes/ceph-rgw-v1-dp.yaml
@@ -36,6 +36,8 @@ spec:
       containers:
         - name: ceph-rgw
           image: ceph/daemon:latest
+          #image: ceph/daemon:tag-build-master-kraken-centos-7
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
This pull request makes the osd container unprivileged by default. That can make it easier to run on a Kubernetes cluster if privileged containers are disallowed by default. I have added comments that state what needs to be done in order to use a raw disk on an OSD. The second patch just adds a comment with an image to use the CentOS version. The Ubuntu version consistently failed for me when running more than one OSD, while the CentOS image worked. This might make it easier for others to use an alternative image.

I understand that the privileged context might be intended and this is why I split this pull request off of my previous one. It just fits the default example with an emptydir for storage where privileges are not required.