### PR TITLE
nfs: create ganesha log directory

### DIFF
--- a/src/daemon/start_nfs.sh
+++ b/src/daemon/start_nfs.sh
@@ -30,6 +30,9 @@ function start_nfs {
     chmod 0600 "$RGW_KEYRING"
   fi
 
+  # create ganesha log directory since the package does not create it
+  mkdir -p /var/log/ganesha/
+
   log "SUCCESS"
   # start ganesha, logging both to STDOUT and to the configured location
   exec /usr/bin/ganesha.nfsd "${GANESHA_OPTIONS[@]}" -F -L STDOUT "${GANESHA_EPOCH}"

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -66,7 +66,7 @@ fi
 cd "$WORKSPACE"
 
 # build everything that was touched to make sure build succeeds
-mapfile -t FLAVOR_ARRAY < <(make flavors.modified)
+mapfile -t FLAVOR_ARRAY < <(sudo make flavors.modified)
 
 if [[ "${#FLAVOR_ARRAY[@]}" -eq "0" ]]; then
   echo "The ceph-container code has not changed."


### PR DESCRIPTION
Fixes the start error: ganesha.nfsd-182[main] create_log_facility :LOG
:CRIT :Cannot create new log file (/var/log/ganesha/ganesha.log),
because: No such file or directory

Signed-off-by: Sébastien Han <seb@redhat.com>