### PR TITLE
[skip ci] fix path to client_host

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -20,6 +20,7 @@ trap 'exit $?' ERR
 
 flavors_to_build="$(get_flavors_to_build "${ARCH}")"
 
+install_docker
 do_clean
 
 echo ''

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -536,3 +536,10 @@ function intersect_lists () {
   # Use sorted_a and _b as inputs to comm, which effectively returns the intersection of the lists
   comm -12 <(echo "${sorted_a}") <(echo "${sorted_b}")
 }
+
+function install_docker {
+  sudo apt-get install -y --force-yes docker.io
+  sudo systemctl start docker
+  sudo systemctl status docker
+  sudo chgrp "$(whoami)" /var/run/docker.sock
+}


### PR DESCRIPTION
2018-10-06T20:15:00.750473+00:00 sake docker-sake-mon[19160]: 2018-10-06T20:15:00Z sake /tmp/tmp.SMDhrLGl1u/confd[716]: ERROR 100: Key not found (/ceph-config/ceph/client_host) [50]
2018-10-06T20:15:00.750679+00:00 sake docker-sake-mon[19160]: 2018-10-06T20:15:00Z sake /tmp/tmp.SMDhrLGl1u/confd[716]: FATAL 100: Key not found (/ceph-config/ceph/client_host) [50]

Also see #901 and #1197