### PR TITLE
Create /ceph-config/ceph/client_host automatically

### DIFF
--- a/src/daemon/populate_kv.sh
+++ b/src/daemon/populate_kv.sh
@@ -8,6 +8,7 @@ function kv {
   read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
+  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}client_host" || log "client_host already exists"
 }
 
 function populate_kv {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

If anybody executes properly the `populate_kvstore` script before booting the cluster, it is expected that it works.

Currently, however, monitor daemons fail with:

    ERROR 100: Key not found (/ceph-config/ceph/client_host)


Which issue is resolved by this Pull Request:
Resolves #901

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
