### PR TITLE
[skip ci] contrib: fix stable release build

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -78,7 +78,10 @@ function compare_docker_hub_and_github_tags {
   # we now look into each array and find a possible missing tag
   # the idea is to find if a tag present on github is not present on docker hub
   for i in "${tags_github_array[@]}"; do
-    echo "${tags_docker_hub_array[@]}" | grep -q "$i" || tag_to_build+=("$i")
+    # the grep has a conditionnal on either the explicit match last character is the end of the line OR
+    # it has a space after it so we cover the case where the tag that matches is placed at the end
+    # of the line or the first one
+    echo "${tags_docker_hub_array[@]}" | grep -qoE "${i}$|${i} " || tag_to_build+=("$i")
   done
 
   # if there is an entry we activate TAGGED_HEAD which tells the script to build a release image


### PR DESCRIPTION
This fixes the situation where we have a tag v3.0.1 but v3.0.1rc1 exists
too. The old version of the grep will match both to true so it won't
find any new addition. The regex wasn't precise enough. Now we either
check the exact match is the last or in-between the list.

Signed-off-by: Sébastien Han <seb@redhat.com>