### PR TITLE
Exit CephNFS with error if ganesha daemon fails

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_nfs.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_nfs.sh
@@ -31,7 +31,6 @@ function start_nfs {
   fi
 
   log "SUCCESS"
-  # start ganesha
-  /usr/bin/ganesha.nfsd "${GANESHA_OPTIONS[@]}" -L /var/log/ganesha/ganesha.log "${GANESHA_EPOCH}" || return 0
-  exec tailf /var/log/ganesha/ganesha.log
+  # start ganesha, logging both to STDOUT and to the configured location
+  exec /usr/bin/ganesha.nfsd "${GANESHA_OPTIONS[@]}" -F -L STDOUT "${GANESHA_EPOCH}"
 }


### PR DESCRIPTION
while still logging the daemon both to STDOUT and the location
configured in the daemon's configuration file.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1546192