### PR TITLE
Make fix 1191 parallel build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,18 @@ stage.%:
 
 # Target for daemon-base image; delegate build/clean/push goals to target makefile
 daemon-base.%:
-	@$(call set_env_vars,$*); $(MAKE) -C $$STAGING_DIR/daemon-base \
-	  $(call set_env_vars,$*) $(MAKECMDGOALS)
+	$(call set_env_vars,$*); $(MAKE) -C $$STAGING_DIR/daemon-base \
+	  $(call set_env_vars,$*) $(filter-out daemon-base.$*,$(MAKECMDGOALS))
 
 # Target for daemon image; delegate build/clean/push goals to target makefile
 daemon.%:
 	@$(call set_env_vars,$*); $(MAKE) $(call set_env_vars,$*) -C $$STAGING_DIR/daemon \
-	  $(call set_env_vars,$*) $(MAKECMDGOALS)
+	  $(call set_env_vars,$*) $(filter-out daemon.$*,$(MAKECMDGOALS))
 
 # Make daemon-base.% and/or daemon.% target based on IMAGES_TO_BUILD setting
-do.image.%: | stage.% $(foreach i, $(IMAGES_TO_BUILD), $(i).% ) ;
+#do.image.%: | stage.% $(foreach i, $(IMAGES_TO_BUILD), $(i).% ) ;
+do.image.%: stage.%
+	@set -eux ; for image in $(IMAGES_TO_BUILD); do $(MAKE) $${image}.$* build ; done
 
 stage: $(foreach p, $(FLAVORS), stage.$(HOST_ARCH),$(p)) ;
 build: $(foreach p, $(FLAVORS), do.image.$(HOST_ARCH),$(p)) ;

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -1,5 +1,6 @@
 # Container images built for each flavor
-IMAGES_TO_BUILD := daemon-base daemon
+# Can be overridden, but don't change the ordering, because the images are built atop each other
+IMAGES_TO_BUILD ?= daemon-base daemon
 
 HOST_ARCH ?= $(shell uname --machine)
 


### PR DESCRIPTION
Description of your changes:

Which issue is resolved by this Pull Request:
Resolves # 1191

Previous misunderstanding of make's order-only prerequisites. Now
enforce order by explicitly calling make rather than using target
dependencies.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
