### PR TITLE
staging: fail when env var replacement not set

### DIFF
--- a/maint-lib/stagelib/replace.py
+++ b/maint-lib/stagelib/replace.py
@@ -80,6 +80,7 @@ def _env_var_replace(template_text, file_path):
             sys.stderr.write(
                 'Variable {} in {} could not be replaced, because the env var {} is unset'.format(
                     var, file_path, var_name))
+            sys.exit(1)
         logging.info(REPLACE_LOGTEXT.format(var, var_value, file_path))
         template_text = template_text.replace(var, var_value)
     return template_text


### PR DESCRIPTION
Staging was not failing when an environment variable intended to be used
as a variable replacement was unset. Make staging exit with error.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>