### PR TITLE
Fix purge

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -305,7 +305,13 @@ function get_part_uuid {
 function is_dmcrypt () {
   # As soon as we find partitions with TYPE=crypto_LUKS on ${OSD_DEVICE} we can
   # assume this device is part of dmcrypt scenario.
-  blkid -t TYPE=crypto_LUKS "${OSD_DEVICE}"* -o value -s PARTUUID &> /dev/null
+
+  # To keep compatibility with existing code
+  if [ -n "${1}" ]; then
+    local OSD_DEVICE
+    OSD_DEVICE="${1}"
+  fi
+  blkid -t TYPE=crypto_LUKS "${OSD_DEVICE}"* -o value -s PARTUUID 1> /dev/null
 }
 
 function ceph_health {

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -302,6 +302,12 @@ function get_part_uuid {
   blkid -o value -s PARTUUID "${1}"
 }
 
+function is_dmcrypt () {
+  # As soon as we find partitions with TYPE=crypto_LUKS on ${OSD_DEVICE} we can
+  # assume this device is part of dmcrypt scenario.
+  blkid -t TYPE=crypto_LUKS "${OSD_DEVICE}"* -o value -s PARTUUID &> /dev/null
+}
+
 function ceph_health {
   local bootstrap_user=$1
   local bootstrap_key=$2

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
@@ -25,12 +25,6 @@ function mandatory_checks () {
   fi
 }
 
-function is_dmcrypt () {
-  # As soon as we find partitions with TYPE=crypto_LUKS on ${OSD_DEVICE} we can
-  # assume this device is part of dmcrypt scenario.
-  blkid -t TYPE=crypto_LUKS "${OSD_DEVICE}"* -o value -s PARTUUID &> /dev/null
-}
-
 function mount_ceph_data () {
   if is_dmcrypt; then
     mount /dev/mapper/"${data_uuid}" "$tmp_dir"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
@@ -1,8 +1,98 @@
 #!/bin/bash
 set -e
 
+# Get a list of child devices from a root device
+function get_child_partitions {
+# $1: raw parent device
+  if [ ! -e  "${1}" ] && [ ! -b "${1}" ]; then
+    log "Error, ${1} doesn't seem to be a valid device!"
+    exit 1
+  fi
+  local parts
+  parts=$(lsblk -no KNAME "${1}")
+  for p in $parts; do
+    kname=$(lsblk --nodeps -no KNAME /dev/"${p}")
+    pkname=$(lsblk --nodeps -no PKNAME /dev/"${p}")
+    if [ "${kname}" != "${pkname}" ] && [ -n "${pkname}" ]; then
+      echo /dev/"${p}"
+    fi
+  done
+}
+
+function get_dmcrypt_uuid_part {
+  # look for Ceph encrypted partitions
+  # Get all dmcrypt for ${device}
+  blkid -t TYPE="crypto_LUKS" "${1}"* -o value -s PARTUUID || true
+}
+
+function get_opened_dmcrypt {
+  # Get actual opened dmcrypt for ${device}
+  dmsetup ls --exec 'basename' --target crypt
+}
+
+function zap_dmcrypt_device {
+  # $1: list of cryptoluks partitions (returned by get_dmcrypt_uuid_part)
+  # $2: list of opened dm (returned by get_opened_dmcrypt)
+  local dm_uuid
+  for dm_uuid in $1; do
+    for dm in $2; do
+      if [ "${dm_uuid}" == "${dm}" ]; then
+        cryptsetup luksClose /dev/mapper/"${dm_uuid}"
+      fi
+    done
+    dm_path="/dev/disk/by-partuuid/${dm_uuid}"
+    dmsetup wipe_table --force "${dm_uuid}" || log "Warning: dmsetup wipe_table non-zero return code"
+    dmsetup remove --force --retry "${dm_uuid}" || log "Warning: dmsetup remove non-zero return code"
+    # erase all keyslots (remove encryption key)
+    payload_offset=$(cryptsetup luksDump "${dm_path}" | awk '/Payload offset:/ { print $3 }')
+    phys_sector_size=$(blockdev --getpbsz "${dm_path}")
+    # If the sector size isn't a number, let's default to 512
+    if ! is_integer "${phys_sector_size}"; then
+      phys_sector_size=512
+    fi
+    # remove LUKS header
+    dd if=/dev/zero of="${dm_path}" bs="${phys_sector_size}" count="${payload_offset}" oflag=direct
+  done
+}
+
+function get_all_ceph_devices {
+  local all_devices
+  # Let's iterate over all devices on the node.
+  for device in $(blkid -o device); do
+    local partlabel
+    # get the partlabel for the current device.
+    partlabel=$(blkid "${device}" -s PARTLABEL -o value)
+
+    # some device might not have partlabel, it means ${partlabel} will be empty
+    # in that case, simply jump to the next iteration.
+    if [ -z "$partlabel" ]; then
+      continue
+    fi
+
+    # if the partlabel doesn't start with 'ceph', it means this is not a ceph used partition.
+    # in that case, simply jump to the next iteration.
+    if [[ ! "$partlabel" =~ ^ceph.* ]]; then
+      continue
+    fi
+
+    # if we reach this point, it means we found a ceph partition,
+    # let's find its raw parent device and add it to the list.
+    local parent_dev
+    parent_dev=$(lsblk --nodeps -pno PKNAME "${device}")
+    if [ -n "${parent_dev}" ]; then
+      all_devices+=("${parent_dev}")
+    fi
+  done
+
+  # Finally, print all the devices with only 1 occurence for each device (uniq)
+  echo "${all_devices[@]}" | tr ' ' '\n' | sort -u
+}
+
 function zap_device {
-  local device_match_string='/dev/([x]?[hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p){1,2}'
+  local phys_sector_size
+  local dm_path
+  local ceph_dm
+  local payload_offset
 
   if [[ -z ${OSD_DEVICE} ]]; then
     log "Please provide device(s) to zap!"
@@ -11,70 +101,35 @@ function zap_device {
   fi
 
   if [[ "${OSD_DEVICE}" == "all_ceph_disks" ]]; then
-    for type in " data" " journal" " block" " block.wal" " block.db"; do
-      for disk in $(blkid -t PARTLABEL="ceph$type" -o device | uniq); do
-        dev="$dev ${disk%?}"
-      done
-    done
-    # get a uniq list of devices to wipe
-    disks=$(echo "$dev" | tr ' ' '\n' | nl | sort -u -k2 | sort -n | cut -f2-)
-    ceph-disk zap "$disks"
-  else
-    # testing all the devices first so we just don't do anything if one device is wrong
-    for device in $(comma_to_space "${OSD_DEVICE}"); do
-      if [[ $(stat --format=%F "$device" 2> /dev/null) != "block special file" ]]; then
-        log "Provided device $device does not exist."
-        exit 1
-      fi
-      # if the disk passed is a raw device AND the boot system disk
-      if echo "$device" | grep -sqE "${device_match_string}" && parted -s "$(echo "$device" | grep -Eo "${device_match_string}")" print | grep -sq boot; then
-        log "Looks like $device has a boot partition,"
-        log "if you want to delete specific partitions point to the partition instead of the raw device"
-        log "Do not use your system disk!"
-        exit 1
-      fi
-    done
-
-    # look for Ceph encrypted partitions
-    local ceph_dm
-    ceph_dm=$(blkid -t TYPE="crypto_LUKS" "${OSD_DEVICE}"* -o value -s PARTUUID || true)
-    if [[ -n $ceph_dm ]]; then
-      for dm_uuid in $ceph_dm; do
-        local dm_path="/dev/disk/by-partuuid/$dm_uuid"
-        dmsetup --verbose --force wipe_table "$dm_uuid" || true
-        dmsetup --verbose --force remove "$dm_uuid" || true
-
-        # erase all keyslots (remove encryption key)
-        cryptsetup --verbose --batch-mode erase "$dm_path"
-        local payload_offset
-        payload_offset=$(cryptsetup luksDump "$dm_path" | awk '/Payload offset:/ { print $3 }')
-        local phys_sector_size
-        phys_sector_size=$(blockdev --getpbsz "$dm_path")
-        if ! is_integer "$phys_sector_size"; then
-          # If the sector size isn't a number, let's default to 512
-          phys_sector_size=512
-        fi
-        # remove LUKS header
-        dd if=/dev/zero of="$dm_path" bs="$phys_sector_size" count="$payload_offset" oflag=direct
-      done
-    fi
-
-    for device in $(comma_to_space "${OSD_DEVICE}"); do
-      local raw_device
-      raw_device=$(echo "$device" | grep -oE "${device_match_string}")
-      if echo "$device" | grep -sqE "${device_match_string}"; then
-        log "Zapping the entire device $device"
-        sgdisk --zap-all --clear --mbrtogpt -g -- "$device"
-      else
-        # get the desired partition number(s)
-        local partition_nb
-        partition_nb=$(echo "$device" | grep -oE '[0-9]{1,2}$')
-        log "Zapping partition $device"
-        sgdisk --delete "$partition_nb" "$raw_device"
-      fi
-      log "Executing partprobe on $raw_device"
-      partprobe "$raw_device"
-      udevadm settle
-    done
+    OSD_DEVICE=$(get_all_ceph_devices)
   fi
+  # testing all the devices first so we just don't do anything if one device is wrong
+  for device in $(comma_to_space "${OSD_DEVICE}"); do
+    # Check if ${device} is well a block device
+    [[ -b "${device}" ]] || log "Provided device ${device} does not exist or is not a valid block device."
+
+    partitions=$(get_child_partitions "${device}")
+    # if the disk passed is a raw device AND the boot system disk
+    [[ $(lsblk --nodeps -no LABEL "${device}") == "boot" ]] && log "Looks like ${device} has a boot partition," &&
+      log "if you want to delete specific partitions point to the partition instead of the raw device" &&
+      log "Do not use your system disk!" &&
+      exit 1
+    if is_dmcrypt "${device}"; then
+    # If dmcrypt partitions detected, loop over all uuid found and check whether they are still opened.
+      ceph_dm=$(get_dmcrypt_uuid_part "${device}")
+      opened_dm=$(get_opened_dmcrypt "${device}")
+      zap_dmcrypt_device "$ceph_dm" "$opened_dm"
+    fi
+    log "Zapping the entire device ${device}"
+    for part in $partitions; do
+      wipefs --all "${part}"
+      dd if=/dev/zero of="${part}" bs=1 count=4096
+    done
+    sgdisk --zap-all --clear --mbrtogpt -g -- "${device}"
+    dd if=/dev/zero of="${device}" bs=1M count=10
+    parted -s "${device}" mklabel gpt
+    log "Executing partprobe on ${device}"
+    partprobe "${device}"
+    udevadm settle
+  done
 }


### PR DESCRIPTION
When a cluster is purged, there is leftover on partitions since they are
not wiped properly and this prevent from redeploying a cluster, indeed,
the osd
disk activate process will complain about mismatching uuids.

In order to fix this issue, we must wipe the first 4k of each created
partitions of the OSD device.