### PR TITLE
daemon: Adds support for client config subsections with confd

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/confd/conf.d/ceph.conf.toml.in
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/confd/conf.d/ceph.conf.toml.in
@@ -8,5 +8,6 @@ keys = [
  "/mon_host/",
  "/osd/",
  "/mds/",
- "/client/"
+ "/client/,"
+ "client_host/"
 ]

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/confd/templates/ceph.conf.tmpl
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/confd/templates/ceph.conf.tmpl
@@ -24,3 +24,8 @@
 [client]
 {{range gets "/client/*"}}
   {{base .Key}} = {{.Value}}{{end}}
+{{range ls "/client_host"}}
+  [{{.}}]
+    {{with $key := . | printf "/client_host/%s/*"}}{{range gets $key}}
+      {{base .Key}} = {{.Value}}{{end}}{{end}}
+{{end}}


### PR DESCRIPTION
This should enable deployments of clients with client specific configurations, such as a RGW deployment with one RGW instance serving the s3 API and another serving the s3websites API.

The config:
```
[client]

  keyring = /etc/ceph/local1.client.admin.keyring

  [client.rgw.rgwstatic]
    
      rgw_dns_s3website_name = "hargwwebsite"
      rgw_enable_apis = s3website
      rgw_enable_static_website = "true"
      rgw_host = "rgwstatic"
```
ceph.defaults:
```
/client_host/client.rgw.rgwstatic/rgw_host "rgwstatic"
/client_host/client.rgw.rgwstatic/rgw_enable_static_website "true"
/client_host/client.rgw.rgwstatic/rgw_dns_s3website_name "hargwwebsite"
/client_host/client.rgw.rgwstatic/rgw_enable_apis "s3website"
```