### PR TITLE
Dockerfiles: Move package verification after clean

### DIFF
--- a/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__

--- a/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+../../centos/daemon/__DOCKERFILE_VERIFY_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+rpm -q __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,2 +1,1 @@
-yum clean all && \
-rpm -q __DAEMON_PACKAGES__
+yum clean all

--- a/ceph-releases/ALL/centos/daemon/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+rpm -q __DAEMON_PACKAGES__

--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,2 +1,1 @@
-__ZYPPER__ info __PACKAGES__ && \
-    rm -f /var/log/zypper.log
+rm -f /var/log/zypper.log

--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+rpm --query __PACKAGES__

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+rpm -q __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/rhel7/daemon/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+rpm -q __DAEMON_PACKAGES__

--- a/ceph-releases/ALL/ubuntu/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/ubuntu/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+apt-cache show __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/ubuntu/daemon-base/__EXTRA_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/ubuntu/daemon-base/__EXTRA_POSTINSTALL_CLEANUP__
@@ -1,1 +1,1 @@
-apt-cache show __CEPH_BASE_PACKAGES__
+/bin/true

--- a/ceph-releases/ALL/ubuntu/daemon/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/ubuntu/daemon/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,0 +1,1 @@
+apt-cache show __DAEMON_PACKAGES__

--- a/ceph-releases/ALL/ubuntu/daemon/__EXTRA_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/ubuntu/daemon/__EXTRA_POSTINSTALL_CLEANUP__
@@ -14,5 +14,4 @@ echo "purge unneeded packages" && \
       rm -rf /var/lib/apt/lists/* \
              /var/cache/debconf/* \
              /var/log/apt/ \
-             /var/log/dpkg.log &&\
-    apt-cache show __DAEMON_PACKAGES__
+             /var/log/dpkg.log

--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -37,4 +37,7 @@ RUN \
     FINAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     REMOVED_SIZE=$((INITIAL_SIZE - FINAL_SIZE)) && \
     echo "Cleaning process removed ${REMOVED_SIZE}MB" && \
-    echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB"
+    echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB" && \
+    #
+    # Verify that the packages installed haven't been accidentally cleaned
+    __DOCKERFILE_VERIFY_PACKAGES__

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -32,7 +32,10 @@ RUN \
     FINAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     REMOVED_SIZE=$((INITIAL_SIZE - FINAL_SIZE)) && \
     echo "Cleaning process removed ${REMOVED_SIZE}MB" && \
-    echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB"
+    echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB" && \
+    #
+    # Verify that the packages installed haven't been accidentally cleaned
+    __DOCKERFILE_VERIFY_PACKAGES__
 
 #======================================================
 # Add ceph-container files


### PR DESCRIPTION
It is most safe to check that no packages have been cleaned after the
cleaning process is over, as a flavor may remove packages at any point
during cleaning.

Add a `__DOCKERFILE_VERIFY_PACKAGES__` step to the daemon and base
Dockerfiles after the cleaning step has finished to accomplish this.
Move all flavor verification steps to a corresponding
`__DOCKERFILE_VERIFY_PACKAGES__` variable file.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>


I did a `make build.all`, and all flavors built successfully; however, rhel7 is not in the all list and didn't get tested.