### PR TITLE
iscsi: fix mount configfs

### DIFF
--- a/src/daemon/start_rbd_target_api.sh
+++ b/src/daemon/start_rbd_target_api.sh
@@ -13,6 +13,9 @@ function start_rbd_target_api {
 
   ceph_health client.admin /etc/ceph/"$CLUSTER".client.admin.keyring
 
+  # mount configfs at /sys/kernel/config
+  mount -t configfs none /sys/kernel/config
+
   log "SUCCESS"
   # start rbd-target-api
   exec /usr/bin/rbd-target-api

--- a/src/daemon/start_rbd_target_gw.sh
+++ b/src/daemon/start_rbd_target_gw.sh
@@ -13,6 +13,9 @@ function start_rbd_target_gw {
 
   ceph_health client.admin /etc/ceph/"$CLUSTER".client.admin.keyring
 
+  # mount configfs at /sys/kernel/config
+  mount -t configfs none /sys/kernel/config
+
   log "SUCCESS"
   # start rbd-target-gw
   exec /usr/bin/rbd-target-gw

--- a/src/daemon/start_tcmu_runner.sh
+++ b/src/daemon/start_tcmu_runner.sh
@@ -13,6 +13,9 @@ function start_tcmu_runner {
 
   ceph_health client.admin /etc/ceph/"$CLUSTER".client.admin.keyring
 
+  # mount configfs at /sys/kernel/config
+  mount -t configfs none /sys/kernel/config
+
   log "SUCCESS"
   # start tcmu-runner
   exec tcmu-runner


### PR DESCRIPTION
The rbd-target-api, rbd-target-gw and tcmu-runner containers need configfs mounted at /sys/kernel/config.

Closes: https://github.com/ceph/ceph-container/issues/1214
Signed-off-by: Sébastien Han <seb@redhat.com>