### PR TITLE
[skip ci] contrib: wait for arm images to build the manifest

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -46,6 +46,10 @@ function create_registry_manifest {
   return
 }
 
+function wait_for_arm_images {
+  return
+}
+
 
 ########
 # MAIN #

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -119,6 +119,17 @@ function push_ceph_imgs_latests {
   done
 }
 
+declare -F wait_for_arm_images ||
+function wait_for_arm_images {
+  echo "Waiting for ARM64 images to be ready"
+  set -e
+  until docker pull ceph/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64; do
+    echo -n .
+    sleep 1
+  done
+  set +e
+}
+
 declare -F create_registry_manifest ||
 function create_registry_manifest {
   enable_experimental_docker_cli
@@ -143,6 +154,7 @@ login_docker_hub
 create_head_or_point_release
 build_ceph_imgs
 push_ceph_imgs
+wait_for_arm_images
 create_registry_manifest
 # If we run on a tagged head, we should not push the 'latest' tag
 if $TAGGED_HEAD; then


### PR DESCRIPTION
Before running the manifest command we must make sure that both jobs
(arm64 and amd64) are done. Currently it appears that the arm64 job take
more time to run than the amd64 one. And since the manifest command runs
on amd64 it fails. So now we wait for arm64 to be ready before running
the manifest command.

Signed-off-by: Sébastien Han <seb@redhat.com>