### PR TITLE
[skip ci] contrib: loging to the registry before enabling the cli

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -126,8 +126,8 @@ function create_registry_manifest {
 
 install_docker
 cleanup_previous_run
-enable_experimental_docker_cli
 login_docker_hub
+enable_experimental_docker_cli
 create_head_or_point_release
 build_ceph_imgs
 push_ceph_imgs


### PR DESCRIPTION
We must log first so this creates the config.json file, then we enable
the experimental cli feature.

Signed-off-by: Sébastien Han <seb@redhat.com>