### PR TITLE
[skip ci] contrib: fix arm64 build with the new syntax

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -14,13 +14,13 @@ CEPH_RELEASES=(luminous)
 
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
-  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 build
+  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASEOS_REPO=centos build
   docker images
 }
 
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASE_IMAGE=centos:7 push
+  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASEOS_REPO=centos push
 }
 
 function build_and_push_latest_bis {


### PR DESCRIPTION
ed708988c1ec18ff5cb1a8bb70fd76bc80e515bf changed the variable names and
decoupled them too so let's use the right variable.

Signed-off-by: Sébastien Han <seb@redhat.com>