### PR TITLE
staging: allow nested env replacements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ underscores with capital letters, digits, and underscores between) can be placed
 staged, the `__VAR_NAME__` variable will be replaced with the raw contents of the file with the
 named `__VAR_NAME__`. Trailing whitespace is stripped from the variable file before insertion.
 `__VAR_NAME__` files are allowed to be empty, but they are not allowed to be nonexistent if a file
-declares them. A `__VAR_NAME__` definition file may contain nested `__OTHER_VAR_NAME__` variables.
+declares them. A `__VAR_NAME__` definition file may contain nested `__OTHER_VAR_NAME__` variables as
+well as nested `__ENV_[ENV_VAR]__` variables (documented below).
 
 If the `__DO_STUFF__` file is supposed to contain actions that need done it generally needs to
 return true. As an example, `echo 'first' && __DO_STUFF__ && echo 'last'` will print 'first' and
@@ -76,8 +77,9 @@ are staged, the `__ENV_[ENV_VAR]__` variable will be replaced with the raw conte
 environment variable named `ENV_VAR`. Only environment variables with all-caps, underscores, and
 digits are supported. Staging will report an error if an environment variable's value is unset.
 
-Environment variable replacements **cannot** be nested inside of other environment variable
-replacements. `__VAR__` file definitions, however, may specify environment variable replacements.
+Environment variable replacements can also be nested inside of other environment variable
+replacements. both `__ENV_[]__` definitions and `__VAR__` file definitions may specify environment
+variable replacements.
 
 A typical usage is to use ``__ENV_[HOST_ARCH]__`` when you need to specify the building
 architecture.

--- a/tests/stage-test/src/daemon-base/src-daemon-base-test-file
+++ b/tests/stage-test/src/daemon-base/src-daemon-base-test-file
@@ -3,3 +3,5 @@ Maintainer: __MAINTAINER__
 Stuff: __DO_STUFF__
 Empty: __EMPTY__
 Nums: __H4X0R__
+Nested env: __ENV_[NESTED_ENV]__
+Nested file: __ENV_[NESTED_FILE]__

--- a/tests/stage-test/stage-key/daemon-base/src-daemon-base-test-file
+++ b/tests/stage-test/stage-key/daemon-base/src-daemon-base-test-file
@@ -4,3 +4,5 @@ Stuff: # Do daemon-base stuff
           hi mom
 Empty: 
 Nums: haxor
+Nested env: luminous
+Nested file: haxor

--- a/tests/stage-test/test_staging.sh
+++ b/tests/stage-test/test_staging.sh
@@ -17,6 +17,8 @@ export IMAGES_TO_BUILD="daemon-base daemon"
 export RELEASE='test-release'
 export DAEMON_BASE_IMAGE=test-reg/daemon-base:test-release-1
 export DAEMON_IMAGE=test-reg/daemon:test-release-1
+export NESTED_ENV="__ENV_[CEPH_VERSION]__"
+export NESTED_FILE="__H4X0R__"
 
 run_stage=$(cat <<'EOF'
 import sys


### PR DESCRIPTION
    __ENV_[VAR]__s are now allowed to contain nested __ENV_[VAR]__s as well
    as __VARIABLE_FILE__s.

    I initially thought that there shouldn't be the need for nested
    __ENV_[VAR]__s, but I have encountered a case where I want to use the
    __ENV_[HOST_ARCH]__ var within another __ENV_[VAR]__.

