### PR TITLE
[skip ci] FLAVORS_TO_BUILD is too damn long

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ architecture.
 #### Staging development aids
 To practically aid developers, helpful tools have been built for staging:
  - To create all default staging directories: `make stage`
- - To create specific staging directory(-ies): `make FLAVORS_TO_BUILD=<flavors> stage`
+ - To create specific staging directory(-ies): `make FLAVORS=<flavors> stage`
  - Find the source of a staged file: `cd <staging dir> ; ./find-src <file-path>`
  - List of staged files and their sources: `<staging dir>/files-sources`
  - List of all possible buildable flavors: `make show.flavors`
@@ -152,10 +152,10 @@ absolutely apply only to the specific flavor(s) and not to others.
   makes sense for the flavor to maximize reuse across flavors.
 
 ### Fixing a bug
-1. Stage the flavor on which the bug was found (`make FLAVORS_TO_BUILD=<bugged flavor> stage`).
+1. Stage the flavor on which the bug was found (`make FLAVORS=<bugged flavor> stage`).
 2. Use the `find-src` script or `files-sources` list to locate the bugged file's source location.
 3. Edit the source location to fix the bug.
-4. Build test versions of the images (`make FLAVORS_TO_BUILD=<bugged flavor> build`).
+4. Build test versions of the images (`make FLAVORS=<bugged flavor> build`).
 5. Test the images you built in your environment.
 6. Make a PR of your changes.
 
@@ -166,7 +166,7 @@ absolutely apply only to the specific flavor(s) and not to others.
    - As a general guideline, new features should usually be added to all Ceph versions and distros.
 2. Add relevant changes to files in the project structure such that they will be added to only the
    Ceph versions and distros in scope for the feature.
-3. Build test versions of the images (`make FLAVORS_TO_BUILD=<in-scope-flavors> build`).
+3. Build test versions of the images (`make FLAVORS=<in-scope-flavors> build`).
 4. Test the images in your environment.
 5. Make a PR of your changes.
 
@@ -192,7 +192,7 @@ In the worst case, trying to make as few modifications as possible:
 3. Edit `ceph-releases/ALL/<distro>` files to support the new version if necessary, making sure not
    to break previous versions.
 4. Add `ceph-releases/<new ceph version>` files to support the new version if necessary.
-5. Build test versions of the images (`make FLAVORS_TO_BUILD=<new release flavors> build`).
+5. Build test versions of the images (`make FLAVORS=<new release flavors> build`).
 6. Test the images in your environment.
 7. Make a PR of your changes.
 
@@ -208,7 +208,7 @@ In the worst case, trying to make as few modifications as possible:
    - Refer to other distros for inspiration.
 3. If necessary, add a `ceph-release/<ceph release>/<new distro>` directory for the new distro. Try
    to avoid this as much as possible and focus on code reuse from the less specific dirs.
-4. Build test versions of the images (`make FLAVORS_TO_BUILD=<new distro flavors> build`).
+4. Build test versions of the images (`make FLAVORS=<new distro flavors> build`).
 5. Test the images in your environment.
 6. Make a PR of your changes.
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 # CEPH_VERSION,ARCH,OS_NAME,OS_VERSION,BASEOS_REG,BASEOS_REPO,BASEOS_TAG
-FLAVORS_TO_BUILD ?= \
+FLAVORS ?= \
 	luminous,amd64,ubuntu,16.04,_,ubuntu,16.04 \
 	jewel,amd64,ubuntu,16.04,_,ubuntu,16.04 \
 	jewel,amd64,ubuntu,14.04,_,ubuntu,14.04 \
@@ -38,7 +38,7 @@ RELEASE ?= $(shell git rev-parse --abbrev-ref HEAD)
 # Internal definitions
 include maint-lib/makelib.mk
 
-# All flavor options that can be passed to FLAVORS_TO_BUILD
+# All flavor options that can be passed to FLAVORS
 # CEPH_VERSION,ARCH,OS_NAME,OS_VERSION,BASEOS_REG,BASEOS_REPO,BASEOS_TAG
 ALL_BUILDABLE_FLAVORS := \
 	luminous,amd64,ubuntu,16.04,_,ubuntu,16.04 \
@@ -73,9 +73,9 @@ daemon.%: daemon-base.%
 
 do.image.%: daemon.% ;
 
-stage: $(foreach p, $(FLAVORS_TO_BUILD), stage.$(p)) ;
-build: $(foreach p, $(FLAVORS_TO_BUILD), do.image.$(p)) ;
-push:  $(foreach p, $(FLAVORS_TO_BUILD), do.image.$(p)) ;
+stage: $(foreach p, $(FLAVORS), stage.$(p)) ;
+build: $(foreach p, $(FLAVORS), do.image.$(p)) ;
+push:  $(foreach p, $(FLAVORS), do.image.$(p)) ;
 
 build.parallel:
 # Due to output-sync, will not output results until finished so there is no text interleaving
@@ -86,7 +86,7 @@ else
 endif
 
 build.all:
-	@$(MAKE) FLAVORS_TO_BUILD="$(ALL_BUILDABLE_FLAVORS)" build.parallel
+	@$(MAKE) FLAVORS="$(ALL_BUILDABLE_FLAVORS)" build.parallel
 
 
 # ==============================================================================
