### PR TITLE
makefile: Build and push openSUSE images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ FLAVORS ?= \
 	jewel,ubuntu,16.04 \
 	jewel,ubuntu,14.04 \
 	kraken,ubuntu,16.04 \
+	luminous,opensuse,42.3 \
 	luminous,centos,7 \
 	jewel,centos,7 \
 	kraken,centos,7 \


### PR DESCRIPTION
PR #1083 stopped building openSUSE images. Re-enable builds of openSUSE
containers.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
