### PR TITLE
[DNM] new approach of building images

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -1,0 +1,59 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include image.mk
+
+# ====================================================================================
+# Images to Build
+#
+# The images to build. The format is as follows:
+# [ceph release name]_[arch]_[base os name]_[base os registry]_[base os repo]_[base os tag]
+
+IMAGES_TO_BUILD ?= \
+	luminous@amd64@ubuntu@_@ubuntu@16.04 \
+	luminous@arm64@ubuntu@arm64v8@ubuntu@16.04
+
+# ====================================================================================
+# Targets
+
+base.%:
+	@$(MAKE) -C base $(MAKECMDGOALS) ARCH=$(word 2, $(subst @, ,$*)) BASEOS_NAME=$(word 3, $(subst @, ,$*)) BASEOS_REG=$(word 4, $(subst @, ,$*)) BASEOS_REPO=$(word 5, $(subst @, ,$*)) BASEOS_TAG=$(word 6, $(subst @, ,$*))
+
+daemon-base.%: base.%
+	@$(MAKE) -C daemon-base $(MAKECMDGOALS) CEPH_VERSION=$(word 1, $(subst @, ,$*)) ARCH=$(word 2, $(subst @, ,$*)) BASEOS_NAME=$(word 3, $(subst @, ,$*)) BASEOS_REG=$(word 4, $(subst @, ,$*)) BASEOS_REPO=$(word 5, $(subst @, ,$*)) BASEOS_TAG=$(word 6, $(subst @, ,$*))
+
+daemon.%: daemon-base.%
+	@$(MAKE) -C daemon $(MAKECMDGOALS) CEPH_VERSION=$(word 1, $(subst @, ,$*)) ARCH=$(word 2, $(subst @, ,$*)) BASEOS_NAME=$(word 3, $(subst @, ,$*)) BASEOS_REG=$(word 4, $(subst @, ,$*)) BASEOS_REPO=$(word 5, $(subst @, ,$*)) BASEOS_TAG=$(word 6, $(subst @, ,$*))
+
+do.image.%: daemon.% ;
+build: $(foreach p,$(IMAGES_TO_BUILD), do.image.$(p)) ;
+clean: $(foreach p,$(IMAGES_TO_BUILD), do.image.$(p)) ;
+push: $(foreach p,$(IMAGES_TO_BUILD), do.image.$(p)) ;
+
+# ====================================================================================
+# Help
+
+.PHONY: help
+help:
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Targets:'
+	@echo '    build        Build all images.'
+	@echo '    clean        Clean all images.'
+	@echo '    push         Push release images to registry.'
+	@echo ''
+	@echo 'Options:'
+	@echo '    CACHEBUST    Whether to disable image caching. Default is 0.'
+	@echo '    PULL         Whether to pull base images. Default is 1.'
+	@echo '    V            Set to 1 enable verbose build. Default is 0.'

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+SHELL ["/bin/bash","-c"]

--- a/images/base/Dockerfile.rootfs
+++ b/images/base/Dockerfile.rootfs
@@ -1,0 +1,16 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+ADD rootfs.tar /

--- a/images/base/Dockerfile.rootfs-centos
+++ b/images/base/Dockerfile.rootfs-centos
@@ -1,0 +1,19 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+SHELL ["/bin/bash","-c"]
+
+# TODO: RUN command to minimize the image

--- a/images/base/Dockerfile.rootfs-opensuse
+++ b/images/base/Dockerfile.rootfs-opensuse
@@ -1,0 +1,19 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+SHELL ["/bin/bash","-c"]
+
+# TODO: RUN command to minimize the image

--- a/images/base/Dockerfile.rootfs-rhel
+++ b/images/base/Dockerfile.rootfs-rhel
@@ -1,0 +1,19 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+SHELL ["/bin/bash","-c"]
+
+# TODO: RUN command to minimize the image

