### PR TITLE
[skip ci] ceph-releases: Adding rhel7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ ALL_BUILDABLE_FLAVORS := \
 	jewel,centos,7 \
 	kraken,centos,7 \
 	luminous,opensuse,42.3 \
+	luminous,rhel7,7-released \
 
 # ==============================================================================
 # Build targets

--- a/ceph-releases/ALL/rhel7/__DOCKERFILE_CLEAN_COMMON__
+++ b/ceph-releases/ALL/rhel7/__DOCKERFILE_CLEAN_COMMON__
@@ -1,0 +1,2 @@
+# We don't clean RHEL
+find /var/log/ -type f -exec truncate -s 0 {} \;

--- a/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
@@ -1,0 +1,1 @@
+Erwan Velu <evelu@redhat.com>

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,0 +1,3 @@
+
+yum update -y && \
+yum install -y __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,5 @@
+echo 'Postinstall cleanup' && \
+ ( yum clean all && \
+   rpmdb --rebuilddb && \
+   rpm -q __CEPH_BASE_PACKAGES__ && \
+   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf )

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -1,0 +1,1 @@
+RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf

--- a/ceph-releases/ALL/rhel7/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__ISCSI_PACKAGES__
@@ -1,0 +1,1 @@
+tcmu-runner ceph-iscsi-config ceph-iscsi-cli

--- a/ceph-releases/ALL/rhel7/daemon-base/__RADOSGW_PACKAGE__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__RADOSGW_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-radosgw__ENV_[CEPH_POINT_RELEASE]__ libradosstriper1__ENV_[CEPH_POINT_RELEASE]__

--- a/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_INSTALL__
@@ -1,0 +1,2 @@
+echo 'Install packages' && \
+      yum install -y wget unzip uuid-runtime python-setuptools udev dmsetup

--- a/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,2 @@
+yum clean all && \
+sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf

--- a/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_PREINSTALL__
@@ -1,0 +1,20 @@
+RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
+
+# Editing /etc/redhat-storage-server release file
+RUN echo "Red Hat Ceph Storage Server 3 (Container)" > /etc/redhat-storage-release
+
+EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
+
+# Atomic specific labels
+ADD install.sh /install.sh
+LABEL version=3
+LABEL run="/usr/bin/docker run -d --net=host --pid=host -e MON_NAME=\${MON_NAME} -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph \${IMAGE}"
+LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -e MON_NAME=\${MON_NAME} -e OSD_DEVICE=\${OSD_DEVICE} -e HOST=/host -e IMAGE=\${IMAGE} --entrypoint=/install.sh \${IMAGE}"
+
+# Build specific labels
+LABEL com.redhat.component="rhceph-rhel7-docker"
+LABEL name="rhceph"
+LABEL description="Red Hat Ceph Storage 3"
+LABEL summary="Provides the latest Red Hat Ceph Storage 3 on RHEL 7 in a fully featured and supported base image."
+LABEL io.k8s.display-name="Red Hat Ceph Storage 3 on RHEL 7"
+LABEL io.openshift.tags="rhceph ceph"

--- a/ceph-releases/ALL/rhel7/daemon/install.sh
+++ b/ceph-releases/ALL/rhel7/daemon/install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+function mon_systemd {
+  cat <<EOF  > ${HOST}/etc/systemd/system/multi-user.target.wants/ceph-mon@${MON_NAME}.service
+[Unit]
+Description=Ceph Monitor
+After=docker.service
+
+[Service]
+EnvironmentFile=/etc/environment
+ExecStartPre=-/usr/bin/docker stop %i
+ExecStartPre=/usr/bin/mkdir -p /etc/ceph /var/lib/ceph/mon
+ExecStart=/usr/bin/docker run --rm --name %i --net=host \
+   -v /var/lib/ceph:/var/lib/ceph \
+   -v /etc/ceph:/etc/ceph \
+   --privileged \
+   -e CEPH_DAEMON=MON \
+   -e MON_IP=${MON_IP} \
+   -e CEPH_PUBLIC_NETWORK=${CEPH_PUBLIC_NETWORK} \
+   -e MON_NAME=${MON_NAME} \
+   --name=${MON_NAME} \
+   ${IMAGE}
+ExecStopPost=-/usr/bin/docker stop %i
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+function osd_systemd {
+  cat <<EOF > ${HOST}/etc/systemd/system/multi-user.target.wants/ceph-osd@${DEVICE}.service
+[Unit]
+Description=Ceph OSD
+After=docker.service
+
+[Service]
+EnvironmentFile=/etc/environment
+ExecStartPre=-/usr/bin/docker stop osd-dev%i
+ExecStartPre=-/usr/bin/docker rm osd-dev%i
+ExecStart=/usr/bin/docker run --rm --net=host --pid=host\
+   -v /var/lib/ceph:/var/lib/ceph \
+   -v /etc/ceph:/etc/ceph \
+   -v /dev:/dev \
+   --privileged \
+   -e CEPH_DAEMON=OSD_CEPH_DISK_ACTIVATE \
+   -e OSD_DEVICE=/dev/%i \
+   --name=dev%i \
+   hchen/rhceph
+ExecStop=-/usr/bin/docker stop osd-dev%i
+ExecStopPost=-/usr/bin/docker rm osd-dev%i
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+
+# Normalize DAEMON to lowercase
+CEPH_DAEMON=$(echo ${CEPH_DAEMON} |tr '[:upper:]' '[:lower:]')
+case "$CEPH_DAEMON" in
+  mon)
+    mon_systemd
+    ;;
+  osd)
+    DEVICE=`echo ${OSD_DEVICE}|sed 's/\/dev\///g'`
+    osd_systemd
+    ;;
+  *)
+    if [ ! -n "$CEPH_DAEMON" ]; then
+      echo "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
+      echo "of the daemon you want to install."
+      echo "Valid values for CEPH_DAEMON are MON, OSD, MDS, RGW, RESTAPI"
+      exit 1
+    fi
+    ;;
+esac


### PR DESCRIPTION
This commit is about adding the necessary files for building a RHEL7 based image.
The main differences with the Centos image:
- no cleaning to keep packages untouched
- /var/log is cleaned up
- only use RHEL repositories (to be added by the buildsystem)
- specific LABELs
- disabling subscription-manager during the build

Signed-off-by: Erwan Velu <evelu@redhat.com>