### PR TITLE
docker_exec: Execute some code based on the return code of the exec'd…

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/docker_exec.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/docker_exec.sh
@@ -56,5 +56,9 @@ function exec {
   wait "$child_for_exec"
   return_code=$?
   echo "exec: PID $child_for_exec: exit $return_code"
+  # If needed, it's possible to execute some user defined code if the exec'd process fails
+  if [ "$return_code" -ne 0 ]; then
+    declare -F trap_exec_failure && trap_exec_failure
+  fi
   exit $return_code
 }


### PR DESCRIPTION
… process

When users are doing the exec call in the entrypoint, it could be useful
being able to run some particular code if the exec'd command success or
fail.

This simple commit let the user defining trap_exec_success() or trap_exec_failure() regarding the code they want to run in such cases.