### PR TITLE
Revert "ceph-releases/rhel7: temporarily hardcode release to "7""

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -8,7 +8,6 @@ EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 # Atomic specific labels
 ADD install.sh /install.sh
 LABEL version=3
-LABEL release=7
 LABEL run="/usr/bin/docker run -d --net=host --pid=host -e MON_NAME=\${MON_NAME} -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph \${IMAGE}"
 LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON_IP}  -e CEPH_PUBLIC_NETWORK=\${CEPH_PUBLIC_NETWORK} -e CEPH_DAEMON=\${CEPH_DAEMON} -e MON_NAME=\${MON_NAME} -e OSD_DEVICE=\${OSD_DEVICE} -e HOST=/host -e IMAGE=\${IMAGE} --entrypoint=/install.sh \${IMAGE}"
 


### PR DESCRIPTION
This reverts commit 52672ea79a846cf93a2466b10681476e37f254e0.

"rhceph-rhel7-3-7" is built now, so we can drop this hard-coded release value. OSBS will automatically bump it to "8" going forward.