### PR TITLE
[skip ci] Add Mimic to list of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Since everyone doesn't use Docker Hub API and Docker Hub WebUI doesn't paginate.
 Here is a list of available stable Ceph images
 
 ```
+ceph/daemon:v3.1.0rc1-stable-3.1-mimic-centos-7-x86_64
+ceph/daemon:v3.0.7-stable-3.0-mimic-centos-7-x86_64
 ceph/daemon:v3.0.5-stable-3.0-luminous-centos-7
 ceph/daemon:v3.0.5-stable-3.0-jewel-centos-7-x86_64
 ceph/daemon:v3.0.5-stable-3.0-kraken-centos-7-x86_64


### PR DESCRIPTION
Does mimic only supports Centos 7? No ubuntu?

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Add mimic centos 7

Which issue is resolved by this Pull Request:
Resolves #1165
