### PR TITLE
make: allow user-defined image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ REGISTRY ?= ceph
 # Could be overrided by user at build time
 RELEASE ?= $(shell git rev-parse --abbrev-ref HEAD)
 
+DAEMON_BASE_TAG ?= ""
+DAEMON_TAG ?= ""
+
 
 # ==============================================================================
 # Internal definitions
@@ -166,9 +169,15 @@ help:
 	@echo ''
 	@echo '  REGISTRY - The name of the registry to tag images with and to push images to.'
 	@echo '             Defaults to "ceph".'
+	@echo '             If specified as empty string, no registry will be prepended to the tag.'
 	@echo '    e.g., REGISTRY="myreg" will tag images "myreg/daemon{,-base}" and push to "myreg".'
 	@echo ''
 	@echo '  RELEASE - The release version to integrate in the tag. If omitted, set to the branch name.'
+	@echo ''
+	@echo '  DAEMON_BASE_TAG - Override the tag name for the daemon-base image'
+	@echo '  DAEMON_TAG - Override the tag name for the daemon image'
+	@echo '    For tags above, the final image tag will include the registry defined by "REGISTRY".'
+	@echo '    e.g., REGISTRY="myreg" DAEMON_TAG="mydaemontag" will tag the daemon "myreg/mydaemontag"'
 	@echo ''
 
 show.flavors:

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -18,14 +18,21 @@ $(shell bash -c 'set -eu ; \
 	set_var BASEOS_TAG        "$(word 4, $(subst $(comma), , $(1)))" ; \
 	set_var BASEOS_REG        "_" ; \
 	set_var IMAGES_TO_BUILD   "$(IMAGES_TO_BUILD)" ; \
+
 	set_var STAGING_DIR       "staging/$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
-	set_var BASE_IMAGE        "$$BASEOS_REG/$$BASEOS_REPO:$$BASEOS_TAG" ; \
-	set_var BASE_IMAGE        "$${BASE_IMAGE#_/}" ; \
-	set_var DAEMON_BASE_IMAGE \
-	  "$(REGISTRY)/daemon-base:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
-	set_var DAEMON_IMAGE \
-	  "$(REGISTRY)/daemon:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
-	set_var RELEASE           "$(RELEASE)" \
+	base_img="$$BASEOS_REG/$$BASEOS_REPO:$$BASEOS_TAG" ; \
+	set_var BASE_IMAGE        "$${base_img#_/}" ; \
+	set_var RELEASE           "$(RELEASE)" ; \
+	\
+	daemon_base_img="daemon-base:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
+	if [ -n "$(DAEMON_BASE_TAG)" ] ; then daemon_base_img="$(DAEMON_BASE_TAG)" ; fi ; \
+	if [ -n "$(REGISTRY)" ]; then daemon_base_img="$(REGISTRY)/$$daemon_base_img" ; fi ; \
+	set_var DAEMON_BASE_IMAGE "$$daemon_base_img" ; \
+	\
+	daemon_img="daemon:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
+	if [ -n "$(DAEMON_TAG)" ] ; then daemon_img="$(DAEMON_TAG)" ; fi ; \
+	if [ -n "$(REGISTRY)" ]; then daemon_img="$(REGISTRY)/$$daemon_img" ; fi ; \
+	set_var DAEMON_IMAGE      "$$daemon_img" ; \
 	'
 )
 endef


### PR DESCRIPTION
I'd like to support the case for building/staging images with different tag names. This comes in 2 parts
 1. Allowing the user to change the tag itself
 2. Allowing the user to specify a tag without a registry

This is built off of #979 (shorten flavor spec)

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

-----

```
> make FLAVORS=luminous,opensuse,42.3 DAEMON_BASE_TAG=my-daemon-base-img DAEMON_TAG=my-daemon-img REGISTRY='' stage

  CEPH_VERSION      : luminous
  ARCH              : x86_64
  BASEOS_REG        : _
  BASEOS_REPO       : opensuse
  BASEOS_TAG        : 42.3
  IMAGES_TO_BUILD   : daemon-base daemon
  STAGING_DIR       : staging/luminous-opensuse-42.3-x86_64
  RELEASE           : make-allow-user-defined-image-names
  DAEMON_BASE_IMAGE : my-daemon-base-img
  DAEMON_IMAGE      : my-daemon-img
```

```
> make FLAVORS=luminous,opensuse,42.3 DAEMON_BASE_TAG=my-daemon-base-img DAEMON_TAG=my-daemon-img stage

  CEPH_VERSION      : luminous
  ARCH              : x86_64
  BASEOS_REG        : _
  BASEOS_REPO       : opensuse
  BASEOS_TAG        : 42.3
  IMAGES_TO_BUILD   : daemon-base daemon
  STAGING_DIR       : staging/luminous-opensuse-42.3-x86_64
  RELEASE           : make-allow-user-defined-image-names
  DAEMON_BASE_IMAGE : ceph/my-daemon-base-img
  DAEMON_IMAGE      : ceph/my-daemon-img
```

```
> make FLAVORS=luminous,opensuse,42.3 REGISTRY='' stage

  CEPH_VERSION      : luminous
  ARCH              : x86_64
  BASEOS_REG        : _
  BASEOS_REPO       : opensuse
  BASEOS_TAG        : 42.3
  IMAGES_TO_BUILD   : daemon-base daemon
  STAGING_DIR       : staging/luminous-opensuse-42.3-x86_64
  RELEASE           : make-allow-user-defined-image-names
  DAEMON_BASE_IMAGE : daemon-base:make-allow-user-defined-image-names-luminous-opensuse-42.3-x86_64
  DAEMON_IMAGE      : daemon:make-allow-user-defined-image-names-luminous-opensuse-42.3-x86_64
```