### PR TITLE
travis: add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ branches:
   only:
     - master
 
+sudo: required
+
+dist: xenial
+
 services:
   - docker
 


### PR DESCRIPTION
This is an attempt to overcome the error 'No output has been received in
the last 10m0s,', see https://github.com/travis-ci/travis-ci/issues/6590

Also trying to force Xenial.

Signed-off-by: Sébastien Han <seb@redhat.com>