### PR TITLE
[skip ci] Update for Kubernetes 1.9 and Luminous

### DIFF
--- a/examples/kubernetes/ceph-mds-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mds-v1-dp.yaml
@@ -72,8 +72,8 @@ spec:
               timeoutSeconds: 5
           resources:
             requests:
-              memory: "10Mi"
+              memory: "100Mi"
               cpu: "250m"
             limits:
-              memory: "50Mi"
+              memory: "500Mi"
               cpu: "500m"

--- a/examples/kubernetes/ceph-mgr-dashboard-v1-svc.yaml
+++ b/examples/kubernetes/ceph-mgr-dashboard-v1-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceph-mgr-dashboard
+  namespace: ceph
+  labels:
+    app: ceph
+    daemon: mgr
+spec:
+  ports:
+  - port: 7000
+    protocol: TCP
+    targetPort: 7000
+  selector:
+    app: ceph
+    daemon: mgr

--- a/examples/kubernetes/ceph-mgr-prometheus-v1-svc.yaml
+++ b/examples/kubernetes/ceph-mgr-prometheus-v1-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceph-mgr-prometheus
+  namespace: ceph
+  labels:
+    app: ceph
+    daemon: mgr
+spec:
+  ports:
+  - port: 9283
+    protocol: TCP
+    targetPort: 9283
+  selector:
+    app: ceph
+    daemon: mgr

--- a/examples/kubernetes/ceph-mgr-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mgr-v1-dp.yaml
@@ -1,0 +1,101 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: ceph
+    daemon: mgr
+  name: ceph-mgr
+  namespace: ceph
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ceph
+      daemon: mgr
+  template:
+    metadata:
+      name: ceph-mgr
+      namespace: ceph
+      labels:
+        app: ceph
+        daemon: mgr
+    spec:
+      serviceAccount: default
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values: ["ceph"]
+              - key: daemon
+                operator: In
+                values: ["mgr"]
+            topologyKey: kubernetes.io/hostname
+      volumes:
+        - name: ceph-conf
+          secret:
+            secretName: ceph-conf-combined
+        - name: ceph-bootstrap-osd-keyring
+          secret:
+            secretName: ceph-bootstrap-osd-keyring
+        - name: ceph-bootstrap-mds-keyring
+          secret:
+            secretName: ceph-bootstrap-mds-keyring
+        - name: ceph-bootstrap-rgw-keyring
+          secret:
+            secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
+      containers:
+        - name: ceph-mgr
+          image: ceph/daemon:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 6800
+            - containerPort: 7000
+              name: dashboard
+          env:
+            - name: CEPH_DAEMON
+              value: MGR
+            - name: KV_TYPE
+              value: k8s
+            - name: NETWORK_AUTO_DETECT
+              value: "4"
+            - name: CLUSTER
+              value: ceph
+          volumeMounts:
+            - name: ceph-conf
+              mountPath: /etc/ceph
+            - name: ceph-bootstrap-osd-keyring
+              mountPath: /var/lib/ceph/bootstrap-osd
+            - name: ceph-bootstrap-mds-keyring
+              mountPath: /var/lib/ceph/bootstrap-mds
+            - name: ceph-bootstrap-rgw-keyring
+              mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
+          livenessProbe:
+              tcpSocket:
+                port: 6800
+              initialDelaySeconds: 60
+              timeoutSeconds: 5
+          readinessProbe:
+              tcpSocket:
+                port: 6800
+              timeoutSeconds: 5
+          resources:
+            requests:
+              memory: "50Mi"
+              cpu: "100m"
+            limits:
+              memory: "100Mi"
+              cpu: "200m"

--- a/examples/kubernetes/ceph-mon-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-v1-dp.yaml
@@ -16,24 +16,25 @@ spec:
       labels:
         app: ceph
         daemon: mon
-      annotations:
-        scheduler.alpha.kubernetes.io/affinity: >
-          {
-            "podAntiAffinity": {
-              "RequiredDuringSchedulingIgnoredDuringExecution": [{
-                "labelSelector": {
-                  "matchExpressions": [{
-                    "key": "daemon",
-                    "operator": "In",
-                    "values":["mon"]
-                  }]
-                },
-              "topologyKey": "kubernetes.io/hostname"
-              }]
-            }
-          }
     spec:
       serviceAccount: default
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values: ["ceph"]
+              - key: daemon
+                operator: In
+                values: ["mon"]
+            topologyKey: kubernetes.io/hostname
       volumes:
         - name: ceph-conf
           secret:

--- a/examples/kubernetes/ceph-rbac.yaml
+++ b/examples/kubernetes/ceph-rbac.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: ceph-admin-binding
+  namespace: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  namespace: ceph
+  name: default

