### PR TITLE
ci: build and push, no invoke sudo

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -9,11 +9,12 @@ set -ex
 function install_docker {
   sudo apt-get install -y --force-yes docker.io
   sudo systemctl start docker
+  sudo chgrp "$(whoami)" /var/run/docker.sock
 }
 
 function login_docker_hub {
   echo "Login in the Docker Hub"
-  sudo docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
+  docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
 }
 
 function build_ceph_imgs {


### PR DESCRIPTION
sudo does not have a tty for the running user, also the 'make'
invocation will not call sudo.

Signed-off-by: Sébastien Han <seb@redhat.com>