### PR TITLE
[skip ci] rhel7: make Dockerfile linting happy

### DIFF
--- a/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
@@ -1,1 +1,0 @@
-Erwan Velu <evelu@redhat.com>

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -18,3 +18,5 @@ LABEL description="Red Hat Ceph Storage 3"
 LABEL summary="Provides the latest Red Hat Ceph Storage 3 on RHEL 7 in a fully featured and supported base image."
 LABEL io.k8s.display-name="Red Hat Ceph Storage 3 on RHEL 7"
 LABEL io.openshift.tags="rhceph ceph"
+LABEL io.openshift.expose-services
+LABEL maintainer="Erwan Velu <evelu@redhat.com>"


### PR DESCRIPTION
Resolved the following checks:

FAIL:Label 'io.openshift.expose-services' has to be specified.
FAIL:Label 'maintainer' has to be specified.
FAIL:Dockerfile instruction `MAINTAINER` is deprecated.

Signed-off-by: Sébastien Han <seb@redhat.com>