### PR TITLE
github: Added issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. Did you already search the existing open issues for anything similar? -->
+
+Is this a bug report or feature request?
+<!-- Remove only one -->
+* Bug Report
+* Feature Request
+
+**Bug Report**
+
+What happened:
+
+What you expected to happen:
+
+How to reproduce it (minimal and precise):
+<!-- Please let us know any circumstances for reproduction of your bug. -->
+
+**Feature Request**
+
+Are there any similar features already existing:
+
+What should the feature do:
+
+What would be solved through this feature:
+
+Does this have an impact on existing features:
+
+**Environment**:
+* OS (e.g. from /etc/os-release):
+* Kernel (e.g. `uname -a`):
+* Docker version (e.g. `docker version`):
+* Ceph version (e.g. `ceph -v`):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. Did you already search the existing open issues for anything similar? -->
+
+Is this a bug report or feature request?
+* Bug Report
+
+**Bug Report**
+
+What happened:
+
+What you expected to happen:
+
+How to reproduce it (minimal and precise):
+<!-- Please let us know any circumstances for reproduction of your bug. -->
+
+**Environment**:
+* OS (e.g. from /etc/os-release):
+* Kernel (e.g. `uname -a`):
+* Docker version (e.g. `docker version`):
+* Ceph version (e.g. `ceph -v`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea/feature for this project
+---
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. Did you already search the existing open issues for anything similar? -->
+
+Is this a bug report or feature request?
+* Feature Request
+
+**Feature Request**
+
+Are there any similar features already existing:
+
+What should the feature do:
+
+What would be solved through this feature:
+
+Does this have an impact on existing features:
+
+**Environment**:
+* OS (e.g. from /etc/os-release):
+* Kernel (e.g. `uname -a`):
+* Docker version (e.g. `docker version`):
+* Ceph version (e.g. `ceph -v`):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
+documentation before submitting a Pull Request!
+Thank you for contributing to ceph-container! -->
+
+Description of your changes:
+
+Which issue is resolved by this Pull Request:
+Resolves #
+
+Checklist:
+- [ ] Documentation has been updated, if necessary.
+- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.


### PR DESCRIPTION
Description of your changes:
This adds issue and pull request templates.
The following issue templates are available:
* Bug report
* Feature request

And a "default" one which contains both bug report and feature request in one.

Let me know what you think and/or if it should just be the PR template.

An example of how the issue type selection looks, can be found in this example repository: https://github.com/galexrt/github-issue-templates. Just go to the project, go to "Issues" and then "New issue".

Which issue is resolved by this Pull Request:
Resolves #939.

/cc @BlaineEXE

[skip ci]