### PR TITLE
contrib/ceph-build-config.sh: Don't install packages in DRY_RUN mode

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -538,6 +538,10 @@ function intersect_lists () {
 }
 
 function install_docker {
+  # When we DRY_RUN there is no need to install packages
+  if [ -n "${DRY_RUN:-}" ]; then
+    return
+  fi
   sudo apt-get install -y --force-yes docker.io
   sudo systemctl start docker
   sudo systemctl status docker


### PR DESCRIPTION
When we run in DRY_RUN, no command is executed on the local machine.
DRY_RUN is usually useful to understand what would have been build.
So this patch is avoiding install the docker packages when DRY_RUN is engaged.

Signed-off-by: Erwan Velu <erwan@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
