### PR TITLE
contrib/build-ceph-base.sh: Removing TAG_REGISTRY

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -75,7 +75,7 @@ for flavor in $flavors_to_build; do
     make_cmd="make --directory="${SCRIPT_DIR}/.." \
         FLAVORS="${ceph_codename}-${version_without_build},${ceph_container_distro_dir},${distro_release}" \
         IMAGES_TO_BUILD=daemon-base \
-        TAG_REGISTRY="${PUSH_LIBRARY}" \
+        TAG_REGISTRY="" \
         DAEMON_BASE_TAG="${full_build_tag}" \
         BASEOS_REGISTRY="${baseos_registry_setting}" \
         BASEOS_REPO="${baseos_repo_setting}" \


### PR DESCRIPTION
The actual build procedure have a mismatch between the name of the local
image and the one trying to be pushed.

The log shows the following :
  info 'Building a new image ceph/ceph-amd64:v11.0.1-20181010'
  make_cmd='make --directory=/home/jenkins-build/build/workspace/ceph-container-build-ceph-base-push-imgs/ceph-container/contrib/..         FLAVORS=kraken-11.0.1,centos,7         IMAGES_TO_BUILD=daemon-base         TAG_REGISTRY=ceph         DAEMON_BASE_TAG=ceph/ceph-amd64:v11.0.1-20181010         BASEOS_REGISTRY=amd64         BASEOS_REPO=centos         BASEOS_TAG=7       build'
  [...]
  docker push ceph/ceph-amd64:v11.0.1-20181010
  The push refers to a repository [docker.io/ceph/ceph-amd64]
  An image does not exist locally with the tag: ceph/ceph-amd64

But the actual docker images is :
  ceph/ceph/ceph-amd64   v11.0.1-20181010    52dfbb138d85        27 seconds ago      485 MB

There is an extra "ceph/" which prevent the image being pushed.

This commit is about unsetting the TAG_REGISTRY variable so the extra ceph/ is removed.

With this commit, the docker images looks like:
    ceph/ceph-amd64     v11.0.1-20181010    d67269f5582e        About a minute ago   486MB

Signed-off-by: Erwan Velu <evelu@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
