### PR TITLE
[skip ci] demo: add "osd_data" config to ceph.conf

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -26,8 +26,6 @@ function bootstrap_mon {
   source start_mon.sh
   start_mon
 
-  # change replica size
-  ceph "${CLI_OPTS[@]}" osd pool set rbd size 1 || true # in Luminous this pool won't exist anymore and this patch runs on Luminous rc
   chown --verbose ceph. /etc/ceph/*
 }
 

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -43,6 +43,9 @@ function bootstrap_osd {
       if [[ -b "$OSD_DEVICE" ]]; then
         ACTIVATE_OSD=${OSD_DEVICE}1
       elif [[ -d "$OSD_DEVICE" ]]; then
+        if ! grep -qE "osd data = $OSD_DEVICE" /etc/ceph/"${CLUSTER}".conf; then
+          echo "osd data = $OSD_DEVICE" >> /etc/ceph/"${CLUSTER}".conf
+        fi
         ACTIVATE_OSD=${OSD_DEVICE}
       else
         echo "Invalid $OSD_DEVICE, only directory and block device are supported"


### PR DESCRIPTION
When running demo with cn (ceph nano) someone can decide to go with a
directory different from the traditional /var/lib/ceph. If so the
bootstrap will fail if osd_data is not changed.

Signed-off-by: Sébastien Han <seb@redhat.com>