### PR TITLE
opensuse: auto add repo keys on repo add

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 ( __ADD_REPOS__ && \
     __ZYPPER__ update --no-recommends --auto-agree-with-licenses --replacefiles --details && \
-    __ZYPPER__ --gpg-auto-import-keys refresh && \
+    __ZYPPER__ refresh && \
     __ZYPPER__ install --no-recommends --auto-agree-with-licenses --replacefiles --details \
         __PACKAGES__ && \
     __REMOVE_REPOS__ ) || \

--- a/ceph-releases/ALL/opensuse/__ZYPPER__
+++ b/ceph-releases/ALL/opensuse/__ZYPPER__
@@ -1,1 +1,1 @@
-zypper --non-interactive
+zypper --non-interactive --gpg-auto-import-keys


### PR DESCRIPTION
The build may (will) fail if the repos added don't have trusted keys.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>