### PR TITLE
confd: Updating to 0.16.0

### DIFF
--- a/ceph-releases/ALL/centos-arm64/daemon/__WEB_INSTALL_CONFD__
+++ b/ceph-releases/ALL/centos-arm64/daemon/__WEB_INSTALL_CONFD__
@@ -1,1 +1,0 @@
-/bin/true

--- a/ceph-releases/ALL/daemon/__WEB_INSTALL_CONFD__
+++ b/ceph-releases/ALL/daemon/__WEB_INSTALL_CONFD__
@@ -1,5 +1,5 @@
 echo 'Web install confd' && \
-      CONFD_VERSION=0.15.0 && \
+      CONFD_VERSION=0.16.0 && \
       # Assume linux
       CONFD_ARCH=linux-__ENV_[GO_ARCH]__ && \
       wget -q -O /usr/local/bin/confd \


### PR DESCRIPTION
In 0.16.0, issue #641 have been closed so confd is now available for arm64 hosts.

This commit bumps the release to 0.16.0 for all and remove the empty
__WEB_INSTALL_CONFD__ of centos-arm64 to let it use the global one.

Signed-off-by: Erwan Velu <evelu@redhat.com>