### PR TITLE
staging, test: alphabetize files-sources text

### DIFF
--- a/maint-lib/stagelib/filetools.py
+++ b/maint-lib/stagelib/filetools.py
@@ -100,8 +100,10 @@ def save_files_copied(files_copied, save_filename, strip_prefix=' '):
                git.get_repo(), git.get_branch(), git.get_hash())
     filetext += printfmt.format('<staged file>', src_key)
     filetext += separator
-    for staged_file, source_file in files_copied.items():
+    staged_paths = sorted(list(files_copied.keys()))
+    for staged_path in staged_paths:
+        staged_file = staged_path
         if staged_file.startswith(strip_prefix):
             staged_file = staged_file[len(strip_prefix):]
-        filetext += printfmt.format(staged_file, source_file)
+        filetext += printfmt.format(staged_file, files_copied[staged_path])
     save_text_to_file(filetext, save_filename)

--- a/tests/stage-test/stage-key/files-sources
+++ b/tests/stage-test/stage-key/files-sources
@@ -3,32 +3,32 @@ Source version info:  repo [testrepo] - branch [testbranch] - commit hash [testh
 
 <staged file>                                                                     <-   <source file> (preceding * indicates file is modified in git without a commit)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
-daemon-base/__MAINTAINER__                                                        <-   tests/stage-test/ceph-releases/ALL/ubuntu/__MAINTAINER__
+daemon-base/__DO_STUFF__                                                          <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/daemon-base/__DO_STUFF__
 daemon-base/__EMPTY__                                                             <-   tests/stage-test/src/daemon-base/__EMPTY__
 daemon-base/__H4X0R__                                                             <-   tests/stage-test/src/daemon-base/__H4X0R__
+daemon-base/__MAINTAINER__                                                        <-   tests/stage-test/ceph-releases/ALL/ubuntu/__MAINTAINER__
+daemon-base/__OS_CODENAME__                                                       <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/__OS_CODENAME__
+daemon-base/l-daemon-base-test-file                                               <-   tests/stage-test/ceph-releases/luminous/daemon-base/l-daemon-base-test-file
+daemon-base/l-test-file                                                           <-   tests/stage-test/ceph-releases/luminous/l-test-file
+daemon-base/lu-daemon-base-test-file                                              <-   tests/stage-test/ceph-releases/luminous/ubuntu/daemon-base/lu-daemon-base-test-file
+daemon-base/lu-test-file                                                          <-   tests/stage-test/ceph-releases/luminous/ubuntu/lu-test-file
+daemon-base/lum-daemon-base-test-file                                             <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/daemon-base/lum-daemon-base-test-file
+daemon-base/lum-test-file                                                         <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/lum-test-file
 daemon-base/src-daemon-base-test-file                                             <-   tests/stage-test/src/daemon-base/src-daemon-base-test-file
 daemon-base/ubuntu-mimic-override                                                 <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/ubuntu-mimic-override
-daemon-base/__OS_CODENAME__                                                       <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/__OS_CODENAME__
-daemon-base/__DO_STUFF__                                                          <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/daemon-base/__DO_STUFF__
-daemon-base/l-test-file                                                           <-   tests/stage-test/ceph-releases/luminous/l-test-file
-daemon-base/l-daemon-base-test-file                                               <-   tests/stage-test/ceph-releases/luminous/daemon-base/l-daemon-base-test-file
-daemon-base/lu-test-file                                                          <-   tests/stage-test/ceph-releases/luminous/ubuntu/lu-test-file
-daemon-base/lu-daemon-base-test-file                                              <-   tests/stage-test/ceph-releases/luminous/ubuntu/daemon-base/lu-daemon-base-test-file
-daemon-base/lum-test-file                                                         <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/lum-test-file
-daemon-base/lum-daemon-base-test-file                                             <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/daemon-base/lum-daemon-base-test-file
-daemon/__MAINTAINER__                                                             <-   tests/stage-test/ceph-releases/ALL/ubuntu/__MAINTAINER__
-daemon/computed-vars                                                              <-   tests/stage-test/src/daemon/computed-vars
-daemon/src-daemon-test-file                                                       <- * tests/stage-test/src/daemon/src-daemon-test-file
-daemon/src-daemon-test-dir/src-daemon-test-dir-test-file                          <-   tests/stage-test/src/daemon/src-daemon-test-dir/src-daemon-test-dir-test-file
-daemon/ubuntu-mimic-override                                                      <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/ubuntu-mimic-override
-daemon/__OS_CODENAME__                                                            <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/__OS_CODENAME__
 daemon/__DO_STUFF__                                                               <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/daemon/__DO_STUFF__
-daemon/l-test-file                                                                <-   tests/stage-test/ceph-releases/luminous/l-test-file
-daemon/l-daemon-test-file                                                         <-   tests/stage-test/ceph-releases/luminous/daemon/l-daemon-test-file
+daemon/__MAINTAINER__                                                             <-   tests/stage-test/ceph-releases/ALL/ubuntu/__MAINTAINER__
+daemon/__OS_CODENAME__                                                            <-   tests/stage-test/ceph-releases/ALL/ubuntu/16.04/__OS_CODENAME__
+daemon/computed-vars                                                              <-   tests/stage-test/src/daemon/computed-vars
 daemon/l-daemon-test-dir/l-daemon-test-dir-test-file                              <-   tests/stage-test/ceph-releases/luminous/daemon/l-daemon-test-dir/l-daemon-test-dir-test-file
-daemon/lu-test-file                                                               <-   tests/stage-test/ceph-releases/luminous/ubuntu/lu-test-file
-daemon/lu-daemon-test-file                                                        <-   tests/stage-test/ceph-releases/luminous/ubuntu/daemon/lu-daemon-test-file
+daemon/l-daemon-test-file                                                         <-   tests/stage-test/ceph-releases/luminous/daemon/l-daemon-test-file
+daemon/l-test-file                                                                <-   tests/stage-test/ceph-releases/luminous/l-test-file
 daemon/lu-daemon-test-dir/lu-daemon-test-dir-test-file                            <-   tests/stage-test/ceph-releases/luminous/ubuntu/daemon/lu-daemon-test-dir/lu-daemon-test-dir-test-file
-daemon/lum-test-file                                                              <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/lum-test-file
-daemon/lum-daemon-test-file                                                       <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/daemon/lum-daemon-test-file
+daemon/lu-daemon-test-file                                                        <-   tests/stage-test/ceph-releases/luminous/ubuntu/daemon/lu-daemon-test-file
+daemon/lu-test-file                                                               <-   tests/stage-test/ceph-releases/luminous/ubuntu/lu-test-file
 daemon/lum-daemon-test-dir/lum-daemon-test-dir-test-file                          <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/daemon/lum-daemon-test-dir/lum-daemon-test-dir-test-file
+daemon/lum-daemon-test-file                                                       <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/daemon/lum-daemon-test-file
+daemon/lum-test-file                                                              <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/lum-test-file
+daemon/src-daemon-test-dir/src-daemon-test-dir-test-file                          <-   tests/stage-test/src/daemon/src-daemon-test-dir/src-daemon-test-dir-test-file
+daemon/src-daemon-test-file                                                       <- * tests/stage-test/src/daemon/src-daemon-test-file
+daemon/ubuntu-mimic-override                                                      <-   tests/stage-test/ceph-releases/luminous/ubuntu/16.04/ubuntu-mimic-override


### PR DESCRIPTION
It seems that Python traverses directories in inode order rather than in
sorted order, so in order to make the files-sources text easily
testable, we need to make sure the output order is deterministic. Do
this by alphabetizing the sources.