### PR TITLE
[skip ci] rgw: allow override RGW_FRONTENDS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ before_install:
 
 install:
   - sudo ./travis-builds/prepare_osd_fs.sh
-  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e CLUSTER=test -e NETWORK_AUTO_DETECT=4 -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_VERSION=v0.1 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:HEAD-mimic-centos-7-x86_64 demo
+  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e RGW_FRONTEND_TYPE=beast -e RGW_CIVETWEB_OPTIONS="num_threads=100" -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e CLUSTER=test -e NETWORK_AUTO_DETECT=4 -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_VERSION=v0.1 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:HEAD-mimic-centos-7-x86_64 demo
   - sleep 5  # let's give the container 5sec to create its Ceph config file
 
 script:
   - sudo ./travis-builds/validate_demo_cluster.sh
+  - docker exec ceph-demo ps fauwwwx
+  - docker exec ceph-demo ss -ntlp
 
 
 after_failure:

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -155,7 +155,7 @@ ENDHERE
   fi
 
   # start RGW
-  radosgw "${DAEMON_OPTS[@]}" -n client.rgw."$(uname -n)" -k "$RGW_KEYRING" --rgw-socket-path="" --rgw-frontends="civetweb port=${RGW_CIVETWEB_PORT}"
+  radosgw "${DAEMON_OPTS[@]}" -n client.rgw."$(uname -n)" -k "$RGW_KEYRING" --rgw-socket-path="" --rgw-frontends="$RGW_FRONTEND"
 }
 
 function bootstrap_demo_user {

--- a/src/daemon/start_rgw.sh
+++ b/src/daemon/start_rgw.sh
@@ -28,12 +28,11 @@ function start_rgw {
 
   log "SUCCESS"
 
-  local rgw_frontends="civetweb port=$RGW_CIVETWEB_IP:$RGW_CIVETWEB_PORT"
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
-    rgw_frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
+    RGW_FRONTEND="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
   fi
 
-  exec /usr/bin/radosgw "${DAEMON_OPTS[@]}" -n client.rgw."${RGW_NAME}" -k "$RGW_KEYRING" --rgw-socket-path="" --rgw-zonegroup="$RGW_ZONEGROUP" --rgw-zone="$RGW_ZONE" --rgw-frontends="$rgw_frontends"
+  exec /usr/bin/radosgw "${DAEMON_OPTS[@]}" -n client.rgw."${RGW_NAME}" -k "$RGW_KEYRING" --rgw-socket-path="" --rgw-zonegroup="$RGW_ZONEGROUP" --rgw-zone="$RGW_ZONE" --rgw-frontends="$RGW_FRONTEND"
 }
 
 function create_rgw_user {

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -46,11 +46,6 @@ HOSTNAME=$(uname -n | cut -d'.' -f1)
 : "${CEPHFS_METADATA_POOL_PG:=8}"
 : "${RGW_ZONEGROUP:=}"
 : "${RGW_ZONE:=}"
-: "${RGW_CIVETWEB_IP:=0.0.0.0}"
-: "${RGW_CIVETWEB_PORT:=8080}"
-: "${RGW_REMOTE_CGI:=0}"
-: "${RGW_REMOTE_CGI_PORT:=9000}"
-: "${RGW_REMOTE_CGI_HOST:=0.0.0.0}"
 : "${RGW_USER:="cephnfs"}"
 : "${RESTAPI_IP:=0.0.0.0}"
 : "${RESTAPI_PORT:=5000}"
@@ -63,6 +58,38 @@ HOSTNAME=$(uname -n | cut -d'.' -f1)
 : "${GANESHA_OPTIONS:=""}"
 : "${GANESHA_EPOCH:=""}" # For restarting
 : "${MGR_IP:=0.0.0.0}"
+
+# rgw options
+: "${RGW_CIVETWEB_IP:=0.0.0.0}"
+: "${RGW_CIVETWEB_PORT:=8080}"
+: "${RGW_REMOTE_CGI:=0}"
+: "${RGW_REMOTE_CGI_PORT:=9000}"
+: "${RGW_REMOTE_CGI_HOST:=0.0.0.0}"
+: "${RGW_FRONTEND_IP:=$RGW_CIVETWEB_IP}"
+: "${RGW_FRONTEND_PORT:=$RGW_CIVETWEB_PORT}"
+: "${RGW_FRONTEND_TYPE:="civetweb"}"
+
+RGW_CIVETWEB_OPTIONS="$RGW_CIVETWEB_OPTIONS port=$RGW_CIVETWEB_IP:$RGW_CIVETWEB_PORT"
+RGW_BEAST_OPTIONS="$RGW_BEAST_OPTIONS endpoint=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
+
+if [[ "$RGW_FRONTEND_TYPE" == "civetweb" ]]; then
+  RGW_FRONTED_OPTIONS="$RGW_CIVETWEB_OPTIONS"
+elif [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
+  RGW_FRONTED_OPTIONS="$RGW_BEAST_OPTIONS"
+else
+  log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE"
+  exit 1
+fi
+
+: "${RGW_FRONTEND:="$RGW_FRONTEND_TYPE $RGW_FRONTED_OPTIONS"}"
+
+if [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
+  if [[ "$CEPH_VERSION" == "jewel" || "$CEPH_VERSION" == "kraken" || "$CEPH_VERSION" == "luminous" ]]; then
+    RGW_FRONTEND_TYPE=beast
+    log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE for your Ceph release $CEPH_VERSION, use at least the Mimic version."
+    exit 1
+  fi
+fi
 
 # Make sure to change the value of one another if user changes some of the default values
 while read -r line; do


### PR DESCRIPTION
We can now pass -e RGW_FRONTENDS and enable more options.

Signed-off-by: Sébastien Han <seb@redhat.com>