### PR TITLE
[skip ci] Add luminous-opensuse-42.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ ALL_BUILDABLE_FLAVORS := \
 	luminous,amd64,centos,7,_,centos,7 \
 	jewel,amd64,centos,7,_,centos,7 \
 	kraken,amd64,centos,7,_,centos,7 \
+	luminous,amd64,opensuse,42.3,_,opensuse,42.3 \
 
 # ==============================================================================
 # Build targets

--- a/ceph-releases/ALL/opensuse/42.3/__OS_REPO__
+++ b/ceph-releases/ALL/opensuse/42.3/__OS_REPO__
@@ -1,0 +1,1 @@
+openSUSE_Leap_42.3

--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_MAINTAINER__
@@ -1,0 +1,1 @@
+Blaine Gardner "blaine.gardner@suse.com"

--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,2 @@
+__ZYPPER__ clean --all && \
+    rm -f /var/log/zypper.log

--- a/ceph-releases/ALL/opensuse/__ZYPPER_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__ZYPPER_INSTALL__
@@ -1,0 +1,1 @@
+__ZYPPER__ install --no-recommends --auto-agree-with-licenses --replacefiles --details

--- a/ceph-releases/ALL/opensuse/__ZYPPER_UPDATE__
+++ b/ceph-releases/ALL/opensuse/__ZYPPER_UPDATE__
@@ -1,0 +1,2 @@
+__ZYPPER__ --gpg-auto-import-keys refresh && \
+    __ZYPPER__ update --no-recommends --auto-agree-with-licenses --replacefiles --details

--- a/ceph-releases/ALL/opensuse/__ZYPPER__
+++ b/ceph-releases/ALL/opensuse/__ZYPPER__
@@ -1,0 +1,1 @@
+zypper --non-interactive

--- a/ceph-releases/ALL/opensuse/daemon-base/__CEPH_REPO__
+++ b/ceph-releases/ALL/opensuse/daemon-base/__CEPH_REPO__
@@ -1,0 +1,1 @@
+http://download.opensuse.org/repositories/filesystems:/ceph:/${CEPH_VERSION}/__OS_REPO__/

--- a/ceph-releases/ALL/opensuse/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,0 +1,6 @@
+( __ZYPPER__ addrepo __CEPH_REPO__ ceph-${CEPH_VERSION} && \
+    __ZYPPER_UPDATE__ && \
+    __ZYPPER_INSTALL__ __CEPH_BASE_PACKAGES__ && \
+    __ZYPPER__ info __CEPH_BASE_PACKAGES__ && \
+    __ZYPPER__ removerepo ceph-${CEPH_VERSION} ) || \
+    ( retval=$? && cat /var/log/zypper.log && exit $retval )

--- a/ceph-releases/ALL/opensuse/daemon-base/__RADOSGW_PACKAGE__
+++ b/ceph-releases/ALL/opensuse/daemon-base/__RADOSGW_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-radosgw

--- a/ceph-releases/ALL/opensuse/daemon/__BUILD_DEPS_REPO__
+++ b/ceph-releases/ALL/opensuse/daemon/__BUILD_DEPS_REPO__
@@ -1,0 +1,1 @@
+http://download.opensuse.org/repositories/filesystems:/ceph/__OS_REPO__/

--- a/ceph-releases/ALL/opensuse/daemon/__CLOUD_REPO__
+++ b/ceph-releases/ALL/opensuse/daemon/__CLOUD_REPO__
@@ -1,0 +1,1 @@
+http://download.opensuse.org/repositories/Cloud:/Tools/__OS_REPO__/

--- a/ceph-releases/ALL/opensuse/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/daemon/__DOCKERFILE_INSTALL__
@@ -1,0 +1,8 @@
+( __ZYPPER__ addrepo __CLOUD_REPO__ cloud-tools && \
+    __ZYPPER__ addrepo __BUILD_DEPS_REPO__ build-deps && \
+    __ZYPPER_UPDATE__ && \
+    __ZYPPER_INSTALL__ __DAEMON_PACKAGES__ && \
+    __ZYPPER__ info __DAEMON_PACKAGES__ && \
+    __ZYPPER__ removerepo cloud-tools && \
+    __ZYPPER__ removerepo build-deps ) || \
+    ( retval=$? && cat /var/log/zypper.log && exit $retval )


### PR DESCRIPTION
After changing to the new project structure, this should add luminous-opensuse-42.3 build support.