### PR TITLE
tests: clean workspace after a build

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -72,6 +72,7 @@ if [[ "${#FLAVOR_ARRAY[@]}" -eq "0" ]]; then
   echo "The ceph-container code has not changed."
   echo "Nothing to test here."
   echo "SUCCESS"
+  sudo make clean.all
   exit 0
 fi
 
@@ -127,4 +128,5 @@ testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE
 
 # teardown
 #################################################################################
+sudo make clean.all
 bash "$TOXINIDIR"/tests/teardown.sh


### PR DESCRIPTION
In our CI, job can fail because workspace isn't cleaned properly with
following typical error:

```
java.nio.file.FileSystemException:
/home/jenkins-build/build/workspace/ceph-container-nightly-ceph_ansible-jewel-centos7-cluster/staging/luminous-opensuse-42.3-x86_64/daemon/__PACKAGES__:
Operation not permitted
```

staging step is processed as `root` and files are left as it, so we
should use the `clean.all` target from the Makefile to clean everything
after a build is done, regardless the status of the build
(success/failed).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>