### PR TITLE
disk_list: fix wrong path to device

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
@@ -35,7 +35,7 @@ function mount_ceph_data () {
   if is_dmcrypt; then
     mount /dev/mapper/"${data_uuid}" "$tmp_dir"
   else
-    mount /dev/mapper/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value "${OSD_DEVICE}"*)" "$tmp_dir"
+    mount /dev/disk/by-partuuid/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value "${OSD_DEVICE}"*)" "$tmp_dir"
   fi
 }
 


### PR DESCRIPTION
since the `mount_ceph_data()` function in disk_list.sh is now looking
for the partuuid to mount it, we must use `/dev/disk/by-partuuid`.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1537980

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>