### PR TITLE
Cleaning container

### DIFF
--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -8,29 +8,32 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 ENV CEPH_VERSION luminous
 ENV CONFD_VERSION 0.10.0
 
-# Install Ceph
-RUN rpm --import 'https://download.ceph.com/keys/release.asc'
-RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
-RUN yum install -y epel-release
-ADD ganesha.repo /etc/yum.repos.d/
-RUN yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd wget nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
-ARG PURGES="/tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux} /usr/lib/{udev,systemd}"
-RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all && rm -rf $PURGES
-
-# Install confd
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
-RUN chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
-
-# Download forego
-RUN wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
-  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
-
-# Add s3cfg file
 ADD s3cfg /root/.s3cfg
 
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
+
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd wget nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
+
+# Install Ceph
+ADD ganesha.repo /etc/yum.repos.d/
+
+RUN rpm --import 'https://download.ceph.com/keys/release.asc' && \
+  rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
+  yum install -y epel-release && \
+  yum clean all && \
+  yum install -y $PACKAGES && \
+  rpm -q $PACKAGES && \
+  yum clean all && \
+  \
+  # Install confd
+  wget -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" && \
+  chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
+  \
+  # Download forego
+  wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
+  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz && \
+  bash /clean_container.sh && rm /clean_container.sh
 
 # Modify the entrypoint
 RUN bash "/generate_entrypoint.sh" && \

