### PR TITLE
[DNM] opensuse: Change package info from zypper to rpm

### DIFF
--- a/ceph-releases/ALL/opensuse/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 ( __ZYPPER__ addrepo __CEPH_REPO__ ceph-${CEPH_VERSION} && \
     __ZYPPER_UPDATE__ && \
     __ZYPPER_INSTALL__ __CEPH_BASE_PACKAGES__ && \
-    __ZYPPER__ info __CEPH_BASE_PACKAGES__ && \
+    rpm --query __CEPH_BASE_PACKAGES__ && \
     __ZYPPER__ removerepo ceph-${CEPH_VERSION} ) || \
     ( retval=$? && cat /var/log/zypper.log && exit $retval )

--- a/ceph-releases/ALL/opensuse/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/daemon/__DOCKERFILE_INSTALL__
@@ -2,7 +2,7 @@
     __ZYPPER__ addrepo __BUILD_DEPS_REPO__ build-deps && \
     __ZYPPER_UPDATE__ && \
     __ZYPPER_INSTALL__ __DAEMON_PACKAGES__ && \
-    __ZYPPER__ info __DAEMON_PACKAGES__ && \
+    rpm --query __DAEMON_PACKAGES__ && \
     __ZYPPER__ removerepo cloud-tools && \
     __ZYPPER__ removerepo build-deps ) || \
     ( retval=$? && cat /var/log/zypper.log && exit $retval )


### PR DESCRIPTION
`zypper info` does not work in environments without internet access. Use
'rpm --query` in place of this to suppor these build environments.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>