### PR TITLE
staging: make BASE_IMAGE a required var

### DIFF
--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -17,8 +17,6 @@ REQUIRED_ENV_VARS = OrderedDict([
     ('CEPH_VERSION',       'Ceph named version being built (e.g., luminous, mimic)'),  # noqa: E241
     ('CEPH_POINT_RELEASE', 'Points to specific version of ceph (e.g -12.2.0) or empty'),  # noqa: E241,E501
     ('HOST_ARCH',          'Architecture of binaries being built (e.g., amd64, arm32, arm64)'),  # noqa: E241,E501
-    ('BASEOS_REGISTRY',    'Registry for the container base image (e.g., _ (x86_64), arm64v8 (aarch64))' +  # noqa: E241,E501
-                           ALIGNED_NEWLINE + 'There is a relation between HOST_ARCH and this value'),  # noqa: E241,E501
     ('BASEOS_REPO',        'Repository for the container base image (e.g., ubuntu, opensuse)'),  # noqa: E241,E501
     ('BASEOS_TAG',         'Tagged version of BASEOS_REPO container (e.g., 16.04, 42.3 respectively)'),  # noqa: E241,E501
     ('IMAGES_TO_BUILD',    'Container images to be built (usually should be "dockerfile daemon")'),  # noqa: E241,E501

--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -19,6 +19,9 @@ REQUIRED_ENV_VARS = OrderedDict([
     ('HOST_ARCH',          'Architecture of binaries being built (e.g., amd64, arm32, arm64)'),  # noqa: E241,E501
     ('BASEOS_REPO',        'Repository for the container base image (e.g., ubuntu, opensuse)'),  # noqa: E241,E501
     ('BASEOS_TAG',         'Tagged version of BASEOS_REPO container (e.g., 16.04, 42.3 respectively)'),  # noqa: E241,E501
+    ('BASE_IMAGE',         'Full image specification (optionally including a registry) of the base image.' +  # noqa: E241,E501
+                            ALIGNED_NEWLINE + 'This normally should include BASEOS_REPO/_TAG values.' +  # noqa: E241,E501
+                            ALIGNED_NEWLINE + '(e.g., myregistry/ubuntu:16.04 or centos:7)'),
     ('IMAGES_TO_BUILD',    'Container images to be built (usually should be "dockerfile daemon")'),  # noqa: E241,E501
     ('STAGING_DIR',        'Dir into which files will be staged' + ALIGNED_NEWLINE +  # noqa: E241
                            'This dir will be overwritten if it already exists'),  # noqa: E241

--- a/src/STAGING_ENV_VARS.md
+++ b/src/STAGING_ENV_VARS.md
@@ -5,7 +5,6 @@ See `ceph-container/maint-lib/stagelib/envglobals.py` for most updated list and 
  - CEPH_VERSION
  - CEPH_POINT_RELEASE
  - HOST_ARCH
- - BASEOS_REGISTRY
  - BASEOS_REPO
  - BASEOS_TAG
  - IMAGES_TO_BUILD

--- a/src/STAGING_ENV_VARS.md
+++ b/src/STAGING_ENV_VARS.md
@@ -7,6 +7,7 @@ See `ceph-container/maint-lib/stagelib/envglobals.py` for most updated list and 
  - HOST_ARCH
  - BASEOS_REPO
  - BASEOS_TAG
+ - BASE_IMAGE
  - IMAGES_TO_BUILD
  - STAGING_DIR
  - RELEASE

--- a/tests/stage-test/src/daemon-base/src-daemon-base-test-file
+++ b/tests/stage-test/src/daemon-base/src-daemon-base-test-file
@@ -5,3 +5,4 @@ Empty: __EMPTY__
 Nums: __H4X0R__
 Nested env: __ENV_[NESTED_ENV]__
 Nested file: __ENV_[NESTED_FILE]__
+Base image: __ENV_[BASE_IMAGE]__

--- a/tests/stage-test/stage-key/daemon-base/src-daemon-base-test-file
+++ b/tests/stage-test/stage-key/daemon-base/src-daemon-base-test-file
@@ -6,3 +6,4 @@ Empty:
 Nums: haxor
 Nested env: luminous
 Nested file: haxor
+Base image: myregistry/ubuntu:16.04

--- a/tests/stage-test/stage-key/staging_output.txt
+++ b/tests/stage-test/stage-key/staging_output.txt
@@ -4,6 +4,7 @@
   HOST_ARCH         : x86_64
   BASEOS_REPO       : ubuntu
   BASEOS_TAG        : 16.04
+  BASE_IMAGE        : myregistry/ubuntu:16.04
   IMAGES_TO_BUILD   : daemon-base daemon
   STAGING_DIR       : tests/stage-test/staging/luminous-12.2.1-0-ubuntu-16.04-x86_64
   RELEASE           : test-release

--- a/tests/stage-test/stage-key/staging_output.txt
+++ b/tests/stage-test/stage-key/staging_output.txt
@@ -2,7 +2,6 @@
   CEPH_VERSION      : luminous
   CEPH_POINT_RELEASE: -12.2.1-0
   HOST_ARCH         : x86_64
-  BASEOS_REGISTRY   : _
   BASEOS_REPO       : ubuntu
   BASEOS_TAG        : 16.04
   IMAGES_TO_BUILD   : daemon-base daemon
@@ -10,4 +9,3 @@
   RELEASE           : test-release
   DAEMON_BASE_IMAGE : test-reg/daemon-base:test-release-1
   DAEMON_IMAGE      : test-reg/daemon:test-release-1
-

--- a/tests/stage-test/test_staging.sh
+++ b/tests/stage-test/test_staging.sh
@@ -11,6 +11,7 @@ export CEPH_POINT_RELEASE
 export HOST_ARCH=x86_64
 export BASEOS_REPO=ubuntu
 export BASEOS_TAG=16.04
+export BASE_IMAGE=myregistry/ubuntu:16.04
 export STAGING_DIR=tests/stage-test/staging/${CEPH_VERSION}${CEPH_POINT_RELEASE}-${BASEOS_REPO}-${BASEOS_TAG}-${HOST_ARCH}
 export IMAGES_TO_BUILD="daemon-base daemon"
 export RELEASE='test-release'

--- a/tests/stage-test/test_staging.sh
+++ b/tests/stage-test/test_staging.sh
@@ -9,7 +9,6 @@ export CEPH_VERSION
 CEPH_POINT_RELEASE=$(maint-lib/ceph_version.sh "${CEPH_VERSION_SPEC}" "CEPH_POINT_RELEASE")
 export CEPH_POINT_RELEASE
 export HOST_ARCH=x86_64
-export BASEOS_REGISTRY=_
 export BASEOS_REPO=ubuntu
 export BASEOS_TAG=16.04
 export STAGING_DIR=tests/stage-test/staging/${CEPH_VERSION}${CEPH_POINT_RELEASE}-${BASEOS_REPO}-${BASEOS_TAG}-${HOST_ARCH}


### PR DESCRIPTION
    `BASE_IMAGE` is not used by the staging Python code, but it is a
    critical part of the Dockerfile that merits adding it to the list of
    required env vars.

    At the same time, `BASEOS_REGISTRY` is not used during any part of the staging process. It is
    only used in the makefile. Therefore, remove it from staging.

    Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>