### PR TITLE
Make it explicit which architectures are supported

### DIFF
--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -40,6 +40,11 @@ CEPH_DAEMON=$(to_lowercase "${CEPH_DAEMON}")
 
 create_mandatory_directories
 
+if [[ ! "x86_64 aarch64" =~ $CEPH_ARCH  ]] ; then
+    echo "$CEPH_DAEMON is not supported on $CEPH_ARCH" >&2
+    exit 1
+fi
+
 # If we are given a valid first argument, set the
 # CEPH_DAEMON variable from it
 case "$CEPH_DAEMON" in

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -65,6 +65,7 @@ fi
 : "${GANESHA_OPTIONS:=""}"
 : "${GANESHA_EPOCH:=""}" # For restarting
 : "${MGR_IP:=0.0.0.0}"
+: "${CEPH_ARCH:=$(uname -m)}"
 
 # Make sure to change the value of one another if user changes some of the default values
 while read -r line; do


### PR DESCRIPTION
Exit early if trying to run the daemon container on untested
architectures.  This has been written such that it's clear what's
supported but also so it can be tested trivially without requiring a
rebuild.

Description of your changes:

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