--- a/examples/kubernetes/rbd-provisioner/README.md
+++ b/examples/kubernetes/rbd-provisioner/README.md
@@ -1,0 +1,39 @@
+# Ceph RBD Provisioner
+
+We use the dynamic RBD provisioner plugin. The manifests are based on
+the example from [1], the storage class is based on [2].
+When setting up the cluster using kubeadm, thus having a self-hosted
+setup where the API server runs as a pod itself, the in-tree provisioner
+may no longer be used as the controller images are lacking the required
+Ceph tools.
+
+OpenShift has a good documentation on how to setup the RBD pool [3].
+Note that we use the 'ceph' namespace for everything, infrastructure
+(see parent directory), provisioner, and secrets.
+I have used the following, slightly adapted, commands:
+
+```
+ceph osd pool create kube 64
+ceph auth get-or-create client.kube mon 'allow r' osd \
+  'allow class-read object_prefix rbd_children, allow rwx pool=kube' \
+  -o ceph.client.kube.keyring
+kubectl --namespace=ceph create secret generic ceph-rbd-kube \
+  --from-literal="key=$(grep key ceph.client.kube.keyring  | awk '{ print $3 }')" \
+  --type=kubernetes.io/rbd
+```
+
+Our current provisioner image is based on [4]. (you can also build the current
+image yourself, however, that failed with missing Go dependencies on the multi-stage
+release build). This should be remedied later when the actual image [5] is finally
+updated [6].
+
+Note that the node hosts still need to have the Ceph RBD tools available
+(on Fedora or CentOS install ceph-common).
+
+[1] https://github.com/kubernetes-incubator/external-storage/tree/master/ceph/rbd/deploy/rbac
+[2] https://github.com/kubernetes-incubator/external-storage/blob/master/ceph/rbd/examples/class.yaml
+[3] https://docs.openshift.org/3.6/install_config/storage_examples/ceph_rbd_dynamic_example.html
+[4] https://hub.docker.com/r/anatolyrugalev/rbd-provisioner/
+[5] https://quay.io/repository/external_storage/rbd-provisioner
+[6] https://github.com/kubernetes-incubator/external-storage/issues/608
+

--- a/examples/kubernetes/rbd-provisioner/clusterrole.yaml
+++ b/examples/kubernetes/rbd-provisioner/clusterrole.yaml
@@ -1,0 +1,22 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rbd-provisioner
+  namespace: ceph
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["list", "get"]

--- a/examples/kubernetes/rbd-provisioner/clusterrolebinding.yaml
+++ b/examples/kubernetes/rbd-provisioner/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rbd-provisioner
+  namespace: ceph
+subjects:
+  - kind: ServiceAccount
+    name: rbd-provisioner
+    namespace: ceph
+roleRef:
+  kind: ClusterRole
+  name: rbd-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/kubernetes/rbd-provisioner/deployment.yaml
+++ b/examples/kubernetes/rbd-provisioner/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rbd-provisioner
+  namespace: ceph
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: rbd-provisioner
+    spec:
+      containers:
+      - name: rbd-provisioner
+        # Currently outdated, hence use inofficial version
+        # built from https://github.com/kubernetes-incubator/external-storage
+        # (in ceph/rbd subdir)
+        # cf. https://github.com/kubernetes-incubator/external-storage/issues/608
+        #image: "quay.io/external_storage/rbd-provisioner:latest"
+        image: anatolyrugalev/rbd-provisioner:latest
+        env:
+        - name: PROVISIONER_NAME
+          value: ceph.com/rbd
+      serviceAccount: rbd-provisioner
+      imagePullSecrets:
+      - name: regsecret
+

--- a/examples/kubernetes/rbd-provisioner/role.yaml
+++ b/examples/kubernetes/rbd-provisioner/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: rbd-provisioner
+  namespace: ceph
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]

--- a/examples/kubernetes/rbd-provisioner/rolebinding.yaml
+++ b/examples/kubernetes/rbd-provisioner/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: rbd-provisioner
+  namespace: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-provisioner
+subjects:
+- kind: ServiceAccount
+  name: rbd-provisioner
+  namespace: ceph

--- a/examples/kubernetes/rbd-provisioner/serviceaccount.yaml
+++ b/examples/kubernetes/rbd-provisioner/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-provisioner
+  namespace: ceph

--- a/examples/kubernetes/rbd-provisioner/storage-class.yaml
+++ b/examples/kubernetes/rbd-provisioner/storage-class.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: rbd
+provisioner: ceph.com/rbd
+parameters:
+  monitors: ceph-mon.ceph.svc.cluster.local
+  pool: kube
+  adminId: admin
+  adminSecretNamespace: ceph
+  adminSecretName: ceph-secret-admin
+  userId: kube
+  userSecretNamespace: ceph
+  userSecretName: ceph-rbd-kube
+  imageFormat: "2"
+  imageFeatures: layering
+  fsType: xfs


### PR DESCRIPTION
We have recently upgraded our cluster to Kubernetes 1.9 and Ceph Luminous. This requires a few modifications and updates (RBAC, missing and updated manifests, rbd provsioner and storage class). This is based on recent updates to the [ceph config in rcll-sim-cluster](https://github.com/timn/rcll-sim-cluster/tree/master/kubernetes/ceph).