### PR TITLE
staging: rename BASEOS_REG to BASEOS_REGISTRY

### DIFF
--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -19,11 +19,11 @@ $(shell bash -c 'set -eu ; \
 	set_var CEPH_POINT_RELEASE "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_POINT_RELEASE)" ; \
 	set_var BASEOS_REPO        "$(word 3, $(subst $(comma), , $(1)))" ; \
 	set_var BASEOS_TAG         "$(word 4, $(subst $(comma), , $(1)))" ; \
-	set_var BASEOS_REG         "_" ; \
+	set_var BASEOS_REGISTRY    "_" ; \
 	set_var IMAGES_TO_BUILD    "$(IMAGES_TO_BUILD)" ; \
 
 	set_var STAGING_DIR       "staging/$$CEPH_VERSION$$CEPH_POINT_RELEASE-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
-	base_img="$$BASEOS_REG/$$BASEOS_REPO:$$BASEOS_TAG" ; \
+	base_img="$$BASEOS_REGISTRY/$$BASEOS_REPO:$$BASEOS_TAG" ; \
 	if [ -n "$(BASE_IMAGE)" ] ; then base_img="$(BASE_IMAGE)" ; fi ; \
 	set_var BASE_IMAGE        "$${base_img#_/}" ; \
 	set_var RELEASE           "$(RELEASE)" ; \

--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -17,7 +17,7 @@ REQUIRED_ENV_VARS = OrderedDict([
     ('CEPH_VERSION',       'Ceph named version being built (e.g., luminous, mimic)'),  # noqa: E241
     ('CEPH_POINT_RELEASE', 'Points to specific version of ceph (e.g -12.2.0) or empty'),  # noqa: E241,E501
     ('HOST_ARCH',          'Architecture of binaries being built (e.g., amd64, arm32, arm64)'),  # noqa: E241,E501
-    ('BASEOS_REG',         'Registry for the container base image (e.g., _ (x86_64), arm64v8 (aarch64))' +  # noqa: E241,E501
+    ('BASEOS_REGISTRY',    'Registry for the container base image (e.g., _ (x86_64), arm64v8 (aarch64))' +  # noqa: E241,E501
                            ALIGNED_NEWLINE + 'There is a relation between HOST_ARCH and this value'),  # noqa: E241,E501
     ('BASEOS_REPO',        'Repository for the container base image (e.g., ubuntu, opensuse)'),  # noqa: E241,E501
     ('BASEOS_TAG',         'Tagged version of BASEOS_REPO container (e.g., 16.04, 42.3 respectively)'),  # noqa: E241,E501

--- a/src/STAGING_ENV_VARS.md
+++ b/src/STAGING_ENV_VARS.md
@@ -5,7 +5,7 @@ See `ceph-container/maint-lib/stagelib/envglobals.py` for most updated list and 
  - CEPH_VERSION
  - CEPH_POINT_RELEASE
  - HOST_ARCH
- - BASEOS_REG
+ - BASEOS_REGISTRY
  - BASEOS_REPO
  - BASEOS_TAG
  - IMAGES_TO_BUILD

--- a/tests/stage-test/stage-key/staging_output.txt
+++ b/tests/stage-test/stage-key/staging_output.txt
@@ -2,7 +2,7 @@
   CEPH_VERSION      : luminous
   CEPH_POINT_RELEASE: -12.2.1-0
   HOST_ARCH         : x86_64
-  BASEOS_REG        : _
+  BASEOS_REGISTRY   : _
   BASEOS_REPO       : ubuntu
   BASEOS_TAG        : 16.04
   IMAGES_TO_BUILD   : daemon-base daemon

--- a/tests/stage-test/test_staging.sh
+++ b/tests/stage-test/test_staging.sh
@@ -9,7 +9,7 @@ export CEPH_VERSION
 CEPH_POINT_RELEASE=$(maint-lib/ceph_version.sh "${CEPH_VERSION_SPEC}" "CEPH_POINT_RELEASE")
 export CEPH_POINT_RELEASE
 export HOST_ARCH=x86_64
-export BASEOS_REG=_
+export BASEOS_REGISTRY=_
 export BASEOS_REPO=ubuntu
 export BASEOS_TAG=16.04
 export STAGING_DIR=tests/stage-test/staging/${CEPH_VERSION}${CEPH_POINT_RELEASE}-${BASEOS_REPO}-${BASEOS_TAG}-${HOST_ARCH}


### PR DESCRIPTION
In prep for making BASEOS_REG a tunable, rename it to BASEOS_REGISTRY so
the variable is more clear.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>