### PR TITLE
contrib: move enable_experimental_docker_cli before creating manifest

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -127,10 +127,10 @@ function create_registry_manifest {
 install_docker
 cleanup_previous_run
 login_docker_hub
-enable_experimental_docker_cli
 create_head_or_point_release
 build_ceph_imgs
 push_ceph_imgs
+enable_experimental_docker_cli
 create_registry_manifest
 # If we run on a tagged head, we should not push the 'latest' tag
 if $TAGGED_HEAD; then


### PR DESCRIPTION
It seems that the file gets somehow created after pull/push so we edit
it (config.json) after that.

Signed-off-by: Sébastien Han <seb@redhat.com>