--- a/images/base/Dockerfile.rootfs-ubuntu
+++ b/images/base/Dockerfile.rootfs-ubuntu
@@ -1,0 +1,35 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+SHELL ["/bin/bash","-c"]
+
+RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
+    # update and upgrade
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy --no-install-recommends && \
+    # cleanup and minimize
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean -y && \
+    rm -rf \
+        /etc/{selinux,systemd,udev} \
+        /lib/{lsb,udev} \
+        /tmp/* \
+        /usr/lib/{locale,systemd,udev} \
+        /usr/share/{doc,info,man} \
+        /var/cache/debconf/* \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/tmp/*

--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -1,0 +1,55 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include ../image.mk
+
+IMAGE = $(REGISTRY)/base:$(ARCH)-$(BASEOS_IMAGE_TAG)
+ROOTFS_BUILDER_IMAGE := $(REGISTRY)/rootfs-builder:$(ARCH)-$(BASEOS_IMAGE_TAG)
+ROOTFS_IMAGE := $(REGISTRY)/rootfs:$$(docker images -q $(ROOTFS_BUILDER_IMAGE))
+
+# Start with the full os-base image, minimize it by cleaning uneeded
+# files and then export the image into a tarball and back in into
+# a new "slim" image. This is the only way to get the removed files
+# from the image history.
+# Note docker multi-stage builds make this much easier but are only
+# available in docker 17.03 which is not widely available.
+BUILDER_TEMP := $(shell mktemp -d)
+rootfs-builder:
+	@echo === docker build $(ROOTFS_BUILDER_IMAGE)
+	@cp Dockerfile.rootfs-$(BASEOS_NAME) $(BUILDER_TEMP)/Dockerfile
+	@cd $(BUILDER_TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEOS_IMAGE)|g' Dockerfile
+	@docker build $(BUILD_BASE_ARGS) -t $(ROOTFS_BUILDER_IMAGE) $(BUILDER_TEMP)
+	@if [ -z "$$(docker images -q $(ROOTFS_IMAGE))" ]; then \
+		$(MAKE) rootfs; \
+	fi
+	@rm -fr $(BUILDER_TEMP)
+
+rootfs:
+	@echo === docker build $(ROOTFS_IMAGE)
+	@CID=`docker create $(ROOTFS_BUILDER_IMAGE) /bin/bash` &&\
+	  docker export $$CID > $(BUILDER_TEMP)/rootfs.tar &&\
+	  docker rm -f $$CID
+	@cp Dockerfile.rootfs $(BUILDER_TEMP)/Dockerfile
+	@docker build $(BUILD_ARGS) -t $(ROOTFS_IMAGE) $(BUILDER_TEMP)
+
+TEMP := $(shell mktemp -d)
+build: rootfs-builder
+	@echo === docker build $(IMAGE)
+	@cp Dockerfile $(TEMP)
+	@cd $(TEMP) && $(SED_CMD) "s|BASEIMAGE|$(ROOTFS_IMAGE)|g" Dockerfile
+	@docker build $(BUILD_ARGS) -t $(IMAGE) $(TEMP)
+	@rm -fr $(TEMP)
+
+push: ; @:
+clean: ; @docker rmi $(IMAGE) $(ROOTFS_BUILDER_IMAGE) $(ROOTFS_IMAGE)

--- a/images/daemon-base/Dockerfile.luminous-ubuntu
+++ b/images/daemon-base/Dockerfile.luminous-ubuntu
@@ -1,0 +1,51 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# add Ceph and other packages needed
+ADD 'https://download.ceph.com/keys/release.asc' /tmp/release.asc
+RUN CEPH_VERSION=luminous && \
+    apt-key add /tmp/release.asc && \
+    echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yy -q --no-install-recommends \
+        ca-certificates \
+        ceph-common \
+        ceph-mon \
+        ceph-osd \
+        ceph-mds \
+        ceph-mgr \
+        kmod \
+        radosgw \
+        rbd-mirror && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean && \
+    rm -rf \
+        /etc/{selinux,systemd,udev} \
+        /lib/{lsb,udev} \
+        /tmp/* \
+        /usr/lib/{locale,systemd,udev} \
+        /usr/share/{doc,info,man} \
+        /var/cache/debconf/* \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/tmp/* && \
+    find  / -xdev -name "*.pyc" -exec rm {} \; && \
+    rm /usr/bin/ceph-dencoder && \
+    strip -s /usr/lib/ceph/erasure-code/* && \
+    strip -s /usr/lib/rados-classes/* && \
+    strip -s /usr/lib/python2.7/dist-packages/{rados,rbd,rgw}.*.so
+

--- a/images/daemon-base/Makefile
+++ b/images/daemon-base/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include ../image.mk
+
+IMAGE := $(REGISTRY)/daemon-base:$(CEPH_VERSION)-$(ARCH)-$(BASEOS_IMAGE_TAG)
+BASEIMAGE = $(REGISTRY)/base:$(ARCH)-$(BASEOS_IMAGE_TAG)
+TEMP := $(shell mktemp -d)
+
+build:
+	@echo === docker build $(IMAGE)
+	@cp -a . $(TEMP)
+	@cp Dockerfile.$(CEPH_VERSION)-$(BASEOS_NAME) $(TEMP)/Dockerfile
+	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+	@docker build $(BUILD_ARGS) -t $(IMAGE) $(TEMP)
+	@rm -fr $(TEMP)
+
+push: ; @docker push $(IMAGE)
+clean: ; @docker rmi $(IMAGE)

--- a/images/daemon/Dockerfile.luminous-ubuntu
+++ b/images/daemon/Dockerfile.luminous-ubuntu
@@ -1,0 +1,17 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# TODO add ceph-container specific stuff (etcd + confd + scripts)

--- a/images/daemon/Makefile
+++ b/images/daemon/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include ../image.mk
+
+CEPH_VERSION ?= luminous
+
+IMAGE = $(REGISTRY)/daemon:$(CEPH_VERSION)-$(ARCH)-$(BASEOS_IMAGE_TAG)
+BASEIMAGE = $(REGISTRY)/daemon-base:$(CEPH_VERSION)-$(ARCH)-$(BASEOS_IMAGE_TAG)
+TEMP := $(shell mktemp -d)
+
+build:
+	@echo === docker build $(IMAGE)
+	@cp Dockerfile.$(CEPH_VERSION)-$(BASEOS_NAME) $(TEMP)/Dockerfile
+	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+	@docker build $(BUILD_ARGS) -t $(IMAGE) $(TEMP)
+	@rm -fr $(TEMP)
+
+push: ; @docker push $(IMAGE)
+clean: ; @docker rmi $(IMAGE)

--- a/images/image.mk
+++ b/images/image.mk
@@ -1,0 +1,101 @@
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# remove default suffixes as we don't use them
+.SUFFIXES:
+SHELL := /bin/bash
+
+# =====================================================================================
+# Common Targets
+#
+.PHONY: all build push clean
+all: build
+
+# =====================================================================================
+# Common Build Options
+
+SED_CMD ?= sed -i -e
+
+CACHEBUST ?= 0
+ifeq ($(CACHEBUST),1)
+BUILD_ARGS += --no-cache
+endif
+
+V ?= 0
+ifeq ($(V),1)
+MAKEFLAGS += VERBOSE=1
+else
+MAKEFLAGS += --no-print-directory
+BUILD_ARGS ?= -q
+endif
+
+PULL ?= 1
+ifeq ($(PULL),1)
+BUILD_BASE_ARGS += --pull
+endif
+export PULL
+
+BUILD_BASE_ARGS += $(BUILD_ARGS)
+
+# =====================================================================================
+# Set the host platform
+
+HOST_OS := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+HOST_ARCH := amd64
+else
+$(error unsupported build platform)
+endif
+HOST_PLATFORM := $(HOST_OS)_$(HOST_ARCH)
+
+# =====================================================================================
+# Set the base OS image name
+
+BASEOS_NAME ?= ubuntu
+BASEOS_REG ?= _
+BASEOS_REPO ?= ubuntu
+BASEOS_TAG ?= 16.04
+
+ifeq ($(BASEOS_REG),_)
+BASEOS_IMAGE := $(BASEOS_REPO):$(BASEOS_TAG)
+else
+BASEOS_IMAGE := $(BASEOS_REG)/$(BASEOS_REPO):$(BASEOS_TAG)
+endif
+BASEOS_IMAGE_TAG := $(BASEOS_NAME)-$(BASEOS_TAG)
+
+# =====================================================================================
+# Docker Registry Options
+
+REGISTRY ?= ceph
+
+# =====================================================================================
+# Ceph Release
+
+CEPH_VERSION ?= luminous
+ARCH ?= amd64
+
+# =====================================================================================
+# nukes all images ( for testing purposes only )
+#
+nuke:
+	@for c in $$(docker ps -a -q --no-trunc); do \
+		echo stopping and removing container $${c}; \
+		docker stop $${c}; \
+		docker rm $${c}; \
+	done
+	@for i in $$(docker images -q); do \
+		echo removing image $$i; \
+		docker rmi -f $$i > /dev/null 2>&1; \
+	done


### PR DESCRIPTION
In an attempt to get more alignment between upstream Ceph and the Rook project, I've started the work to use rook-style images within the ceph-container project. The approach is described in https://github.com/rook/rook/issues/1404. It also borrows some of the tricks in #877 to reduce the image sizes further.

I'm opening up this for early review, its not ready to merge nor has it been tested with Rook. I took the following path:

- Use Makefiles to build images
- Use multiple images for better factoring (base os, ceph daemon base, ceph daemon)
- Reduce the size of the images to the extent possible
- Support multiple base OS flavors as does ceph-container today.
- Reduce the duplication of code and DockerFiles
- Support for multiple arch `amd64` and `arm64`
- Provide minimal clean ceph images that could be used as base images for other projects like Ceph

Lots to be done before this effort could be considered complete:
- [ ] Add minimization scripts to reduce size of base os image besides ubuntu
- [ ] Add ceph-cotainer entry point scripts to the `ceph-daemon` images
- [ ] Support for manifest tool to create multi-arch images `docker pull ceph-daemon` should work for both amd64 and arm64
- [ ] Integration with CI and test environments

To keep things simple I recommend we only use this new approach for lumninous and future versions.

Here's an example usage:

```
10:48 $ make -j4
=== docker build ceph/rootfs-builder:arm64-ubuntu-16.04
=== docker build ceph/rootfs-builder:amd64-ubuntu-16.04
sha256:9bf695330af93bec0fd3c0c70d30df49477973acb0faadf83a08285276da0fe7
=== docker build ceph/rootfs:9bf695330af9
faabb60a5374c96e0598f3f77a44f051bdaa1dcdba10e0adfdd5a48b1514228b
sha256:e70c833f7bbe5b8d9b9f100d726d5da5684f6ec7ba5c180b8cc32e6d61fd4722
=== docker build ceph/base:amd64-ubuntu-16.04
sha256:4379e7492e64d5129d03c30cffcf10530e7cd31153526fd4eeabea08a2624290
=== docker build ceph/daemon-base:luminous-amd64-ubuntu-16.04
sha256:9489cf5856883c0654064e366e467f12c60ab4472e57224a6b3f30122f32959f
=== docker build ceph/rootfs:9489cf585688
755198161d7889a2df04d75a1fd49520a853c5936dd94067f55eb70110ae8efb
sha256:1b740d22bf5214c7ff5a4c3b7da27d48f896500fa7720d7854ea0ca988eecbed
=== docker build ceph/base:arm64-ubuntu-16.04
sha256:1f306f10cdafe30c89a0ea65ef15de481937d98c77e1bd8632fe9054d3a36771
=== docker build ceph/daemon-base:luminous-arm64-ubuntu-16.04
sha256:f159aed50dc42579e38d5390bd4d71b96e27e7736e4a7f7af4d314f12281e3f3
=== docker build ceph/daemon:luminous-amd64-ubuntu-16.04
sha256:f159aed50dc42579e38d5390bd4d71b96e27e7736e4a7f7af4d314f12281e3f3
sha256:1a78e1a01fb49f7a38890b13ab9617c7b5ece48e778909da371946fafd555c8f
=== docker build ceph/daemon:luminous-arm64-ubuntu-16.04
sha256:1a78e1a01fb49f7a38890b13ab9617c7b5ece48e778909da371946fafd555c8f

docker images
REPOSITORY            TAG                           IMAGE ID            CREATED             SIZE
ceph/daemon-base      luminous-arm64-ubuntu-16.04   1a78e1a01fb4        About an hour ago   341MB
ceph/daemon           luminous-arm64-ubuntu-16.04   1a78e1a01fb4        About an hour ago   341MB
ceph/daemon-base      luminous-amd64-ubuntu-16.04   f159aed50dc4        About an hour ago   363MB
ceph/daemon           luminous-amd64-ubuntu-16.04   f159aed50dc4        About an hour ago   363MB
ceph/base             arm64-ubuntu-16.04            1f306f10cdaf        About an hour ago   71.9MB
ceph/rootfs           9489cf585688                  1b740d22bf52        About an hour ago   71.9MB
ceph/rootfs-builder   arm64-ubuntu-16.04            9489cf585688        About an hour ago   103MB
ceph/base             amd64-ubuntu-16.04            4379e7492e64        About an hour ago   77.4MB
ceph/rootfs           9bf695330af9                  e70c833f7bbe        About an hour ago   77.4MB
ceph/rootfs-builder   amd64-ubuntu-16.04            9bf695330af9        About an hour ago   111MB
arm64v8/ubuntu        16.04                         292966ec354d        4 weeks ago         103MB
ubuntu                16.04                         00fd29ccc6f1        4 weeks ago         111MB
```

With this approach I hope to change the Rook DockerFile to something like:

```
FROM ceph/daemon-base:luminous-ubuntu-16.04

ADD rook rookflex /usr/local/bin/

ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
CMD [""]
```

/cc @liewegas @leseb 