### PR TITLE
[skip ci] ceph-releases: Adding centos-arm64

### DIFF
--- a/ceph-releases/ALL/centos-arm64/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/centos-arm64/__DOCKERFILE_MAINTAINER__
@@ -1,0 +1,1 @@
+../centos/__DOCKERFILE_MAINTAINER__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__DOCKERFILE_INSTALL__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__DOCKERFILE_PREINSTALL__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__RADOSGW_PACKAGE__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__RADOSGW_PACKAGE__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__RADOSGW_PACKAGE__

--- a/ceph-releases/ALL/centos-arm64/daemon/__CONFD_PACKAGE__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__CONFD_PACKAGE__
@@ -1,0 +1,1 @@
+../../centos/daemon/__CONFD_PACKAGE__

--- a/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_INSTALL__
@@ -1,0 +1,1 @@
+../../centos/daemon/__DOCKERFILE_INSTALL__

--- a/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,1 @@
+../../centos/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__

--- a/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_PREINSTALL__
@@ -1,0 +1,1 @@
+../../centos/daemon/__DOCKERFILE_PREINSTALL__

--- a/ceph-releases/ALL/centos-arm64/daemon/__FOREGO_PACKAGE__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__FOREGO_PACKAGE__
@@ -1,0 +1,1 @@
+../../centos/daemon/__FOREGO_PACKAGE__

--- a/ceph-releases/ALL/centos-arm64/daemon/__WEB_INSTALL_CONFD__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__WEB_INSTALL_CONFD__
@@ -1,0 +1,1 @@
+/bin/true

--- a/ceph-releases/ALL/centos-arm64/daemon/disabled_scenario
+++ b/ceph-releases/ALL/centos-arm64/daemon/disabled_scenario
@@ -1,0 +1,4 @@
+# You can find the complete list of scenario by looking at the 'case' statement
+# in the entrypoint.sh.in file.
+ 
+EXCLUDED_TAGS="populate_kvstore kv_type_etcd kv_type_k8s nfs tcmu_runner rbd_target_api rbd_target_gw"

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -ex
+
+#############
+# VARIABLES #
+#############
+
+CEPH_RELEASES=(luminous)
+
+
+#############
+# FUNCTIONS #
+#############
+
+function build_ceph_imgs {
+  echo "Build Ceph container image(s)"
+  make RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
+  docker images
+}
+
+function push_ceph_imgs {
+  echo "Push Ceph container image(s) to the Docker Hub registry"
+  make RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 push
+}
+
+function build_and_push_latest_bis {
+  # latest-bis is needed by ceph-ansible so it can test the restart handlers on an image ID change
+  # rebuild latest again to get a different image ID
+  make RELEASE="$RELEASE"-bis FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
+  docker tag ceph/daemon:"$BRANCH"-bis-"${CEPH_RELEASES[-1]}"-centos-7-x86_64 ceph/daemon:latest-bis
+  docker push ceph/daemon:latest-bis
+}
+
+
+########
+# MAIN #
+########
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $SCRIPT_DIR/build-push-ceph-container-imgs.sh

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -10,7 +10,7 @@ set -ex
 BRANCH="${GIT_BRANCH#*/}"
 LATEST_COMMIT_SHA=$(git rev-parse --short HEAD)
 TAGGED_HEAD=false # does HEAD is on a tag ?
-CEPH_RELEASES=(jewel kraken luminous)
+if [ -z "$CEPH_RELEASES" ]; then CEPH_RELEASES=(jewel kraken luminous); fi
 
 
 #############
@@ -55,17 +55,20 @@ function create_head_or_point_release {
   fi
 }
 
+declare -F build_ceph_imgs  ||
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
   make RELEASE="$RELEASE" build.parallel
   docker images
 }
 
+declare -F push_ceph_imgs ||
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
   make RELEASE="$RELEASE" push.parallel
 }
 
+declare -F build_and_push_latest_bis ||
 function build_and_push_latest_bis {
   # latest-bis is needed by ceph-ansible so it can test the restart handlers on an image ID change
   # rebuild latest again to get a different image ID


### PR DESCRIPTION
This commit is about adding support for arm64 for centos.

In a perfect world, supporting a new arch is supposed to get anything
changed.

We are in a situation where the build of centos on ARM64 trigger the
following issues :
- nfs-ganesha & tcmu-runner packages are not available
- confd is not available from github

This commit is a little bit special as it try to workaround this
situation. It does create a centos-arm64 OS which links most of the
files from centos.

In this project, we are not supposed to have symlinks but as we are
using the same OS with a very few constrains specific to this arch,
Blaine & I considered that was the best approach.

The differences with centos are :

- __GANESHA_PACKAGES__ is empty to avoid it to be installed
- __WEB_INSTALL_CONFD__ is set to /bin/true to avoid the installation
- __ISCSI_PACKAGES__ is not defined to get it to empty to avoid the installation

This flavor have to be built in a particular fashion as centos-arm64 doesn't exist on the docker registry.
It have to be built with the following command :

    make FLAVORS=luminous,centos-arm64,7 BASE_IMAGE=centos:7 build

The BASE_IMAGE override the centos-arm64 to let docker use the centos:7 image.

Signed-off-by: Erwan Velu <evelu@redhat.com>