### PR TITLE
lum:openSUSE: Dockerfile updates

### DIFF
--- a/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
@@ -23,7 +23,7 @@ ARG CLOUD_REPO="http://download.opensuse.org/repositories/Cloud:/Tools/${OS_VERS
 ARG BUILD_DEPS_REPO="http://download.opensuse.org/repositories/filesystems:/ceph/${OS_VERSION}/"
 ARG PACKAGES="ceph ceph-radosgw rbd-mirror \
               nfs-ganesha-ceph nfs-ganesha-rgw \
-              etcd device-mapper e2fsprogs kubernetes-client \
+              etcd device-mapper e2fsprogs kubernetes-client s3cmd \
               confd=$CONFD_VERSION forego"
 RUN ( $ADDREPO $CEPH_REPO ceph-luminous && \
     $ADDREPO $CLOUD_REPO cloud-tools && \

--- a/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
@@ -16,7 +16,7 @@ ARG INSTALL="$PACKAGE_MANAGER install"
 
 # Ceph source repository
 ARG CEPH_REPO="http://download.opensuse.org/repositories/filesystems:/ceph:/${CEPH_VERSION}/${OS_VERSION}/"
-# The Cloud:Tools repo has s3cmd
+# The Cloud:Tools repo has 's3cmd' (used by the demo only)
 ARG CLOUD_REPO="http://download.opensuse.org/repositories/Cloud:/Tools/${OS_VERSION}/"
 # Other build dependencies (confd, forego)
 ARG BUILD_DEPS_REPO="http://download.opensuse.org/repositories/filesystems:/ceph/${OS_VERSION}/"

--- a/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
@@ -8,7 +8,6 @@ MAINTAINER Blaine Gardner "blaine.gardner@suse.com"
 # OS version string for repos
 ARG OS_VERSION='openSUSE_Leap_42.3'
 # Prevent upgrades to a newer major release
-ARG CEPH_VERSION_NUM_UPPERBOUND='13'
 ENV CEPH_VERSION 'luminous'
 ARG CONFD_VERSION='0.13.0'
 
@@ -16,24 +15,19 @@ ARG PACKAGE_MANAGER="zypper --non-interactive"
 ARG ADDREPO="$PACKAGE_MANAGER addrepo"
 ARG INSTALL="$PACKAGE_MANAGER install"
 
-# Install Ceph
+# Ceph source repository
 ARG CEPH_REPO="http://download.opensuse.org/repositories/filesystems:/ceph:/${CEPH_VERSION}/${OS_VERSION}/"
 # The Cloud:Tools repo has s3cmd
 ARG CLOUD_REPO="http://download.opensuse.org/repositories/Cloud:/Tools/${OS_VERSION}/"
-# Virtualization:Containers has confd
-ARG CONTAINERS_REPO="http://download.opensuse.org/repositories/home:/blgardner:/branches:/Virtualization:/containers/${OS_VERSION}/"
-# blgardner's home repo is the current place to get forego
-ARG FOREGO_REPO="http://download.opensuse.org/repositories/home:/blgardner/${OS_VERSION}/"
-ARG PACKAGES="ceph<${CEPH_VERSION_NUM_UPPERBOUND} \
-              ceph-radosgw<${CEPH_VERSION_NUM_UPPERBOUND} \
-              rbd-mirror<${CEPH_VERSION_NUM_UPPERBOUND} \
+# Other build dependencies (confd, forego)
+ARG BUILD_DEPS_REPO="http://download.opensuse.org/repositories/filesystems:/ceph/${OS_VERSION}/"
+ARG PACKAGES="ceph ceph-radosgw rbd-mirror \
               nfs-ganesha-ceph nfs-ganesha-rgw \
               etcd device-mapper e2fsprogs kubernetes-client \
               confd=$CONFD_VERSION forego"
 RUN ( $ADDREPO $CEPH_REPO ceph-luminous && \
     $ADDREPO $CLOUD_REPO cloud-tools && \
-    $ADDREPO $CONTAINERS_REPO virtualization-containers && \
-    $ADDREPO $FOREGO_REPO forego && \
+    $ADDREPO $BUILD_DEPS_REPO build-deps && \
     $PACKAGE_MANAGER --gpg-auto-import-keys refresh && \
     $INSTALL $PACKAGES && \
     $PACKAGE_MANAGER info $PACKAGES && \

--- a/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/opensuse/42.3/daemon/Dockerfile
@@ -9,7 +9,6 @@ MAINTAINER Blaine Gardner "blaine.gardner@suse.com"
 ARG OS_VERSION='openSUSE_Leap_42.3'
 # Prevent upgrades to a newer major release
 ENV CEPH_VERSION 'luminous'
-ARG CONFD_VERSION='0.13.0'
 
 ARG PACKAGE_MANAGER="zypper --non-interactive"
 ARG ADDREPO="$PACKAGE_MANAGER addrepo"
@@ -24,7 +23,7 @@ ARG BUILD_DEPS_REPO="http://download.opensuse.org/repositories/filesystems:/ceph
 ARG PACKAGES="ceph ceph-radosgw rbd-mirror \
               nfs-ganesha-ceph nfs-ganesha-rgw \
               etcd device-mapper e2fsprogs kubernetes-client s3cmd \
-              confd=$CONFD_VERSION forego"
+              confd forego"
 RUN ( $ADDREPO $CEPH_REPO ceph-luminous && \
     $ADDREPO $CLOUD_REPO cloud-tools && \
     $ADDREPO $BUILD_DEPS_REPO build-deps && \


### PR DESCRIPTION
The luminous/openSUSE dockerfile needed to be updated with the latest location of package repos. And there were a few other updates as well. Like `s3cmd` actually needed to be installed.