### PR TITLE
make: Allow user to specify BASE_IMAGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ RELEASE ?= $(shell git rev-parse --abbrev-ref HEAD)
 DAEMON_BASE_TAG ?= ""
 DAEMON_TAG ?= ""
 
+BASE_IMAGE ?= ""
+
 
 # ==============================================================================
 # Internal definitions
@@ -182,6 +184,11 @@ help:
 	@echo '  DAEMON_TAG - Override the tag name for the daemon image'
 	@echo '    For tags above, the final image tag will include the registry defined by "REGISTRY".'
 	@echo '    e.g., REGISTRY="myreg" DAEMON_TAG="mydaemontag" will tag the daemon "myreg/mydaemontag"'
+	@echo ''
+	@echo '  BASE_IMAGE - Do not compute the base image to be used as container base from BASEOS_REPO'
+	@echo '               and BASEOS_TAG. Instead, use the base image specified. The BASEOS_ vars will'
+	@echo '               still be used to determine the ceph-container source files to use.'
+	@echo '               e.g., BASE_IMAGE="myrepo/mycustomubuntu:mytag"'
 	@echo ''
 
 show.flavors:

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -24,6 +24,7 @@ $(shell bash -c 'set -eu ; \
 
 	set_var STAGING_DIR       "staging/$$CEPH_VERSION$$CEPH_POINT_RELEASE-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
 	base_img="$$BASEOS_REG/$$BASEOS_REPO:$$BASEOS_TAG" ; \
+	if [ -n "$(BASE_IMAGE)" ] ; then base_img="$(BASE_IMAGE)" ; fi ; \
 	set_var BASE_IMAGE        "$${base_img#_/}" ; \
 	set_var RELEASE           "$(RELEASE)" ; \
 	\


### PR DESCRIPTION
    In an environment where users have custom base containers that they want
    to use with ceph-container, allow them to override BASE_IMAGE.