### PR TITLE
[skip ci] daemon: osd: source ceph default file env

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_osd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_osd.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 
-if is_redhat; then
-  source /etc/sysconfig/ceph
-elif is_ubuntu; then
-  source /etc/default/ceph
-fi
+[ -e /etc/sysconfig/ceph ] && . /etc/sysconfig/ceph && ceph_env_file=/etc/sysconfig/ceph
+[ -e /etc/default/ceph ] && . /etc/default/ceph && ceph_env_file=/etc/default/ceph
+
+# shellcheck disable=SC2013
+for i in $(grep -vE '^#|^$' < "$ceph_env_file"); do
+  # shellcheck disable=SC2163
+  export $i
+done
 
 function start_osd {
   get_config


### PR DESCRIPTION
Prior to this commit we were sourcing the file but the variables weren't
exposed.

Signed-off-by: Sébastien Han <seb@redhat.com>