### PR TITLE
[skip ci] introduce post install tweaks

### DIFF
--- a/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
+++ b/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
@@ -1,0 +1,5 @@
+# disable sync with udev since the container can not contact udev
+sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/' /etc/lvm/lvm.conf && \
+# validate the sed command worked as expected
+grep -sqo "udev_sync = 0" /etc/lvm/lvm.conf && \
+grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf

--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -27,6 +27,8 @@ RUN \
     #
     # Perform any final cleanup actions like package manager cleaning, etc.
     __DOCKERFILE_POSTINSTALL_CLEANUP__ && \
+    # Tweak some configuration files on the container system
+    __DOCKERFILE_POSTINSTALL_TWEAKS__ && \
     # Clean common files like /tmp, /var/lib, etc.
     __DOCKERFILE_CLEAN_COMMON__ && \
     #


### PR DESCRIPTION
This commit introduces 'tweaks', tweak is a new capability that allows
you to configure the container OS. Typically this makes a particular
service more container aware or change its default configuration so it
can work better in containers.

Its first implementation is for configuring LVM.
lvm when creating devices tries to talk to udev. In a container this is
not possible and lvm can not reach udev on the host. Disabling the sync
and the rules help us getting through the lv creation.
Later to scan the lv on the host you can use lvs --readonly

Signed-off-by: Sébastien Han <seb@redhat.com>