### PR TITLE
[skip ci] contrib: stop building and pushing ubuntu on mimic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ FLAVORS ?= \
 	luminous,centos,7 \
 	jewel,centos,7 \
 	kraken,centos,7 \
-	mimic,ubuntu,16.04 \
 	mimic,centos,7 \
 
 TAG_REGISTRY ?= ceph


### PR DESCRIPTION
We don't always have packages for ubuntu and we can't hold a release
just because of that. So until we get a proper maintainer for the
ubuntu image we will stop building and pushing the image. However it's
up to anyone to build it locally.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
