### PR TITLE
Revert moving of get_mon_config $ip_version

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
@@ -117,9 +117,10 @@ function start_mon {
     exit 1
   fi
 
+  get_mon_config $ip_version
+
   # If we don't have a monitor keyring, this is a new monitor
   if [ ! -e "$MON_DATA_DIR/keyring" ]; then
-    get_mon_config $ip_version
 
     if [ ! -e "$MON_KEYRING" ]; then
       log "ERROR- $MON_KEYRING must exist.  You can extract it from your current monitor by running 'ceph auth get mon. -o $MON_KEYRING' or use a KV Store"


### PR DESCRIPTION
Revert "get_mon_config $ip_version" move from https://github.com/ceph/ceph-docker/commit/5676bb74cea112a49b604e437bcea355934f1561#diff-e3e55f84c79d8da58edb99156bf4fddc

It solves this issue https://github.com/ceph/ceph-docker/issues/816