### PR TITLE
[skip ci] build and push mimic images for arm64

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -5,7 +5,7 @@ set -ex
 # VARIABLES #
 #############
 
-CEPH_RELEASES=(luminous)
+CEPH_RELEASES=(luminous mimic)
 
 
 #############
@@ -21,13 +21,17 @@ function install_docker {
 
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
-  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASEOS_REPO=centos build
+  for ceph_release in "${CEPH_RELEASES[@]}"; do
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,7" BASEOS_REPO=centos build
+  done
   docker images
 }
 
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
-  make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${CEPH_RELEASES[-1]},centos-arm64,7" BASEOS_REPO=centos push
+  for ceph_release in "${CEPH_RELEASES[@]}"; do
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,7" BASEOS_REPO=centos push
+  done
 }
 
 function build_and_push_latest_bis {


### PR DESCRIPTION
Add arm64 support to the images we build and push on the docker
registry.

Signed-off-by: Sébastien Han <seb@redhat.com>