### PR TITLE
[skip ci] contrib: use centos as latest instead of ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 install:
   - sudo ./travis-builds/prepare_osd_fs.sh
   - docker run -d --name ceph-demo -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e CLUSTER=test -e NETWORK_AUTO_DETECT=4 -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar ceph/daemon:HEAD-luminous-centos-7-x86_64 demo
+  - sleep 5  # let's give the container 5sec to create its Ceph config file
 
 script:
   - sudo ./travis-builds/validate_demo_cluster.sh

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -73,7 +73,7 @@ function push_ceph_imgs_latest {
   fi
 
   for i in daemon-base daemon; do
-    tag=ceph/$i:${BRANCH}-${LATEST_COMMIT_SHA}-luminous-ubuntu-16.04-x86_64
+    tag=ceph/$i:${BRANCH}-${LATEST_COMMIT_SHA}-luminous-centos-7-x86_64
     # tag latest daemon-base and daemon images
     docker tag "$tag" ceph/$i:latest
 

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -79,17 +79,17 @@ if [[ "${#FLAVOR_ARRAY[@]}" -eq "1" ]]; then
   FLAVOR="${FLAVOR_ARRAY[0]}"
 else
   # if more than one release/distro is impacted then we test this in priority
-  FLAVOR="luminous,ubuntu,16.04"
+  FLAVOR="luminous,centos,7"
 fi
 
 CURRENT_CEPH_STABLE_RELEASE="$(echo $FLAVOR|awk -F ',' '{ print $1}')"
 
 # CEPH_STABLE_RELEASE is an info passed by the CI (see tox.ini)
 # if CEPH_STABLE_RELEASE does not match CURRENT_CEPH_STABLE_RELEASE then CEPH_STABLE_RELEASE wins
-# so we will build the desired CEPH_STABLE_RELEASE since the current patch didn't change the ceph version
+# so we will build the desired CEPH_STABLE_RELEASE since the current patch didn't change the Ceph version
 # Since we test all the Ceph releases, we will always test the impacted one
 if [[ "$CEPH_STABLE_RELEASE" != "$CURRENT_CEPH_STABLE_RELEASE" ]]; then
-  FLAVOR="$CEPH_STABLE_RELEASE,ubuntu,16.04"
+  FLAVOR="$CEPH_STABLE_RELEASE,centos,7"
 fi
 
 echo "Building flavor $FLAVOR"


### PR DESCRIPTION
CentOS is the distro that currently has:

* the best CI coverage in terms of functional tests
* all the packages for all the various ceph projects

So this is natural to us to change our latest image to poin to CentOS
instead of Ubuntu.

Closes: https://github.com/ceph/ceph-container/issues/984
Signed-off-by: Sébastien Han <seb@redhat.com>