### PR TITLE
zap_device: ability to zap partitions only

### DIFF
--- a/src/daemon/zap_device.sh
+++ b/src/daemon/zap_device.sh
@@ -105,8 +105,10 @@ function zap_device {
   fi
 
   for device in $(comma_to_space "${OSD_DEVICE}"); do
-    # Check if ${device} is well a block device
-    [[ -b "${device}" ]] || log "Provided device ${device} does not exist or is not a valid block device."
+    if [ ! -b "${device}" ]; then
+      log "Provided device ${device} is not a block special file."
+      exit 1
+    fi
 
     pkname=$(lsblk --nodeps -no PKNAME "${device}")
     if [ -z "$pkname" ]; then


### PR DESCRIPTION
Although the previous implementation was harmless, it failed to only
remove a single partition from a device. Now you can pass -e
OSD_DEVICE=/dev/sda1, as well as an nvme partition such as
/dev/nvme0n1p2.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1572933
Signed-off-by: Sébastien Han <seb@redhat.com>