### PR TITLE
daemon: remove OSD_FORCE_ZAP option

### DIFF
--- a/ceph-releases/luminous/rhel/7.3/daemon/README.md
+++ b/ceph-releases/luminous/rhel/7.3/daemon/README.md
@@ -122,7 +122,7 @@ Options for OSDs (TODO: consolidate these options between the types):
 
 If the operator does not specify an `OSD_TYPE` autodetection happens:
 
-- `disk` is used if no bootstrapped OSD is found. `OSD_FORCE_ZAP=1` must be set at this point.
+- `disk` is used if no bootstrapped OSD is found.
 - `activate` is used if a bootstrapped OSD is found and `OSD_DEVICE` is also provided.
 - `directory` is used if a bootstrapped OSD is found and no `OSD_DEVICE` is provided.
 
@@ -136,7 +136,6 @@ docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
 -e OSD_DEVICE=/dev/vdd \
--e OSD_FORCE_ZAP=1 \
 ceph/daemon osd
 ```
 
@@ -148,7 +147,6 @@ docker run -d --net=host \
 --pid=host \
 -v /dev/:/dev/ \
 -e OSD_DEVICE=/dev/vdd \
--e OSD_FORCE_ZAP=1 \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon osd

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/README.md
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/README.md
@@ -121,7 +121,7 @@ Options for OSDs (TODO: consolidate these options between the types):
 
 If the operator does not specify an `OSD_TYPE` autodetection happens:
 
-- `disk` is used if no bootstrapped OSD is found. `OSD_FORCE_ZAP=1` must be set at this point.
+- `disk` is used if no bootstrapped OSD is found.
 - `activate` is used if a bootstrapped OSD is found and `OSD_DEVICE` is also provided.
 - `directory` is used if a bootstrapped OSD is found and no `OSD_DEVICE` is provided.
 
@@ -135,7 +135,6 @@ docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
 -e OSD_DEVICE=/dev/vdd \
--e OSD_FORCE_ZAP=1 \
 ceph/daemon osd
 ```
 
@@ -147,7 +146,6 @@ docker run -d --net=host \
 --pid=host \
 -v /dev/:/dev/ \
 -e OSD_DEVICE=/dev/vdd \
--e OSD_FORCE_ZAP=1 \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon osd

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -19,30 +19,12 @@ function osd_disk_prepare {
 
   ceph_health client.bootstrap-osd "$OSD_BOOTSTRAP_KEYRING"
 
-  # check device status first
-  if ! parted --script "${OSD_DEVICE}" print > /dev/null 2>&1; then
-    if [[ ${OSD_FORCE_ZAP} -eq 1 ]]; then
-      log "It looks like ${OSD_DEVICE} isn't consistent, however OSD_FORCE_ZAP is enabled so we are zapping the device anyway"
-      ceph-disk -v zap "${OSD_DEVICE}"
-    else
-      log "Regarding parted, device ${OSD_DEVICE} is inconsistent/broken/weird."
-      log "It would be too dangerous to destroy it without any notification."
-      log "Please set OSD_FORCE_ZAP to '1' if you really want to zap this disk."
-      exit 1
-    fi
-  fi
-
   # then search for some ceph metadata on the disk
   if parted --script "${OSD_DEVICE}" print | grep -qE '^ 1.*ceph data'; then
-    if [[ ${OSD_FORCE_ZAP} -eq 1 ]]; then
-      log "It looks like ${OSD_DEVICE} is an OSD, however OSD_FORCE_ZAP is enabled so we are zapping the device anyway"
-      ceph-disk -v zap "${OSD_DEVICE}"
-    else
-      log "INFO- It looks like ${OSD_DEVICE} is an OSD, set OSD_FORCE_ZAP=1 to use this device anyway and zap its content"
-      log "You can also use the zap_device scenario on the appropriate device to zap it"
-      log "Moving on, trying to activate the OSD now."
-      return
-    fi
+    log "INFO: It looks like ${OSD_DEVICE} is an OSD"
+    log "You can use the zap_device scenario on the appropriate device to zap it"
+    log "Moving on, trying to activate the OSD now."
+    return
   fi
 
   IFS=" " read -r -a CEPH_DISK_CLI_OPTS <<< "${CLI_OPTS[*]}"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
@@ -47,12 +47,9 @@ function osd_disks {
     OSD_DEV="/dev/$(echo "${OSD_DISK}"|sed 's/\(.*\):\(.*\)/\2/')"
 
     if parted --script "${OSD_DEV}" print | grep -qE '^ 1.*ceph data'; then
-      if [[ ${OSD_FORCE_ZAP} -eq 1 ]]; then
-        ceph-disk -v zap "${OSD_DEV}"
-      else
-        log "ERROR- It looks like the device ($OSD_DEV) is an OSD, set OSD_FORCE_ZAP=1 to use this device anyway and zap its content"
-        exit 1
-      fi
+      log "ERROR: It looks like the device ($OSD_DEV) is an OSD"
+      log "You can use the zap_device scenario on the appropriate device to zap it."
+      exit 1
     fi
 
     ceph-disk -v prepare "${CLI_OPTS[@]}" "${OSD_DEV}" "${OSD_JOURNAL}"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -24,7 +24,6 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 : "${KUBECTL_PARAM:='-l daemon=mon'}"
 : "${NETWORK_AUTO_DETECT:=0}"
 : "${MDS_NAME:=${HOSTNAME}}"
-: "${OSD_FORCE_ZAP:=0}"
 : "${OSD_JOURNAL_SIZE:=100}"
 : "${OSD_BLUESTORE:=1}"
 : "${OSD_FILESTORE:=0}"


### PR DESCRIPTION
It is too dangerous to have this kind of capability, especially if there
is automation in place that uses this option.
Prior to deploy an OSD you must make sure the device is in a proper
shape. Also, ceph-disk prepare will create a GPT label if there is no
label on the drive.

Signed-off-by: Sébastien Han <seb@redhat.com>