### PR TITLE
Add minimal numactl support

### DIFF
--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -14,7 +14,7 @@ RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-releas
 RUN yum install -y epel-release
 ADD ganesha.repo /etc/yum.repos.d/
 RUN yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd wget nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd wget nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw hwloc numactl"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -6,7 +6,7 @@ LABEL Maintainer="Sebastien Han 'seb@redhat.com'"
 
 ENV container docker
 
-ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw e2fsprogs ceph-mgr"
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw e2fsprogs ceph-mgr hwloc numactl"
 RUN yum -y update && \
     yum -y install $PACKAGES && \
     rpm -q $PACKAGES && \

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -13,7 +13,7 @@ ENV KUBECTL_VERSION v1.6.0
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
 # Packages list
-ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw hwloc numactl"
 
 # install prerequisites
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev dmsetup && \

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/entrypoint.sh.in
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/entrypoint.sh.in
@@ -148,6 +148,10 @@ case "$CEPH_DAEMON" in
     # TAG: demo
     source demo.sh
     ;;
+  topology)
+    # TAG: topology
+    lstopo-no-graphics
+    ;;
   disk_list)
     # TAG: disk_list
     source disk_list.sh

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -69,6 +69,12 @@ function osd_activate {
   fi
   apply_ceph_ownership_to_disks
 
+  if [[ ${OSD_NUMACTL} -eq 1 ]]; then
+      NUMACTL="/usr/bin/numactl -N ${OSD_NUMACTL_NODE_NUMBER} --${OSD_NUMACTL_POLICY}=${OSD_NUMACTL_POLICY_OPT}"
+  else
+      NUMACTL=""
+  fi
+
   log "SUCCESS"
-  exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  exec ${NUMACTL} /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
 }


### PR DESCRIPTION
Adds -e OSD_NUMACTL* options for ceph/daemon to start OSDs
using nuamctl. Also adds topology option to show the NUMA
topology of container host. Includes two new packages: hwloc
and numactl.