### PR TITLE
[skip ci] contrib: fix error handling in ceph/ceph scripts

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
+# -E option is 'errtrace' and is needed for -e to fail properly from subshell failures
 
 # Allow running this script with the env var DRY_RUN="<something>" to do a dry run of the
 # script. Dry runs will output commands that they would have executed as info messages.
@@ -7,11 +8,6 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # shellcheck disable=SC1090  # sourcing from a variable here does indeed work
 source "${SCRIPT_DIR}/ceph-build-config.sh"
-
-# As a note, bash functions which return strings do so by echo'ing the result. When the function
-# is called like 'var="$(fxn)"', var will get the return string. Trapping on ERR and returning
-# the exit code will make the script exit as expected.
-trap 'exit $?' ERR
 
 
 #

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+# Make subshells use '-uo pipefail'
+export SHELLOPTS
+
+# As a note, bash functions which return strings do so by echo'ing the result. When the function
+# is called like 'var="$(fxn)"', var will get the return string. Trapping on ERR and returning
+# the exit code will make the script exit as expected.
+trap 'exit $?' ERR
+
 # This is mostly an internal representation of 'FLAVORS_TO_BUILD'.
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts

--- a/contrib/make-ceph-base-manifests.sh
+++ b/contrib/make-ceph-base-manifests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
+# -E option is 'errtrace' and is needed for -e to fail properly from subshell failures
 
 # Allow running this script with the env var DRY_RUN="<something>" to do a dry run of the
 # script. Dry runs will output commands that they would have executed as info messages.


### PR DESCRIPTION
Add `export SHELLOPTS` to export the parent's shell options to
subshells so they definitely run with `-e` option.

Add `-E` (errtrace) option to scripts since this is needed for `-e` to
properly fail from subshells.

Move ERR trap to build config so that the manifest creation script also
gets this.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
