### PR TITLE
[skip ci] contrib: fix build ceph base

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -20,6 +20,7 @@ trap 'exit $?' ERR
 
 flavors_to_build="$(get_flavors_to_build "${ARCH}")"
 
+install_docker
 do_clean
 
 echo ''

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -536,3 +536,10 @@ function intersect_lists () {
   # Use sorted_a and _b as inputs to comm, which effectively returns the intersection of the lists
   comm -12 <(echo "${sorted_a}") <(echo "${sorted_b}")
 }
+
+function install_docker {
+  sudo apt-get install -y --force-yes docker.io
+  sudo systemctl start docker
+  sudo systemctl status docker
+  sudo chgrp "$(whoami)" /var/run/docker.sock
+}

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -11,7 +11,7 @@ AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'
 # ARCH='aarch64'
-ARCH=${ARCH}  # This is here to prevent shellcheck errors about ARCH not being defined
+: "${ARCH:?must be declared with either x86_64 or aarch64!}"
 
 # Use the ceph library by default
 PUSH_LIBRARY="ceph"


### PR DESCRIPTION
Add a meaningful error message if ARCH is not provided when executing
the script.

Signed-off-by: Sébastien Han <seb@redhat.com>