### PR TITLE
[skip ci] contrib: fix unbound var error in manifest script

### DIFF
--- a/contrib/make-ceph-base-manifests.sh
+++ b/contrib/make-ceph-base-manifests.sh
@@ -97,7 +97,7 @@ done"  # add 'done' to end of next_versions list so for loop will continue one p
     if ! full_tag_exists "${manifest_image_tag}" || [ -n "${FORCE_MANIFEST_CREATION:-}" ]; then
       # If the image doesn't exist in the repo, push it
       push_manifest_image "${manifest_image_tag}" \
-        "${x86_latest_server_image_tag}" "${arm_latest_server_image_tag}" "${additional_tags[*]}"
+        "${x86_latest_server_image_tag}" "${arm_latest_server_image_tag}" "${additional_tags[*]:-}"
     fi
     # Don't push the image if it already exists
 


### PR DESCRIPTION
Some versions of bash seem to treat printing an array with no elements
as an unbound variable error. Add a default empty to the variable
reference to fix this.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
