### PR TITLE
tests: update ceph-ansible requirements.txt picked up

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -46,10 +46,10 @@ fi
 rm -rf "$WORKSPACE"/ceph-ansible || true
 git clone -b "$CEPH_ANSIBLE_BRANCH" --single-branch https://github.com/ceph/ceph-ansible.git ceph-ansible
 
-if [[ "$CEPH_ANSIBLE_BRANCH" == 'stable-2.2' ]] || [[ "$CEPH_ANSIBLE_BRANCH" == 'stable-3.0' ]]; then
-  REQUIREMENTS=requirements2.2.txt
-else
+if [[ "$CEPH_ANSIBLE_BRANCH" != 'master' ]]; then
   REQUIREMENTS=requirements2.4.txt
+else
+  REQUIREMENTS=requirements.txt
 fi
 
 pip install -r "$TOXINIDIR"/ceph-ansible/tests/"$REQUIREMENTS"


### PR DESCRIPTION
Update the ceph-ansible requirements.txt picked up in ceph-container
tests accordingly with the ceph-ansible branch being tested.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit c748e107bcbdf6c76398c7238778763667607799)