### PR TITLE
[skip ci] contrib: fix arm64 img script

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -14,21 +14,21 @@ CEPH_RELEASES=(luminous)
 
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
-  make RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
+  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
   docker images
 }
 
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 push
+  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 push
 }
 
 function build_and_push_latest_bis {
-  # latest-bis is needed by ceph-ansible so it can test the restart handlers on an image ID change
-  # rebuild latest again to get a different image ID
-  make RELEASE="$RELEASE"-bis FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
-  docker tag ceph/daemon:"$BRANCH"-bis-"${CEPH_RELEASES[-1]}"-centos-7-arm64 ceph/daemon:latest-bis
-  docker push ceph/daemon:latest-bis
+  True
+}
+
+function push_ceph_imgs_latests {
+  True
 }
 
 
@@ -37,4 +37,6 @@ function build_and_push_latest_bis {
 ########
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/build-push-ceph-container-imgs.sh
+# shellcheck source=./
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR"/build-push-ceph-container-imgs.sh


### PR DESCRIPTION
Prior to this commit we were getting the wrong name for the image tags.
We had "luminous-centos-arm64-7-aarch64" which was wrong.

luminous-centos-7-aarch64 is what we need.

Ultimately we will get master-XXXX-luminous-centos-7-aarch64

Signed-off-by: Sébastien Han <seb@redhat.com>