### PR TITLE
contrib: declare DRY_RUN empty

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -461,7 +461,7 @@ function add_tag () {
   local existing_image_full_tag="${1}" full_tag_to_add="${2}"
   info "add_tag - adding tag ${full_tag_to_add} to ${existing_image_full_tag}"
   local tag_cmd="docker tag ${existing_image_full_tag} ${full_tag_to_add}"
-  if [ -z "${DRY_RUN}" ]; then
+  if [ -z "${DRY_RUN:-}" ]; then
     ${tag_cmd}
   else
     # Just echo the make command we would've executed if this is a dry run


### PR DESCRIPTION
We must declare DRY_RUN but not assign anything, if we don't the script
will fail because of the -u option.

Fix /home/jenkins-build/build/workspace/ceph-container-build-ceph-base-push-imgs/ceph-container/contrib/ceph-build-config.sh: line 464: DRY_RUN: unbound variable

Signed-off-by: Sébastien Han <seb@redhat.com>