### PR TITLE
Update the URL. 404 for current.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -197,7 +197,7 @@ kubectl create -f ceph-osd-activate-v1-ds.yaml --namespace=ceph
 First, create a RBD provisioner pod:
 
 ```
-$ kubectl create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/ceph/rbd/deployment.yaml --namespace=ceph
+$ kubectl create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/ceph/rbd/deploy/non-rbac/deployment.yaml --namespace=ceph
 ```
 Then, if there is no Ceph admin secret with type `kubernetes.io/rbd`, create one:
 


### PR DESCRIPTION
RBAC is now part of k8s, so for simplicity I linked to the non RBAC role version