### PR TITLE
docker_exec: Reworking SIGTERM handler

### DIFF
--- a/src/daemon/__DAEMON_PACKAGES__
+++ b/src/daemon/__DAEMON_PACKAGES__
@@ -1,5 +1,6 @@
 \
           sharutils \
+          lsof \
           __CONFD_PACKAGE__ \
           __FOREGO_PACKAGE__ \
           __KUBECTL_PACKAGE__ \

--- a/src/daemon/docker_exec.sh
+++ b/src/daemon/docker_exec.sh
@@ -32,33 +32,122 @@ function trap_error {
 }
 
 child_for_exec=1
-function _term {
-  echo "Sending SIGTERM to PID $child_for_exec"
+
+function teardown {
+  # Disabling the traps to avoid a cascading
+  trap - SIGINT SIGILL SIGABRT SIGFPE SIGSEGV SIGTERM SIGBUS SIGCHLD SIGKILL
+
+  # This function is called when we got a signal reporting something died
+  # It will check the child_for_exec process exited
+  # Then it will execute the optional sigterm_cleanup_post and return the passed exit code
+  local signal_name=$1
+  local exit_code=$2
+  echo "teardown: managing teardown after $signal_name"
 
   # Disabling the ERR trap before killing the process
   # That's an expected failure so don't handle it
   # Doing "trap ERR" or "trap - ERR" didn't worked :/
   NOTRAP="yes"
-  declare -F sigterm_cleanup_pre && sigterm_cleanup_pre
-  kill -TERM "$child_for_exec" 2>/dev/null
-  declare -F sigterm_cleanup_post && sigterm_cleanup_post
+
+  # If we receive SIGTERM, it means the process is supposed to still be alive
+  # So let's call sigterm_cleanup_pre if any defined
+  if [ "$signal_name" = "SIGTERM" ]; then
+    declare -F sigterm_cleanup_pre && sigterm_cleanup_pre
+  fi
+
+  # Sending the TERM signal to the exec'd program
+  # If we got a SIGTERM, that is propagating the signal,
+  # If we got any other signal, we need to teardown as the stability is no more guaranteed
+  [ -e /proc/$child_for_exec ] && (echo "teardown: Sending SIGTERM to PID $child_for_exec"; kill -TERM "$child_for_exec" 2>/dev/null)
+
+  echo -n "teardown: Waiting PID $child_for_exec to terminate "
+  local MAX_TIMEOUT=50
+  local timeout=0
+  while [ -e /proc/$child_for_exec ]; do
+    echo -n "."
+    sleep .1
+    timeout=$(($timeout + 1))
+    if [ $timeout -eq $MAX_TIMEOUT ]; then
+      echo "<!>"
+      echo "teardown: TIMEOUT ! Let's consider it died and continue. Container will be reported in error."
+      exit_code=-1
+      break;
+    fi
+  done
+  echo
+  echo "teardown: Process $child_for_exec is terminated"
+
+  if [ "$signal_name" = "SIGTERM" ]; then
+    # Execute the cleanup post-script if any is declared
+    declare -F sigterm_cleanup_post && sigterm_cleanup_post
+  else
+    # Execute some user defined code if the exec'd process fails
+    declare -F trap_exec_failure && trap_exec_failure
+  fi
+
+  echo "teardown: Bye Bye, container will die with return code $exit_code"
+  exit $exit_code
+}
+
+function _int {
+  teardown "SIGINT" -1
+}
+
+function _ill {
+  teardown "SIGILL" -1
+}
+
+function _abrt {
+  teardown "SIGABRT" -1
+}
+
+function _fpe {
+  teardown "SIGFPE" -1
+}
+
+function _segv {
+  teardown "SIGSEGV" -1
+}
+
+function _term {
+  teardown "SIGTERM" 0
+}
+
+function _bus {
+  teardown "SIGBUS" -1
+}
+
+function _chld {
+  teardown "SIGCHLD" -1
+}
+
+function _kill {
+  teardown "SIGKILL" -1
 }
 
 function exec {
   # This function overrides the built-in exec() call
   # It starts the process in background to catch ERR but
   # as per docker requirement, forward the SIGTERM to it.
+  trap _int SIGINT
+  trap _ill SIGILL
+  trap _abrt SIGABRT
+  trap _fpe SIGFPE
+  trap _segv SIGSEGV
   trap _term SIGTERM
+  trap _bus SIGBUS
+  trap _chld SIGCHLD
+  trap _kill SIGKILL
 
+  # Running the program in background and save the pid in child_for_exec
   "$@" &
   child_for_exec=$!
+
   echo "exec: PID $child_for_exec: spawning $*"
-  wait "$child_for_exec"
-  return_code=$?
-  echo "exec: PID $child_for_exec: exit $return_code"
-  # If needed, it's possible to execute some user defined code if the exec'd process fails
-  if [ "$return_code" -ne 0 ]; then
-    declare -F trap_exec_failure && trap_exec_failure
-  fi
-  exit $return_code
+  echo "exec: Waiting $child_for_exec to quit"
+  wait $child_for_exec
+
+  # We should not reach that point as a SIGCHLD should be emitted
+  # Just keep a protection "in-case-of"
+  teardown "QUIT" -1
 }

--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+
+# We need the -m to track child process in docker_exec.sh
+# It is expected to receive some SIGCHLD, so -m is mandatory
+set -me
 export LC_ALL=C
 
 source variables_entrypoint.sh

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -79,8 +79,8 @@ function osd_activate {
     local ceph_mnt
     ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | tail -n +2)
     for mnt in $ceph_mnt; do
-      log "Unmounting $mnt"
-      umount "$mnt" || log "Failed to umount $mnt"
+      log "osd_disk_activate: Unmounting $mnt"
+      umount "$mnt" || (log "osd_disk_activate: Failed to umount $mnt"; lsof $mnt)
     done
   }
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -77,7 +77,7 @@ function osd_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | tail -n +2)
+    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | grep '^/')
     for mnt in $ceph_mnt; do
       log "osd_disk_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_disk_activate: Failed to umount $mnt"; lsof $mnt)

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -29,8 +29,8 @@ function osd_volume_activate {
     local ceph_mnt
     ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | tail -n +2)
     for mnt in $ceph_mnt; do
