### PR TITLE
[skip ci] contrib: fix latest release name

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -86,7 +86,7 @@ function build_and_push_latest_bis {
   # rebuild latest again to get a different image ID
   # shellcheck disable=SC2043
   for ceph_release in luminous; do  # I know it's a loop with one element, I'm preparing the ground for the next release
-    make RELEASE="$BRANCH"-bis-"$ceph_release" FLAVORS="${ceph_release}",centos,7 build
+    make RELEASE="$BRANCH"-bis FLAVORS="${ceph_release}",centos,7 build
     docker tag ceph/daemon:"$BRANCH"-bis-"${ceph_release}"-centos-7-"${HOST_ARCH}" ceph/daemon:latest-bis-"$ceph_release"
     docker push ceph/daemon:latest-bis-"$ceph_release"
   done


### PR DESCRIPTION
Problem: using "make RELEASE=master-bis-luminous
FLAVORS=luminous,centos,7 build" gives the following tag:
daemon:master-bis-luminous-luminous because FLAVORS uses the release
field to produce the tag.

Solution: there is no nede to pass the release in RELEASE so we can get
daemon:master-bis-luminous only.

Signed-off-by: Sébastien Han <seb@redhat.com>