@@ -96,7 +96,7 @@ build.all:
 clean.image.%: do.image.%
 	@$(call set_env_var,STAGING_DIR,$*); rm -rf $$STAGING_DIR
 
-clean: $(foreach p, $(FLAVORS_TO_BUILD), clean.image.$(p))
+clean: $(foreach p, $(FLAVORS), clean.image.$(p))
 
 clean.nones:
 	@docker rmi -f $(shell docker images | egrep "^<none> " | awk '{print $$3}') || true
@@ -153,14 +153,14 @@ help:
 	@echo ''
 	@echo '  Help:'
 	@echo '    help              Print this help message.'
-	@echo '    show.flavors      Show all flavor options to FLAVORS_TO_BUILD.'
+	@echo '    show.flavors      Show all flavor options to FLAVORS.'
 	@echo "    flavors.modified  Show the flavors impacted by this branch's changes vs origin/master."
 	@echo '                      All buildable flavors are staged for this test.'
 	@echo '                      The env var VS_BRANCH can be set to compare vs a different branch.'
 	@echo ''
 	@echo 'OPTIONS:'
 	@echo ''
-	@echo '  FLAVORS_TO_BUILD - ceph-container images to operate on in the form'
+	@echo '  FLAVORS - ceph-container images to operate on in the form'
 	@echo '    <ceph rel>,<arch>,<os name>,<os version>,<base registry>,<base repo>,<base tag>'
 	@echo '    and multiple forms may be separated by spaces.'
 	@echo '      ceph rel - named ceph version (e.g., luminous, mimic)'
@@ -171,7 +171,7 @@ help:
 	@echo '      base repo - The base image to use for the daemon-base container. generally this is'
 	@echo '                  also the os name (e.g., ubuntu) but could be something like "alpine"'
 	@echo '      base tag - Tagged version of the base os to use (e.g., ubuntu:"16.04", alpine:"3.6")'
-	@echo '    e.g., FLAVORS_TO_BUILD="luminous,amd64,ubuntu,16.04,_,ubuntu,16.04 \'
+	@echo '    e.g., FLAVORS="luminous,amd64,ubuntu,16.04,_,ubuntu,16.04 \'
 	@echo '                            luminous,arm64,ubuntu,16.04,arm64v8,alpine,3.6"'
 	@echo ''
 	@echo '  REGISTRY - The name of the registry to tag images with and to push images to.'

--- a/README.md
+++ b/README.md
@@ -47,26 +47,26 @@ Building ceph-container
 `make` is used for ceph-container builds. See `make help` for all make options.
 
 ### Specifying flavors for make
-The `make` tooling allows the environment variable `FLAVORS_TO_BUILD` to be optionally set by the
-user to define which flavors to operate on. Flavor specifications follow a strict format that
-declares what ceph-container source to use, what architecture to build for, and what container image
-to use as the base for the build. See `make help` for a full description.
+The `make` tooling allows the environment variable `FLAVORS` to be optionally set by the user to
+define which flavors to operate on. Flavor specifications follow a strict format that declares what
+ceph-container source to use, what architecture to build for, and what container image to use as the
+base for the build. See `make help` for a full description.
 
 ### Building a single flavor
-Once the flavor is selected, specify its name in the `FLAVORS_TO_BUILD` environment variable and call the
+Once the flavor is selected, specify its name in the `FLAVORS` environment variable and call the
 `build` target:
 ```
-make FLAVORS_TO_BUILD=luminous,amd64,centos,7,_,centos,7 build
+make FLAVORS=luminous,amd64,centos,7,_,centos,7 build
 ```
 
 ### Building multiple flavors
 Multiple flavors are specified by separating each flavor by a space and surrounding the entire
 specification in quotes and built the same as a single flavor:
 ```
-make FLAVORS_TO_BUILD="luminous,amd64,centos,7,_,centos,7 kraken,amd64,centos,7,_,centos,7"  build
+make FLAVORS="luminous,amd64,centos,7,_,centos,7 kraken,amd64,centos,7,_,centos,7"  build
 ```
 
 Flavors can be built in parallel easily with the `build.parallel` target:
 ```
-make FLAVORS_TO_BUILD="<flavor> <other flavor> <...>" build.parallel
+make FLAVORS="<flavor> <other flavor> <...>" build.parallel
 ```

--- a/maint-lib/flavors-modified-vs-master.py
+++ b/maint-lib/flavors-modified-vs-master.py
@@ -18,7 +18,7 @@ def _run_cmd(cmd_array):
 
 # Stage the flavor and return the staging dir
 def _stage_flavor(flavor):
-    stage_output = _run_cmd(['make', 'FLAVORS_TO_BUILD=' + flavor, 'stage'])
+    stage_output = _run_cmd(['make', 'FLAVORS=' + flavor, 'stage'])
     staging_dir_pattern = re.compile(r'^\s*STAGING_DIR\s*:\s+(.*)$', re.MULTILINE)
     match = staging_dir_pattern.search(stage_output)
     if not match or not match[1] or match[1] == '':


### PR DESCRIPTION
Typing "FLAVORS_TO_BUILD" on the commandline a lot of times is tiring.
    Changing this to just "FLAVORS" makes this easier, and the name is still
    adequate.

This PR is built on top of #930 