### PR TITLE
images: fix bug if iSCSI packages left blank

### DIFF
--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -40,4 +40,4 @@ RUN \
     echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB" && \
     #
     # Verify that the packages installed haven't been accidentally cleaned
-    __DOCKERFILE_VERIFY_PACKAGES__
+    __DOCKERFILE_VERIFY_PACKAGES__ && echo 'Packages verified successfully'

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -35,7 +35,7 @@ RUN \
     echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB" && \
     #
     # Verify that the packages installed haven't been accidentally cleaned
-    __DOCKERFILE_VERIFY_PACKAGES__
+    __DOCKERFILE_VERIFY_PACKAGES__ && echo 'Packages verified successfully'
 
 #======================================================
 # Add ceph-container files


### PR DESCRIPTION
This fixes a bug I missed in commit 11883989ec3124a2e88c74bf45d668a8b4d7229d

If iSCSI packages is left blank, the Dockerfile's verify packages step
may produce code that ends in a trailing `\` character, which will cause
the build to fail. Fix this by adding a final `&& echo ...` message.
`/bin/true` will work just as well, but the echo may be more useful for
debugging.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>