### PR TITLE
contrib: push tag latest-master

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -10,7 +10,11 @@ set -ex
 BRANCH="${GIT_BRANCH#*/}"
 LATEST_COMMIT_SHA=$(git rev-parse --short HEAD)
 TAGGED_HEAD=false # does HEAD is on a tag ?
-if [ -z "$CEPH_RELEASES" ]; then CEPH_RELEASES=(luminous mimic); fi
+if [ -z "$CEPH_RELEASES" ]; then
+  # NEVER change 'master' position in the array, this will break the 'latest' tag
+  CEPH_RELEASES=(master luminous mimic)
+fi
+
 CEPH_RELEASES_BIS=(luminous) # list of releases that need a "bis" image for ceph-ansible
 HOST_ARCH=$(uname -m)
 


### PR DESCRIPTION
We are now building through each PR merged the latest ceph package
available at build time, which corresponds to the latest version dev
version. This commit adds a tag to that image 'latest-master' so whoever
wants to always fetch the latest ceph dev version can.

Signed-off-by: Sébastien Han <seb@redhat.com>