### PR TITLE
[skip ci] contrib: allow pattern matching for rc tags

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -46,7 +46,7 @@ function enable_experimental_docker_cli {
 }
 
 function grep_sort_tags {
-  "$@" | grep -oE 'v[3-9].[0-9]*.[0-9]' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
+  "$@" | grep -oE 'v[3-9].[0-9]*.[0-9]|v[3-9].[0-9]*.[0-9][rc]{2}?[0-9]{1,2}?' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
 }
 
 function download_cn {


### PR DESCRIPTION
We recently introduced v3.0.1rc1 which was not covered by the regex that
searches tags, now it's taken into account.

Signed-off-by: Sébastien Han <seb@redhat.com>