### PR TITLE
makefile: Let user override BASEOS_REGISTRY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ RELEASE ?= $(shell git rev-parse --abbrev-ref HEAD)
 DAEMON_BASE_TAG ?= ""
 DAEMON_TAG ?= ""
 
+BASEOS_REGISTRY ?= "_"
 BASE_IMAGE ?= ""
 
 
@@ -173,6 +174,9 @@ help:
 	@echo '                      sourced from ceph-container (e.g., ubuntu:"16.04", centos:"7")'
 	@echo '    e.g., FLAVORS="luminous,ubuntu,16.04 jewel,ubuntu,14.04"'
 	@echo ''
+	@echo '  REGISTRY - The url of the registry to pull images from.'
+	@echo '             Default to "_" which means the default docker registry'
+	@echo ''
 	@echo '  TAG_REGISTRY - The name of the registry to tag images with and to push images to.'
 	@echo '             Defaults to "ceph".'
 	@echo '             If specified as empty string, no registry will be prepended to the tag.'
@@ -188,7 +192,7 @@ help:
 	@echo '  BASE_IMAGE - Do not compute the base image to be used as container base from BASEOS_REPO'
 	@echo '               and BASEOS_TAG. Instead, use the base image specified. The BASEOS_ vars will'
 	@echo '               still be used to determine the ceph-container source files to use.'
-	@echo '               e.g., BASE_IMAGE="myrepo/mycustomubuntu:mytag"'
+	@echo '               e.g., BASE_IMAGE="mycustomubuntu:mytag"'
 	@echo ''
 
 show.flavors:

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -19,11 +19,11 @@ $(shell bash -c 'set -eu ; \
 	set_var CEPH_POINT_RELEASE "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_POINT_RELEASE)" ; \
 	set_var BASEOS_REPO        "$(word 3, $(subst $(comma), , $(1)))" ; \
 	set_var BASEOS_TAG         "$(word 4, $(subst $(comma), , $(1)))" ; \
-	set_var BASEOS_REGISTRY    "_" ; \
+	set_var BASEOS_REGISTRY    "$(BASEOS_REGISTRY)" ; \
 	set_var IMAGES_TO_BUILD    "$(IMAGES_TO_BUILD)" ; \
 
 	set_var STAGING_DIR       "staging/$$CEPH_VERSION$$CEPH_POINT_RELEASE-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH" ; \
-	base_img="$$BASEOS_REGISTRY/$$BASEOS_REPO:$$BASEOS_TAG" ; \
+	base_img="$$BASEOS_REPO:$$BASEOS_TAG" ; \
 	if [ -n "$(BASE_IMAGE)" ] ; then base_img="$(BASE_IMAGE)" ; fi ; \
 	set_var BASE_IMAGE        "$${base_img#_/}" ; \
 	set_var RELEASE           "$(RELEASE)" ; \


### PR DESCRIPTION
By default, the BASEOS_REGISTRY is set to "_" but some could need
overriding this variable to point to a particular registry to get
images.

This patch let users defining BASEOS_REGISTRY while keeping the same
default value.

This patch does change the behvior introduce by commit 6c90f47a44c93664f50acd67ebfe7e7786b2067d.
The registry is no more part of the BASE_IMAGE override. If one needs a
different name and a different registry, then it have to use both
BASEOS_REGISTRY & BASE_IMAGE overrides.
Signed-off-by: Erwan Velu <evelu@redhat.com>