### PR TITLE
rhel7: remove wrong label format

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -18,5 +18,4 @@ LABEL description="Red Hat Ceph Storage 3"
 LABEL summary="Provides the latest Red Hat Ceph Storage 3 on RHEL 7 in a fully featured and supported base image."
 LABEL io.k8s.display-name="Red Hat Ceph Storage 3 on RHEL 7"
 LABEL io.openshift.tags="rhceph ceph"
-LABEL io.openshift.expose-services
 LABEL maintainer="Erwan Velu <evelu@redhat.com>"


### PR DESCRIPTION
The following label added in daae090424157c41a2567acd4c0764c54703a41f :
`LABEL io.openshift.expose-services` is an incorrect syntax.
By the way, this LABEL is not needed and should be removed according to
https://github.com/user-cont/colin/issues/165

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1610454

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 33a04bfcf5a3066d77a5f3789a79ce715c90c854)