### PR TITLE
images: build and push all images not just default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ push:  $(foreach p, $(FLAVORS), do.image.$(HOST_ARCH),$(p)) ;
 push.parallel:
 	@$(MAKE) $(PARALLEL) push
 
+push.all:
+  @$(MAKE) FLAVORS="$(ALL_BUILDABLE_FLAVORS)" push.parallel
+
 build.parallel:
 	@$(MAKE) $(PARALLEL) build
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -58,14 +58,14 @@ function create_head_or_point_release {
 declare -F build_ceph_imgs  ||
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
-  make RELEASE="$RELEASE" build.parallel
+  make RELEASE="$RELEASE" build.all
   docker images
 }
 
 declare -F push_ceph_imgs ||
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make RELEASE="$RELEASE" push.parallel
+  make RELEASE="$RELEASE" push.all
 }
 
 declare -F build_and_push_latest_bis ||


### PR DESCRIPTION
Any images not set in the `FLAVORS` default variable in the Makefile
will not be built and pushed upstream. This currently only includes
opensuse, but it may include more in the future.

Now use `make build.all` to build and push *all* images, not just the
default values for `FLAVORS`.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>