### PR TITLE
[skip ci] contrib: build latest-bis-luminous

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -82,8 +82,16 @@ function push_ceph_imgs {
 
 declare -F build_and_push_latest_bis ||
 function build_and_push_latest_bis {
-  # latest-bis is needed by ceph-ansible so it can test the restart handlers on an image ID change
+  # latest-bis-$ceph_release is needed by ceph-ansible so it can test the restart handlers on an image ID change
   # rebuild latest again to get a different image ID
+  # shellcheck disable=SC2043
+  for ceph_release in luminous; do  # I know it's a loop with one element, I'm preparing the ground for the next release
+    make RELEASE="$BRANCH"-bis-"$ceph_release" FLAVORS="${ceph_release}",centos,7 build
+    docker tag ceph/daemon:"$BRANCH"-bis-"${ceph_release}"-centos-7-"${HOST_ARCH}" ceph/daemon:latest-bis-"$ceph_release"
+    docker push ceph/daemon:latest-bis-"$ceph_release"
+  done
+
+  # Now let's build the latest
   make RELEASE="$BRANCH"-bis FLAVORS="${CEPH_RELEASES[-1]}",centos,7 build
   docker tag ceph/daemon:"$BRANCH"-bis-"${CEPH_RELEASES[-1]}"-centos-7-"${HOST_ARCH}" ceph/daemon:latest-bis
   docker push ceph/daemon:latest-bis


### PR DESCRIPTION
For the ceph-ansible luminous container restart on image change test we
need to have an identical image to latest-luminous but with a different
ID.

Signed-off-by: Sébastien Han <seb@redhat.com>