### PR TITLE
luminous: Don't provide a keyring argument to rbd-mirror

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_rbd_mirror.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_rbd_mirror.sh
@@ -28,5 +28,5 @@ function start_rbd_mirror {
 
   log "SUCCESS"
   # start rbd-mirror
-  exec /usr/bin/rbd-mirror "${DAEMON_OPTS[@]}" -n client.rbd-mirror."${RBD_MIRROR_NAME}" -k "$RBD_MIRROR_KEYRING"
+  exec /usr/bin/rbd-mirror "${DAEMON_OPTS[@]}" -n client.rbd-mirror."${RBD_MIRROR_NAME}"
 }


### PR DESCRIPTION
rbd-mirror needs to use multiple keyrings to connect to multiple
clusters. Passing the -k argument prevents it from doing so. It finds
the correct keyring on its own via the -n argument, so the -k is
unnecessary anyhow.