### PR TITLE
Revert "DAEMON_PACKAGES: Adding rook package"

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
 yum update -y && \
 yum install -y wget unzip util-linux python-setuptools udev device-mapper && \
-yum install -y __CEPH_BASE_PACKAGES__ __ROOK_PACKAGES__
+yum install -y __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_VERIFY_PACKAGES__
@@ -1,1 +1,1 @@
-rpm -q __CEPH_BASE_PACKAGES__ __ROOK_PACKAGES__
+rpm -q __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/rhel7/daemon-base/__ROOK_PACKAGES__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__ROOK_PACKAGES__
@@ -1,1 +1,0 @@
-rook rook-rookflex


### PR DESCRIPTION
This reverts commit 4765d7fdbec44ab9acc14fce614398dd737b1334.

The `rook` RPM Requires `ceph-mon`, `ceph-osd`, and `ceph-mgr`, which causes Pungi to pull these packages into the RHCS Tools repository.

Revert the rook addition to the RHCS container so we can remove Rook for RHCS 3.1. When the rook packaging is fixed in https://bugzilla.redhat.com/show_bug.cgi?id=1598522 we can add it back in.