### PR TITLE
[skip ci] opensuse: tail the zypper log instead of cat

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -5,4 +5,4 @@
         __PACKAGES__ && \
     __ZYPPER__ info __PACKAGES__ && \
     __REMOVE_REPOS__ ) || \
-    ( retval=$? && cat /var/log/zypper.log && exit $retval )
+    ( retval=$? && tail --lines=300 /var/log/zypper.log && exit $retval )


### PR DESCRIPTION
cat'ing the zypper log on fail gets to be overwhelming. The last 300
lines should be sufficient for most debugging.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>