### PR TITLE
opensuse: do zypper update before zypper refresh

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 ( __ADD_REPOS__ && \
-    __ZYPPER__ --gpg-auto-import-keys refresh && \
     __ZYPPER__ update --no-recommends --auto-agree-with-licenses --replacefiles --details && \
+    __ZYPPER__ --gpg-auto-import-keys refresh && \
     __ZYPPER__ install --no-recommends --auto-agree-with-licenses --replacefiles --details \
         __PACKAGES__ && \
     __ZYPPER__ info __PACKAGES__ && \


### PR DESCRIPTION
The appropriate ordering of commands is to do update before refresh.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>