### PR TITLE
zap: fix issue on AWS environment

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/zap_device.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/zap_device.sh
@@ -2,7 +2,7 @@
 set -e
 
 function zap_device {
-  local device_match_string='/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p){1,2}'
+  local device_match_string='/dev/([x]?[hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p){1,2}'
 
   if [[ -z ${OSD_DEVICE} ]]; then
     log "Please provide device(s) to zap!"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
@@ -2,7 +2,7 @@
 set -e
 
 function zap_device {
-  local device_match_string='/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p){1,2}'
+  local device_match_string='/dev/([x]?[hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p){1,2}'
 
   if [[ -z ${OSD_DEVICE} ]]; then
     log "Please provide device(s) to zap!"


### PR DESCRIPTION
devices like : `/dev/xvda` don't match the current regexp, therefore the
purge fails on AWS environment.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>