--- a/ceph-releases/luminous/centos/7/daemon/clean_container.sh
+++ b/ceph-releases/luminous/centos/7/daemon/clean_container.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+INITIAL_SIZE="$(du -sm / 2>/dev/null | awk '{ print $1 }')"
+DEBUG=
+
+PURGES="/tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux} /usr/lib/{udev,systemd}"
+PURGES="$PURGES /usr/share/hwdata/{iab.txt,oui.txt}"
+# As we need to keep every PURGES as an arguement to rm, let's ignore SC2086
+# shellcheck disable=SC2086
+rm -rf $PURGES
+
+PURGE_PKGS="groff-base e2fsprogs sharutils shadow-utils yum-utils python-gobject-base python-kitchen passwd bind-license policycoreutils-python epel-release"
+PURGE_PKGS="$PURGE_PKGS libselinux-python libss libcgroup dbus-python yum-plugin-ovl rbd-mirror libxml2-python python-IPy checkpolicy libsemanage-python setools-libs"
+PURGE_PKGS="$PURGE_PKGS systemd-sysv dbus-glib gobject-introspection audit-libs-python"
+
+# Step 1
+# Let's remove easy stuff
+strip -s /usr/local/bin/{confd,forego}
+
+# Compressing those very big binaries
+# As we don't run them often, the peformance penalty isn't huge
+for binary in /usr/bin/{etcdctl,kubectl} /usr/local/bin/{forego,confd}; do
+  gzexe $binary && rm ${binary}~
+done
+
+rm -rf /usr/share/{doc,info,locale,man}/*
+
+# Some logfiles are not empty, there is no need to keep them
+find /var/log/ -type f -exec truncate -s 0 {} \;
+
+STEP1_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP1_SIZE=$((INITIAL_SIZE - STEP1_SIZE))
+echo "Stripping process: Step 1 removed ${REMOVED_STEP1_SIZE}MB"
+
+# Step 2
+# Let's remove stuff than can be discussed
+
+rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* # Photoshop files inside a container ?
+
+# Let's remove all the pre-compiled python files, if needed they will be rebuilt
+find  / -xdev -name "*.pyc" -exec rm {} \; # 23MB of pyc
+
+# ceph-dencoder is only used for debugging, compressing it saves 10MB
+# If needed it will be decompressed
+xz /usr/bin/ceph-dencoder
+
+# Timezone is not configured so let's remove the zoneinfo (8MB)
+rpm -e tzdata --nodeps
+
+# Removing perl as we don't need it
+# perl is required by libibverbs (Infiniband) which is required by ceph in general
+# the ceph daemons are linked against the lib but we don't care about perl itself
+#	perl(Getopt::Long) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(File::Basename) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(strict) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(warnings) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	/usr/bin/perl is needed by (installed) libibverbs-13-7.el7.x86_64
+# as we need to keep every rpm as an argument to rpm, let's ignore SC2046
+# shellcheck disable=SC2046
+rpm -e $(rpm -qa perl* | tr  "\\n" " ") --nodeps
+
+# Removing useless packages
+# As we need to keep every PURGE_PKGS as an arguement to rpm, let's ignore SC2086
+# shellcheck disable=SC2086
+rpm -e $PURGE_PKGS
+
+# rebuilding the rpm database to save space (~25%)
+rpmdb --rebuilddb
+
+STEP2_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP2_SIZE=$((STEP1_SIZE - STEP2_SIZE))
+echo "Stripping process: Step 2 removed ${REMOVED_STEP2_SIZE}MB"
+
+# Final
+REMOVED_SIZE=$((INITIAL_SIZE - STEP2_SIZE))
+echo "Stripping process saved ${REMOVED_SIZE}MB and dropped container size from ${INITIAL_SIZE}MB to ${STEP2_SIZE}MB"
+
+if [ -n "$DEBUG" ]; then
+  find / -xdev -type f  -exec du -c {} \; |sort -n
+fi

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -38,7 +38,6 @@ WORKDIR /
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Atomic specific labels
-ADD install.sh /install.sh
 LABEL version=3
 LABEL run="/usr/bin/docker run -d --net=host --pid=host -e MON_NAME=\${MON_NAME} -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph \${IMAGE}"
 LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -e MON_NAME=\${MON_NAME} -e OSD_DEVICE=\${OSD_DEVICE} -e HOST=/host -e IMAGE=\${IMAGE} --entrypoint=/install.sh \${IMAGE}"

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -1,18 +1,23 @@
 # RHCS IMAGE
 # RHCS VERSION: 3
 
-FROM rhel7:7-released
+ARG DOCKER_REPO
+FROM ${DOCKER_REPO}rhel7:7.3-released
 LABEL Maintainer="Sebastien Han 'seb@redhat.com'"
 
 ENV container docker
 
+# Add bootstrap script, ceph defaults key/values for KV store
+ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
+
+ARG CEPH_REPO_URL
 ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw e2fsprogs ceph-mgr"
-ARG PURGES="/tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux}"
-RUN yum -y update && \
+RUN [ -n "$CEPH_REPO_URL" ] && yum-config-manager --add-repo ${CEPH_REPO_URL} ; \
+    yum -y update && \
     yum -y install $PACKAGES && \
     rpm -q $PACKAGES && \
     yum clean all && \
-    rm -rf $PURGES
+    /clean_container.sh && rm -f /clean_container.sh
 
 # Editing /etc/redhat-storage-server release file
 RUN echo "Red Hat Ceph Storage Server 3 (Container)" > /etc/redhat-storage-release
@@ -22,8 +27,6 @@ EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph","/etc/ganesha"]
 
-# Add bootstrap script, ceph defaults key/values for KV store
-ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
 RUN bash "/generate_entrypoint.sh" && \

--- a/ceph-releases/luminous/rhel/7.3/daemon/clean_container.sh
+++ b/ceph-releases/luminous/rhel/7.3/daemon/clean_container.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+INITIAL_SIZE="$(du -sm / 2>/dev/null | awk '{ print $1 }')"
+DEBUG=
+
+PURGES="/tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux} /usr/lib/{udev,systemd}"
+PURGES="$PURGES /usr/share/hwdata/{iab.txt,oui.txt}"
+# As we need to keep every PURGES as an arguement to rm, let's ignore SC2086
+# shellcheck disable=SC2086
+rm -rf $PURGES
+
+PURGE_PKGS="groff-base e2fsprogs shadow-utils yum-utils python-gobject-base python-kitchen passwd"
+PURGE_PKGS="$PURGE_PKGS libss dbus-python yum-plugin-ovl rbd-mirror libxml2-python"
+PURGE_PKGS="$PURGE_PKGS systemd-sysv dbus-glib gobject-introspection python-dmidecode subscription-manager usermode"
+PURGE_PKGS="$PURGE_PKGS dbus-glib python-kitchen python-decorator python-ethtool gobject-introspection yum-plugin-ovl m2crypto python-rhsm virt-what"
+
+# Step 1
+# Let's remove easy stuff
+strip -s /usr/local/bin/{confd,forego}
+
+# Compressing those very big binaries
+# As we don't run them often, the peformance penalty isn't huge
+for binary in /usr/bin/{etcdctl,kubectl} /usr/local/bin/{forego,confd}; do
+  gzexe $binary && rm ${binary}~
+done
+
+rm -rf /usr/share/{doc,info,locale,man}/*
+
+# Some logfiles are not empty, there is no need to keep them
+find /var/log/ -type f -exec truncate -s 0 {} \;
+
+STEP1_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP1_SIZE=$((INITIAL_SIZE - STEP1_SIZE))
+echo "Stripping process: Step 1 removed ${REMOVED_STEP1_SIZE}MB"
+
+# Step 2
+# Let's remove stuff than can be discussed
+
+rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* # Photoshop files inside a container ?
+
+# Let's remove all the pre-compiled python files, if needed they will be rebuilt
+find  / -xdev -name "*.pyc" -exec rm {} \; # 23MB of pyc
+
+# ceph-dencoder is only used for debugging, compressing it saves 10MB
+# If needed it will be decompressed
+xz /usr/bin/ceph-dencoder
+
+# Timezone is not configured so let's remove the zoneinfo (8MB)
+rpm -e tzdata --nodeps
+
+# Removing perl as we don't need it
+# perl is required by libibverbs (Infiniband) which is required by ceph in general
+# the ceph daemons are linked against the lib but we don't care about perl itself
+#	perl(Getopt::Long) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(File::Basename) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(strict) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	perl(warnings) is needed by (installed) libibverbs-13-7.el7.x86_64
+#	/usr/bin/perl is needed by (installed) libibverbs-13-7.el7.x86_64
+# as we need to keep every rpm as an argument to rpm, let's ignore SC2046
+# shellcheck disable=SC2046
+rpm -e $(rpm -qa perl* | tr  "\\n" " ") --nodeps
+
+# Removing useless packages
+# As we need to keep every PURGE_PKGS as an arguement to rpm, let's ignore SC2086
+# shellcheck disable=SC2086
+rpm -e $PURGE_PKGS
+
+# rebuilding the rpm database to save space (~25%)
+rpmdb --rebuilddb
+
+STEP2_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP2_SIZE=$((STEP1_SIZE - STEP2_SIZE))
+echo "Stripping process: Step 2 removed ${REMOVED_STEP2_SIZE}MB"
+
+# Final
+REMOVED_SIZE=$((INITIAL_SIZE - STEP2_SIZE))
+echo "Stripping process saved ${REMOVED_SIZE}MB and dropped container size from ${INITIAL_SIZE}MB to ${STEP2_SIZE}MB"
+
+if [ -n "$DEBUG" ]; then
+  find / -xdev -type f  -exec du -c {} \; |sort -n
+fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -9,40 +9,35 @@ ENV CEPH_VERSION luminous
 ENV CONFD_VERSION 0.10.0
 ENV KUBECTL_VERSION v1.6.0
 
-# Download confd
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
-
 # Packages list
 ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
 ARG PURGES="/var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux} /usr/lib/{udev,systemd}"
-
-# install prerequisites
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev dmsetup && \
-\
-# Install ceph, ganesha and etcd
-    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
-    echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    echo "deb http://download.ceph.com/nfs-ganesha/deb-V2.5-stable/luminous/ xenial main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
-    apt-get update && apt-get install -y --force-yes $PACKAGES && \
-    dpkg -s $PACKAGES && \
-    apt-get clean && rm -rf $PURGES && \
-\
-# Install confd
-    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
-\
-# Install forego
-    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
-    cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
-
-# Install kubectl
-ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
-
 # Add s3cfg file
 ADD s3cfg /root/.s3cfg
 
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
+
+# install prerequisites
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev dmsetup && \
+  \ # Install ceph, ganesha and etcd
+  wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+  echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
+  echo "deb http://download.ceph.com/nfs-ganesha/deb-V2.5-stable/luminous/ xenial main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
+  apt-get update && apt-get install -y  --no-install-recommends --force-yes $PACKAGES && \
+  dpkg -s $PACKAGES && \
+  apt-get clean && rm -rf $PURGES && \
+  \ # Download & install confd
+  wget -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" && \
+  chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
+  \ # Install forego
+  wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
+  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz && \
+  \ # Install kubectl
+  wget -O /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+  chmod +x /usr/local/bin/kubectl && \
+  \ # Cleaning container
+  bash /clean_container.sh && rm /clean_container.sh
 
 # Modify the entrypoint
 RUN bash "/generate_entrypoint.sh" && \

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/clean_container.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/clean_container.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+INITIAL_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+DEBUG=
+
+# Step 1
+# Let's remove easy stuff
+strip -s /usr/local/bin/{confd,forego,kubectl}
+strip -s /usr/bin/{crushtool,monmaptool,osdmaptool}
+rm -rf /usr/share/{doc,info,locale,man}/*
+rm -f /usr/bin/{etcd-tester,etcd-dump-logs}
+
+# Let's compress fat binaries but keep them executable
+# As we don't run them often, the performance penalty isn't that big
+for binary in /usr/local/bin/{confd,forego,kubectl} /usr/bin/etcdctl; do
+  gzexe $binary && rm -f ${binary}~
+done
+
+STEP1_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP1_SIZE=$((INITIAL_SIZE - STEP1_SIZE))
+echo "Stripping process: Step 1 removed ${REMOVED_STEP1_SIZE}MB"
+
+# Step 2
+# Let's remove stuff than can be discussed
+
+# Let's strip the ceph libraries
+strip -s /usr/lib/ceph/erasure-code/*
+strip -s /usr/lib/rados-classes/*
+strip -s /usr/lib/python2.7/dist-packages/{rados,rbd,rgw}.x86_64-linux-gnu.so
+
+rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* # Photoshop files inside a container ?
+
+# Let's remove all the pre-compiled python files, if needed they will be rebuilt
+find  / -xdev -name "*.pyc" -exec rm {} \; # 23MB of pyc
+
+# ceph-dencoder is only used for debugging, compressing it saves 10MB
+# If needed it will be decompressed
+gzip -9 /usr/bin/ceph-dencoder
+
+# Timezone is not configured so let's remove the zoneinfo (8MB)
+dpkg --purge --force-all tzdata
+
+# Removing perl as we don't need it
+apt-get remove -y --auto-remove perl
+apt-get purge -y perl
+apt-get purge -y --auto-remove perl
+# Removing agressively perl-base as nothing we use call perl yet.
+# perl-base is required by adduser, init-system-helpers and debconf
+# At this stage of the build process, it's not a big deal breaking those tools for saving storage space
+dpkg --purge --force-all perl-base libperl5.22
+
+# Some logfiles are not empty, there is no need to keep them
+find /var/log/ -type f -exec truncate -s 0 {} \;
+
+STEP2_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}')
+REMOVED_STEP2_SIZE=$((STEP1_SIZE - STEP2_SIZE))
+echo "Stripping process: Step 2 removed ${REMOVED_STEP2_SIZE}MB"
+
+# Final
+REMOVED_SIZE=$((INITIAL_SIZE - STEP2_SIZE))
+echo "Stripping process saved ${REMOVED_SIZE}MB and dropped container size from ${INITIAL_SIZE}MB to ${STEP2_SIZE}MB"
+
+if [ -n "$DEBUG" ]; then
+  find / -xdev -type f -exec du -c {} \; |sort -n
+fi


### PR DESCRIPTION
The actual container is running a pretty classic ubuntu container full of useless stuff.
As a result the container is pretty big on the filesystem.

This patch aims at gaining disk's space by using the following techniques:
- stripping raw binaries/libraries
- removing useless data files like documentation
- removing useless binaries
- removing useless packages like perl
- removing testing code/binaries
- removing pre-compiled python files as we nearly don't use them
- compressing debugging tools
- clearing log files

Note the stripping process is done in two passes :
- first one targets "easy" stuff
- second one targets more tricky such that may be discussed if some
  issue occurs

A typical output looks like the following :
  Step 18 : RUN bash "/clean_container.sh"
   ---> Running in 6a48dec89816
  Stripping process: Step 1 removed 137MB
  [...]
  Stripping process: Step 2 removed 212MB
  [...]
  Stripping process saved 349MB and dropped container size from 851MB to 502MB