### PR TITLE
Dockerfiles: Remove dependency on awk

### DIFF
--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -21,8 +21,8 @@ RUN \
     #   download and install packages from web, cleaning any files as you go.
     # Installs should support install of ganesha for luminous without installing for jewel/kraken.
     __DOCKERFILE_INSTALL__ && \
-    # Clean container, starting with record of current size
-    INITIAL_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}') && \
+    # Clean container, starting with record of current size (strip / from end)
+    INITIAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     #
     #
     # Perform any final cleanup actions like package manager cleaning, etc.
@@ -33,8 +33,8 @@ RUN \
     __DOCKERFILE_CLEAN_COMMON__ && \
     #
     #
-    # Report size savings
-    FINAL_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}') && \
+    # Report size savings (strip / from end)
+    FINAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     REMOVED_SIZE=$((INITIAL_SIZE - FINAL_SIZE)) && \
     echo "Cleaning process removed ${REMOVED_SIZE}MB" && \
     echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB"

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -16,8 +16,8 @@ RUN \
     # Typical workflow: add new repos; refresh repos; install packages; package-manager clean;
     #   download and install packages from web, cleaning any files as you go.
     __DOCKERFILE_INSTALL__ && \
-    # Clean container, starting with record of current size
-    INITIAL_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}') && \
+    # Clean container, starting with record of current size (strip / from end)
+    INITIAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     #
     #
     # Perform any final cleanup actions like package manager cleaning, etc.
@@ -28,8 +28,8 @@ RUN \
     __DOCKERFILE_CLEAN_COMMON__ && \
     #
     #
-    # Report size savings
-    FINAL_SIZE=$(du -sm / 2>/dev/null | awk '{print $1}') && \
+    # Report size savings (strip / from end)
+    FINAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     REMOVED_SIZE=$((INITIAL_SIZE - FINAL_SIZE)) && \
     echo "Cleaning process removed ${REMOVED_SIZE}MB" && \
     echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB"


### PR DESCRIPTION
awk is used to strip the trailing '/' from the output of du used to
estimate size savings in the container build. If a container release
doesn't include awk, it will fail here, and awk is totally unnecessary,
as bash string manipulation can work in its place.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>