### PR TITLE
[skip ci] build-push-ceph-container-imgs.sh: Building only FLAVORS

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -70,14 +70,14 @@ function create_head_or_point_release {
 declare -F build_ceph_imgs  ||
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
-  make RELEASE="$RELEASE" build.all
+  make RELEASE="$RELEASE" build.parallel
   docker images
 }
 
 declare -F push_ceph_imgs ||
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make RELEASE="$RELEASE" push.all
+  make RELEASE="$RELEASE" push.parallel
 }
 
 declare -F build_and_push_latest_bis ||


### PR DESCRIPTION
The actual code is using the .all target which rebuilds all possibles FLAVORS.
In this part of the project, we only want to build the supported flavors encoded in the FLAVORS variable.

This patch switch from the .all to the .parallel targets to avoid using ALL_BUILDABLE_FLAVORS.

Signed-off-by: Erwan Velu <evelu@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
