### PR TITLE
demo: respect ${RGW_NAME} more

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -169,7 +169,7 @@ function bootstrap_rgw {
   if [ ! -e "$RGW_PATH"/keyring ]; then
     # bootstrap RGW
     mkdir -p "$RGW_PATH" /var/log/ceph
-    ceph "${CLI_OPTS[@]}" auth get-or-create client.rgw."$(uname -n)" osd 'allow rwx' mon 'allow rw' -o "$RGW_KEYRING"
+    ceph "${CLI_OPTS[@]}" auth get-or-create client.rgw."${RGW_NAME}" osd 'allow rwx' mon 'allow rw' -o "$RGW_KEYRING"
     chown --verbose -R ceph. "$RGW_PATH"
 
     #configure rgw dns name
@@ -189,7 +189,7 @@ ENDHERE
   fi
 
   # start RGW
-  radosgw "${DAEMON_OPTS[@]}" -n client.rgw."$(uname -n)" -k "$RGW_KEYRING"
+  radosgw "${DAEMON_OPTS[@]}" -n client.rgw."${RGW_NAME}" -k "$RGW_KEYRING"
 }
 
 function bootstrap_demo_user {


### PR DESCRIPTION
The RGW_NAME variable is intended to be use instead of the
hostname when applicable.

Fixes: d1e2d07b8b8c ("demo: oversimply the setup")
Signed-off-by: Zac Medico <zmedico@gmail.com>

@leseb