### PR TITLE
Updating confd/etcd/kubectl

### DIFF
--- a/ceph-releases/ALL/daemon/__WEB_INSTALL_CONFD__
+++ b/ceph-releases/ALL/daemon/__WEB_INSTALL_CONFD__
@@ -1,5 +1,5 @@
 echo 'Web install confd' && \
-      CONFD_VERSION=0.10.0 && \
+      CONFD_VERSION=0.15.0 && \
       # Assume linux
       CONFD_ARCH=linux-__ENV_[GO_ARCH]__ && \
       wget -q -O /usr/local/bin/confd \

--- a/ceph-releases/ALL/daemon/__WEB_INSTALL_ETCDCTL__
+++ b/ceph-releases/ALL/daemon/__WEB_INSTALL_ETCDCTL__
@@ -1,5 +1,5 @@
 echo 'Web install etcdctl' && \
-    ETCDCTL_VERSION=v2.2.4 && \
+    ETCDCTL_VERSION=v3.2.18 && \
     # Assume linux
     ETCDCTL_ARCH=linux-__ENV_[GO_ARCH]__ && \
     wget -q -O- \

--- a/ceph-releases/ALL/daemon/__WEB_INSTALL_KUBECTL__
+++ b/ceph-releases/ALL/daemon/__WEB_INSTALL_KUBECTL__
@@ -1,5 +1,5 @@
 echo 'Web install kubectl' && \
-      KUBECTL_VERSION=v1.6.0 && \
+      KUBECTL_VERSION=v1.8.11 && \
       # Assume linux
       KUBECTL_ARCH=__ENV_[GO_ARCH]__ && \
       wget -q -O /usr/local/bin/kubectl \


### PR DESCRIPTION
Confd/etcd/kubectl didn't got updated since a very long while and mostly because of the complex tree/file architecture.

Since we have the new tree & build tools, its much more easier to update versions for all flavors.

This PR offer to bump :

- etcd from 2.2.4 to 3.2.18
- confd from 0.10.0 to 0.15.0
- kubectl from 1.6.0 to 1.8.11