### PR TITLE
mgr: use the mgr key to enable module

### DIFF
--- a/src/daemon/start_mgr.sh
+++ b/src/daemon/start_mgr.sh
@@ -18,7 +18,9 @@ function start_mgr {
   fi
 
   log "SUCCESS"
-  ceph -v
+
+  # Add the mgr keyring to the command line instead of using client.admin
+  CLI_OPTS+=(-n mgr."$MGR_NAME" -k "$MGR_KEYRING")
 
   # Env. variables matching the pattern "<module>_" will be
   # found and parsed for config-key settings by


### PR DESCRIPTION
We don't need to use the admin key for work with modules. The mgr key
has enough permissions for that.

Also removed the uncessary ceph -v command. Leftover.

Signed-off-by: Sébastien Han <seb@redhat.com>