### PR TITLE
staging: fix bug when checking for dirty branch

### DIFF
--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -23,7 +23,7 @@ try:
     os.environ['GIT_COMMIT'] = GIT_COMMIT
     GIT_BRANCH = git.get_branch()
     os.environ['GIT_BRANCH'] = GIT_BRANCH
-    if git.file_is_dirty(""):
+    if git.branch_is_dirty():
         GIT_CLEAN = "True"
     else:
         GIT_CLEAN = "False"

--- a/maint-lib/stagelib/git.py
+++ b/maint-lib/stagelib/git.py
@@ -39,3 +39,12 @@ def file_is_dirty(file_path):
     if re.match(r'^\s*' + file_path + '$', file_status_msg):
         return True
     return False
+
+
+def branch_is_dirty():
+    """If any files are new, modified, or deleted in git's tracking return True. False otherwise."""
+    branch_status_msg = _run_cmd(['git', 'status', '--untracked-files=all', '--porcelain'])
+    # --porcelain returns no output if no changes
+    if branch_status_msg:
+        return True
+    return False


### PR DESCRIPTION
Previously, `file_is_dirty('')` was used to determine if the branch had
any dirty files, but because of the regex match in the method, this
cannot be guaranteed to return as expected. Add a `branch_is_dirty`
method to fix this.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>