### PR TITLE
[skip ci] common: fix detect_ceph_files function

### DIFF
--- a/ceph-releases/jewel/daemon/common_functions.sh
+++ b/ceph-releases/jewel/daemon/common_functions.sh
@@ -313,13 +313,14 @@ function detect_ceph_files {
     log "This looks like a restart, processing."
     return 0
   fi
-  if [ -d /var/lib/ceph ] || [ -d /etc/ceph ]; then
-    if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ -z "$(find /etc/ceph -prune -empty)" ]]; then
-      log "I can see existing Ceph files, please remove them!"
-      log "To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/"
-      log "Before doing this, make sure you are removing any sensitive data."
-      exit 1
-    fi
+    if [ -d /var/lib/ceph ] || [ -d /etc/ceph ]; then
+      # For /etc/ceph, it always contains a 'rbdmap' file so we must check for length > 1
+      if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ "$(find /etc/ceph -mindepth 1 -type f| wc -l)" -gt "1" ]]; then
+        log "I can see existing Ceph files, please remove them!"
+        log "To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/"
+        log "Before doing this, make sure you are removing any sensitive data."
+        exit 1
+      fi
   fi
 }
 

--- a/ceph-releases/kraken/daemon/common_functions.sh
+++ b/ceph-releases/kraken/daemon/common_functions.sh
@@ -327,7 +327,8 @@ function detect_ceph_files {
     return 0
   fi
   if [ -d /var/lib/ceph ] || [ -d /etc/ceph ]; then
-    if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ -z "$(find /etc/ceph -prune -empty)" ]]; then
+    # For /etc/ceph, it always contains a 'rbdmap' file so we must check for length > 1
+    if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ "$(find /etc/ceph -mindepth 1 -type f| wc -l)" -gt "1" ]]; then
       log "I can see existing Ceph files, please remove them!"
       log "To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/"
       log "Before doing this, make sure you are removing any sensitive data."

--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -346,15 +346,14 @@ function detect_ceph_files {
     log "This looks like a restart, processing."
     return 0
   fi
-  if [[ "$NETWORK_AUTO_DETECT" == "0" ]]; then
     if [ -d /var/lib/ceph ] || [ -d /etc/ceph ]; then
-      if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ -z "$(find /etc/ceph -prune -empty)" ]]; then
+      # For /etc/ceph, it always contains a 'rbdmap' file so we must check for length > 1
+      if [[ "$(find /var/lib/ceph/ -mindepth 3 -maxdepth 3 -type f | wc -l)" != 0 ]] || [[ "$(find /etc/ceph -mindepth 1 -type f| wc -l)" -gt "1" ]]; then
         log "I can see existing Ceph files, please remove them!"
         log "To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/"
         log "Before doing this, make sure you are removing any sensitive data."
         exit 1
       fi
-    fi
   fi
 }
 


### PR DESCRIPTION
/etc/ceph wasn't beeing checked properly so now we check the length of
the output to see if there are any Ceph files.

Signed-off-by: Sébastien Han <seb@redhat.com>