### PR TITLE
tests: update python requirements

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -46,13 +46,7 @@ fi
 rm -rf "$WORKSPACE"/ceph-ansible || true
 git clone -b "$CEPH_ANSIBLE_BRANCH" --single-branch https://github.com/ceph/ceph-ansible.git ceph-ansible
 
-if [[ "$CEPH_ANSIBLE_BRANCH" != 'master' ]]; then
-  REQUIREMENTS=requirements2.4.txt
-else
-  REQUIREMENTS=requirements.txt
-fi
-
-pip install -r "$TOXINIDIR"/ceph-ansible/tests/"$REQUIREMENTS"
+pip install -r "$TOXINIDIR"/ceph-ansible/tests/requirements.txt
 
 bash "$WORKSPACE"/travis-builds/purge_cluster.sh
 # XXX purge_cluster only stops containers, it doesn't really remove them so try to


### PR DESCRIPTION
in ceph-ansible requirements.txt is now managed in each respective
branch so it's now the same filename in all branches.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit b7dc7824b92d76f9e53a5b169467cb0a46b322a5)
