### PR TITLE
Opensuse: zypper debugging

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -5,4 +5,4 @@
         __PACKAGES__ && \
     __ZYPPER__ info __PACKAGES__ && \
     __REMOVE_REPOS__ ) || \
-    ( retval=$? && cat /var/log/zypper.log && exit $retval )
+    ( retval=$? && echo ' = zypper log = ' && cat /var/log/zypper.log && exit $retval )


### PR DESCRIPTION
    Sometimes the zypper log is sufficiently long that 300 lines actually
    isn't enough. Revert this, and try something new.

    Keeping the whole zypper log on build fail, though overwhelming, is
    sometimes necessary. To make debugging a little easier, add a header
    before the zypper log output that at least clearly marks where the
    zypper log starts, and thus where the normal build output ends.

