### PR TITLE
[skip ci] daemon: Removing VOLUME[] from Dockerfile

### DIFF
--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -53,9 +53,6 @@ RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 
-# Add volumes for Ceph config and data
-VOLUME ["/etc/ceph","/var/lib/ceph", "/etc/ganesha"]
-
 # Execute the entrypoint
 WORKDIR /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
As per the actual configuration, it is useless defining VOLUME[] in our
Dockerfile.

Signed-off-by: Erwan Velu <evelu@redhat.com>