### PR TITLE
Enable Ceph Manager restful module port for the Ubuntu 16.04 demo

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/demo/ceph_demo
+++ b/ceph-releases/luminous/ubuntu/16.04/demo/ceph_demo
@@ -186,6 +186,7 @@ function start_ceph_nano {
     --memory 1g \
     "${VOLUMES[@]}" \
     -v $WORKING_DIR:$WORKING_DIR \
+    -p "$IP":5000:5000 \
     -p "$IP":8000:8000 \
     -p "$IP":7000:7000 \
     -e CEPH_DEMO_UID=$CEPH_NANO_UID \


### PR DESCRIPTION
This is just a suggestion, so that one doesn't need to find out the IP of the Docker container to be able to access the API of the Ceph Manager.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>