### PR TITLE
opensuse: move zypper clean to get debugging

### DIFF
--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_INSTALL__
@@ -8,5 +8,6 @@
     __ZYPPER__ install --no-recommends --auto-agree-with-licenses --replacefiles --details \
         __PACKAGES__ && \
     echo 'zypper remove repos' && \
-    __REMOVE_REPOS__ ) || \
+    __REMOVE_REPOS__ && \
+    __ZYPPER__ clean --all ) || \
     ( retval=$? && echo ' = zypper log = ' && cat /var/log/zypper.log && exit $retval )

--- a/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/opensuse/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,3 +1,2 @@
-__ZYPPER__ clean --all && \
 __ZYPPER__ info __PACKAGES__ && \
     rm -f /var/log/zypper.log


### PR DESCRIPTION
When the build fails on the zypper clean step, the dockerfile does not
output the zypper log. Move the zypper clean instruction from
`__DOCKERFILE_POSTINSTALL_CLEANUP__` to the end of `__DOCKERFILE_INSTALL__`
to gain the zypper log output from the install code.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>