### PR TITLE
contrib: do not build master on 'base' builds

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,7 +13,7 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 master,centos,7"
+X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
 AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images


### PR DESCRIPTION
Since 4cab875f888cb7933423430bd7b80e4792c2115a we fail for return code
!= 0 in subshell (-E option), thus when trying to fetch the repo for the
'master' release this fails since master packages do not live in
download.ceph.com. Building master was introduced in
c8c1931c8dc575495607fea7794d5aaab3b6f457 and I'm partially reverting it.
In the first, the base build script should have not been modified.

Signed-off-by: Sébastien Han <seb@redhat.com>