### PR TITLE
mon: add ability to inject existing keyring

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -94,6 +94,7 @@ List of available options:
 - `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
 - `MON_IP`: IP address of the host running Docker
 - `NETWORK_AUTO_DETECT`: Whether and how to attempt IP and network autodetection. Meant to be used without `--net=host`.
+- `NEW_USER_KEYRING`: if specified, it will be imported to keyrings. Works in demo mode only.
 
   - 0 = Do not detect (default)
   - 1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)

--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -173,6 +173,10 @@ function start_mon {
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then
     /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}:6789"
+
+    if [ -n "$NEW_USER_KEYRING" ]; then
+      echo "$NEW_USER_KEYRING" | ceph "${CLI_OPTS[@]}" auth import -i -
+    fi
   else
     # enable cluster/audit/mon logs on the same stream
     # Mind the extra space after 'debug'


### PR DESCRIPTION
Please consider merging this or something similar.

Usefull when running CI against temporary ceph cluster created
with demo mode.

Description of your changes: adds NEW_USER_KEYRING variable when starting in demo mode. Enables injecting existing keyring to keyrings.

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
