### PR TITLE
Improving parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ push:  $(foreach p, $(FLAVORS), do.image.$(p)) ;
 build.parallel:
 # Due to output-sync, will not output results until finished so there is no text interleaving
 ifeq (4.00,$(firstword $(sort $(MAKE_VERSION) 4.00)))
-	@$(MAKE) --jobs --output-sync build
+	@$(MAKE) --jobs $(nproc) --output-sync build
 else
-	@$(MAKE) --jobs build
+	@$(MAKE) --jobs $(nproc) build
 endif
 
 build.all:

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ stage: $(foreach p, $(FLAVORS), stage.$(p)) ;
 build: $(foreach p, $(FLAVORS), do.image.$(p)) ;
 push:  $(foreach p, $(FLAVORS), do.image.$(p)) ;
 
+push.parallel:
+# Due to output-sync, will not output results until finished so there is no text interleaving
+ifeq (4.00,$(firstword $(sort $(MAKE_VERSION) 4.00)))
+	@$(MAKE) --jobs $(nproc) --output-sync push
+else
+	@$(MAKE) --jobs $(nproc) push
+endif
+
 build.parallel:
 # Due to output-sync, will not output results until finished so there is no text interleaving
 ifeq (4.00,$(firstword $(sort $(MAKE_VERSION) 4.00)))
@@ -138,6 +146,7 @@ help:
 	@echo '    build.parallel    Build default flavors in parallel.'
 	@echo '    build.all         Build all buildable flavors with build.parallel'
 	@echo '    push              Push release images to registry.'
+	@echo '    push.parallel     Push release images to registy in parallel'
 	@echo ''
 	@echo '  Clean:'
 	@echo '    clean             Remove images and staging dirs for the current flavors.'

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -60,7 +60,7 @@ function build_ceph_imgs {
 
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make -j "$(nproc)" RELEASE="$RELEASE" push
+  make RELEASE="$RELEASE" push.parallel
 
   for i in daemon-base daemon; do
     tag=ceph/$i:${BRANCH}-${LATEST_COMMIT_SHA}-luminous-ubuntu-16.04-x86_64


### PR DESCRIPTION
This PR is about 
- controlling the parallelism of the build.parallel target to avoid saturating build hosts
- adding a push.parallel to speed up the push process