### PR TITLE
ceph-releases/rhel7: rename component to "-container"

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -8,6 +8,7 @@ EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 # Atomic specific labels
 ADD install.sh /install.sh
 LABEL version=3
+LABEL release=7
 LABEL run="/usr/bin/docker run -d --net=host --pid=host -e MON_NAME=\${MON_NAME} -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph \${IMAGE}"
 LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -e MON_NAME=\${MON_NAME} -e OSD_DEVICE=\${OSD_DEVICE} -e HOST=/host -e IMAGE=\${IMAGE} --entrypoint=/install.sh \${IMAGE}"
 

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -12,7 +12,7 @@ LABEL run="/usr/bin/docker run -d --net=host --pid=host -e MON_NAME=\${MON_NAME}
 LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -e MON_NAME=\${MON_NAME} -e OSD_DEVICE=\${OSD_DEVICE} -e HOST=/host -e IMAGE=\${IMAGE} --entrypoint=/install.sh \${IMAGE}"
 
 # Build specific labels
-LABEL com.redhat.component="rhceph-rhel7-docker"
+LABEL com.redhat.component="rhceph-rhel7-container"
 LABEL name="rhceph"
 LABEL description="Red Hat Ceph Storage 3"
 LABEL summary="Provides the latest Red Hat Ceph Storage 3 on RHEL 7 in a fully featured and supported base image."


### PR DESCRIPTION
The first commit in this PR changes the component name from "-docker" to "-container".

The second commit in this PR temporarily hardcodes the release value to "7".

Ordinarily OSBS will dynamically set the "release" label to the
proper value (see https://github.com/projectatomic/atomic-reactor/blob/master/atomic_reactor/plugins/pre_bump_release.py)

When the component name changes like this, OSBS will not know that the last release was "6" in order to bump it to "7". We must hardcode "release" for our first rhceph-rhel7-container build.

(We can revert this commit when we have the first rhceph-rhel7-container non-scratch build present in RH's downstream build system.)