### PR TITLE
[skip ci] demo: jewel osd pool default size = 1

### DIFF
--- a/ceph-releases/jewel/daemon/config.static.sh
+++ b/ceph-releases/jewel/daemon/config.static.sh
@@ -29,6 +29,7 @@ osd journal size = 100
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_PUBLIC_NETWORK}
 log file = /dev/null
+osd pool default size = 1
 ENDHERE
 
       # For ext4


### PR DESCRIPTION
Otherwise ceph will never be happy.

Signed-off-by: Sébastien Han <seb@redhat.com>