### PR TITLE
tests: set owner of staging dir to jenkins user

### DIFF
--- a/tests/teardown.sh
+++ b/tests/teardown.sh
@@ -4,4 +4,6 @@
 . "$WORKSPACE/.tox_vars"
 cd "$CEPH_ANSIBLE_SCENARIO_PATH" || exit 1
 vagrant destroy --force
+# see https://github.com/ceph/ceph-container/issues/1048
+sudo chown -R "$(whoami)" ./staging || true
 cd "$WORKSPACE" || exit


### PR DESCRIPTION
Description of your changes: Sets owner of `$CEPH_ANSIBLE_SCENARIO_PATH/staging` to jenkins user so the slaves can wipe the workspace before each job.

Which issue is resolved by this Pull Request:
Resolves #1048 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.