-      log "Unmounting $mnt"
-      umount "$mnt" || log "Failed to umount $mnt"
+      log "osd_volume_activate: Unmounting $mnt"
+      umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof $mnt)
     done
   }
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}"

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -27,7 +27,7 @@ function osd_volume_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | tail -n +2)
+    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | grep '^/')
     for mnt in $ceph_mnt; do
       log "osd_volume_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof $mnt)


### PR DESCRIPTION
    The actual SIGTERM handler was racy as it didn't waited the targeted PID to actually die before running the post script.
    
    Adding a wait() just after the kill was an initial though but failed as we are in a sig context and another wait is already pending in the exec().
    
    This part of the program have to handle two cases :
    - managing a fault of the exec'd program (return < 0 or SEGFAULT)
    - managing the graceful shutdown triggered by the SIGTERM sent by docker
    
    Both cases are considering watching the state of the exec'd program.
    Having two wait() calls (one in _term(), one in exec()) isn't possible.
    
    The actual implementation is considering the following :
    - we just track the presence of the exec'd process by watching if the PID is running. The return code have no interest here.
    - if we got a SIGTERM then we execute the pre & post scripts
    - if we got any other signals like SIGCHLD, SIGINT, SIGBUS, ... then we make a best effort teardown as we cannot guarantee the behavior of the container
    
    This patch make a single function (teardown()) to handle the process of shutting down the container.
    SIGTERM (a docker stop) or a SIGCHLD (a process died) will lead to almost the same code path with a lot of tracing to get the reason why the container is dying.
    
    Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1624341
