### PR TITLE
contrib: minor fixes to base manifest script

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -48,16 +48,14 @@ for flavor in $flavors_to_build; do
       # Pull the last image and the base image to see if the base images match
       do_pull "${latest_server_image_tag}"
       do_pull "${base_image_full_tag}"
-      latest_image_base_id="$(get_base_image_id "${latest_server_image_tag}")"
-      base_image_id="$(get_image_id "${base_image_full_tag}")"
-      if [ "${latest_image_base_id}" = "${base_image_id}" ]; then
+      if image_base_changed "${latest_server_image_tag}" "${base_image_full_tag}"; then
+        info "Base container ${base_image_full_tag} has an update for Ceph release ${version}-${ARCH}"
+        # Build a new container
+      else
         # The last ceph image's base ID is the same as the latest centos image's ID
         info "No base container update for Ceph release ${version}-${ARCH}"
         info "Image will remain at tag ${latest_server_image_tag}"
         continue  # Go to the next loop item without building
-      else
-        info "Base container ${base_image_full_tag} has an update for Ceph release ${version}-${ARCH}"
-        # Build a new container
       fi
     else
       info "No tag exists matching Ceph release ${version}-${ARCH}"

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -409,7 +409,7 @@ function get_base_image_id () {
   # Docker history gives all the image IDs which built the given image with recent images first
   # The earliest layers can be ID'ed '<missing>', so filter this out with grep
   # Of the remaining non-missing IDs, the last one should be the base image
-  if [ -n "${TEST_RUN}" ]; then
+  if [ -n "${TEST_RUN:-}" ]; then
     test_info "get_base_image_id - Returning base image ID 000000000000"
     echo "000000000000"
     return

--- a/contrib/make-ceph-base-manifests.sh
+++ b/contrib/make-ceph-base-manifests.sh
@@ -108,7 +108,11 @@ for flavor in $flavors_to_build; do
                                  "${full_minor_tag}" "${PUSH_REPOSITORY}")"
     minor_push_image_tag="$(construct_full_push_image_tag "${minor_version_tag}" \
                               "${PUSH_REPOSITORY}" '')"   # No build number for minor tag
-    add_tag "${latest_server_image_tag}" "${minor_push_image_tag}"
+    if [ -z "${latest_server_image_tag}" ]; then
+      info "No manifest image to apply ${minor_push_image_tag} to"
+    else
+      add_tag "${latest_server_image_tag}" "${minor_push_image_tag}"
+    fi
   done
 
   # The last image we apply a minor version tag to should be the image that we apply a major version
@@ -117,6 +121,10 @@ for flavor in $flavors_to_build; do
   major_version_tag="$(convert_version_tag_to_major_tag "${full_minor_tag}")"
   major_push_image_tag="$(construct_full_push_image_tag "${major_version_tag}" \
                             "${PUSH_REPOSITORY}" '')"   # No build num for major tag
-  add_tag "${latest_server_image_tag}" "${major_push_image_tag}"
+  if [ -z "${latest_server_image_tag}" ]; then
+    info "No manifest image to apply ${major_push_image_tag} to"
+  else
+    add_tag "${latest_server_image_tag}" "${major_push_image_tag}"
+  fi
 
 done  # for flavor in $flavors_to_build


### PR DESCRIPTION
I went through running a dry-run of the ceph/ceph image creation scripts, and I made 2 notable fixes.

Description of your changes:

I noticed that all ceph/ceph images have been built repeatedly for the past 5+ days. The centos:7 base image hasn't updated in a week or more. The source of this issue resulted from the base image not having an ID when doing `docker history ceph/ceph:v...`. Fix this.

Fix an unlikely bug where a manifest image doesn't exist where the
script tries to apply minor/major version tags to it. Also a minor issue
to checking for dry run status.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

Which issue is resolved by this Pull Request:
N/A

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
