### PR TITLE
Add sudo and lvm packages for ceph-volume

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -10,7 +10,7 @@ ENV CONFD_VERSION 0.10.0
 ENV KUBECTL_VERSION v1.6.0
 
 # Packages list
-ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw"
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw lvm2"
 ARG PURGES="/var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/lib/{dracut,locale,systemd,udev} /usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /etc/{udev,selinux} /usr/lib/{udev,systemd}"
 # Add s3cfg file
 ADD s3cfg /root/.s3cfg


### PR DESCRIPTION
ceph-volume requires sudo, and supports LVM.  This change adds those packages to the image so that we can make progress toward deprecating ceph-disk.