### PR TITLE
Fix typo when creating client_host

### DIFF
--- a/src/daemon/populate_kv.sh
+++ b/src/daemon/populate_kv.sh
@@ -8,7 +8,7 @@ function kv {
   read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
-  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}client_host" || log "client_host already exists"
+  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}/client_host" || log "client_host already exists"
 }
 
 function populate_kv {


### PR DESCRIPTION
Typo introduced in https://github.com/ceph/ceph-container/pull/1186, that was making it not actually fixing #901.

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
