### PR TITLE
Fix a broken link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Core Components
 ---------------
 
 - [`ceph/daemon-base`](src/daemon-base/): Base container image containing Ceph core components.
-- [`ceph/daemon`](daemon/): All-in-one container containing all Ceph daemons.
+- [`ceph/daemon`](src/daemon/): All-in-one container containing all Ceph daemons.
 
 See README files in subdirectories for instructions on using containers.
 


### PR DESCRIPTION
This PR just fix a broken link to the `ceph-daemon` source directory on README.md.