### PR TITLE
[skip ci] contrib: rework enable_experimental_docker_cli

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -39,12 +39,7 @@ function login_docker_hub {
 
 function enable_experimental_docker_cli {
   mkdir -p "$HOME/.docker"
-  cat <<EOF  > "$HOME/.docker/daemon.json"
-{
-  "debug" : true,
-  "experimental" : true
-}
-EOF
+  sed -i '$i,"experimental": "enabled"' .docker/config.json
 }
 
 function create_head_or_point_release {


### PR DESCRIPTION
before this commit we were activating the feature in the wrong file.
config.json is the right one.

Signed-off-by: Sébastien Han <seb@redhat.com>