### PR TITLE
centos: Adding CEPH_VERSION=master support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ FLAVORS ?= \
 	luminous,opensuse,42.3 \
 	luminous,centos,7 \
 	mimic,centos,7 \
+	master,centos,7
 
 TAG_REGISTRY ?= ceph
 
@@ -45,7 +46,8 @@ include maint-lib/makelib.mk
 ALL_BUILDABLE_FLAVORS := \
 	luminous,centos,7 \
 	luminous,opensuse,42.3 \
-	mimic,centos,7
+	mimic,centos,7 \
+	master,centos,7
 
 # ==============================================================================
 # Build targets
@@ -164,6 +166,10 @@ OPTIONS:
       DISTRO_VERSION - Distro version part of the ceph-releases source path
                        (e.g., opensuse/"42.3", centos/"7")
     e.g., make FLAVORS="luminous,opensuse,42.3" ...
+
+	It is also possible to build a container running the latest development release (master).
+	This is only available on centos with the following command :
+		make FLAVORS="master,centos,7"
 
   RELEASE - The release version to integrate in the tag. If omitted, set to the branch name.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ ceph/daemon:v3.0.1-stable-3.0-luminous-centos-7-x86_64
 ceph/daemon:tag-stable-3.0-luminous-centos-7
 ```
 
+Development images
+------------------
+It is possible to build a container running the latest development release (master). It also includes the latest development packages from the nfs-ganesha project.
+
+This is only available on centos with the following command :
+`make FLAVORS="master,centos,7"`
+
+
+
 Core Components
 ---------------
 

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,8 +1,15 @@
+yum install -y epel-release && \
+yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-    echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.6-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+    if [ "${CEPH_VERSION}" == "master" ]; then \
+      REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
+      echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+    else \
+      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.6-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+    fi && \
     echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi && \
@@ -14,6 +21,13 @@ bash -c ' \
   fi' && \
 yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
-rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/noarch/ceph-release-1-1.el__ENV_[BASEOS_TAG]__.noarch.rpm && \
-yum install -y epel-release && \
+bash -c ' \
+  if [ "${CEPH_VERSION}" == "master" ]; then \
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=master&sha1=latest" | jq -a ".[0] | .url"); \
+    RELEASE_VER=0 ;\
+  else \
+    RELEASE_VER=1 ;\
+    REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
+  fi && \
+  rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
 yum install -y __CEPH_BASE_PACKAGES__

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -5,7 +5,7 @@ set -uo pipefail
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
+X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 master,centos,7"
 AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images


### PR DESCRIPTION
Testing the master release of ceph is useful for many.
This patch is about adding a new flavor to support it.

To achieve that the following changes are made in this commit :
- download.ceph.com remains the repo for releases
- shaman.ceph.com   becomes the repo for master
REPO_URL variable is feed with the proper repo regarding the CEPH_VERSION
Finding the right repo on shaman requires 'jq' which is provided by epel.
So epel is now installed _before_ we try to install the ceph/ganesha rpms.

Note both ganesha & ceph are taken from shaman when CEPH_VERSION is set to master

On shaman, the main package is name ceph-release-1-0 while its ceph-release-1-1 on download.ceph.com
RELEASE_VER variable is feed with the appropriate value regarding the CEPH_VERSION

As shaman doesn't provides any arm64 builds, the master build is not
included in AARCH64_FLAVORS_TO_BUILD

To use that feature:

    make FLAVORS=master,centos,7 build

Signed-off-by: Erwan Velu <erwan@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
