### PR TITLE
make: improve flavor modified

### DIFF
--- a/maint-lib/flavors-modified-vs-master.py
+++ b/maint-lib/flavors-modified-vs-master.py
@@ -42,9 +42,10 @@ if 'VS_BRANCH' in os.environ and not os.environ['VS_BRANCH'] == '':
 
 # Get list of files different from VS_BRANCH
 try:
+    _run_cmd(['git', 'fetch', 'origin', 'master'])
     filediff = _run_cmd(['git', 'diff', '--name-only', VS_BRANCH])
 except subprocess.CalledProcessError as c:
-    _fatal('Could not get file diff. Is the VS_BRANCH specified a real branch?')
+    _fatal('Could not fetch origin master or get file diff. Is your remote named origin? Is the VS_BRANCH specified a real branch?')
 
 # Files that haven't been committed don't show up in git diff, so also list those
 modified_files_with_status = _run_cmd(['git', 'status', '--short'])


### PR DESCRIPTION
We must fetch origin master to make sure our understanding of
origin/master's content is up to date. If we don't do this we will find
irrelevant/wrong results.

Signed-off-by: Sébastien Han <seb@redhat.com>