### PR TITLE
opensuse: Add debug echo statemets to install

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -1,7 +1,12 @@
-( __ADD_REPOS__ && \
+( echo 'zypper add repos' && \
+    __ADD_REPOS__ && \
+    echo 'zypper update' && \
     __ZYPPER__ update --no-recommends --auto-agree-with-licenses --replacefiles --details && \
+    echo 'zypper refresh' && \
     __ZYPPER__ refresh && \
+    echo 'zypper install' && \
     __ZYPPER__ install --no-recommends --auto-agree-with-licenses --replacefiles --details \
         __PACKAGES__ && \
+    echo 'zypper remove repos' && \
     __REMOVE_REPOS__ ) || \
     ( retval=$? && echo ' = zypper log = ' && cat /var/log/zypper.log && exit $retval )


### PR DESCRIPTION
When builds fail, the large run statement makes it hard to track what
was the command on which the build failed. Add echo statements to help.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>