### PR TITLE
Dockerfile: Don't fail if CEPH_POINT_RELEASE is unset

### DIFF
--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER __DOCKERFILE_MAINTAINER__
 __DOCKERFILE_TRACEABILITY_LABELS__
 
 ENV CEPH_VERSION __ENV_[CEPH_VERSION]__
-ENV CEPH_POINT_RELEASE __ENV_[CEPH_POINT_RELEASE]__
+ENV CEPH_POINT_RELEASE "__ENV_[CEPH_POINT_RELEASE]__"
 
 #======================================================
 # Install ceph and dependencies, and clean up


### PR DESCRIPTION
When building the code with an empty CEPH_POINT_RELEASE, the build fails
with the following message :

    Error response from daemon: ENV must have two arguments

This was introduced by commit 18c0ba745c29b9834c3b4e04972e41519376337f.
If CEPH_POINT_RELEASE is empty, the Dockerfile is missing a parameter.

This patch simply add some double quotes around the variable to avoid this.
From the container itself, it looks like :

    [root@2beae00c96d3 /]# env |grep CEPH
        CEPH_VERSION=luminous
        CEPH_POINT_RELEASE=
    [root@2beae00c96d3 /]#

Signed-off-by: Erwan Velu <evelu@redhat.com>