### PR TITLE
[skip ci] contrib: override push_ceph_imgs_latests function

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,1 +1,0 @@
-tcmu-runner ceph-iscsi-config ceph-iscsi-cli

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -24,11 +24,11 @@ function push_ceph_imgs {
 }
 
 function build_and_push_latest_bis {
-  True
+  return
 }
 
 function push_ceph_imgs_latests {
-  True
+  return
 }
 
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -77,6 +77,7 @@ function build_and_push_latest_bis {
   docker push ceph/daemon:latest-bis
 }
 
+declare -F push_ceph_imgs_latests ||
 function push_ceph_imgs_latests {
   local latest_name
   for release in "${CEPH_RELEASES[@]}" latest; do


### PR DESCRIPTION
Let arm64 script override push_ceph_imgs_latests and also use return and
not 'True' which does not exist in bash as opposed to 'true'.

Signed-off-by: Sébastien Han <seb@redhat.com>