### PR TITLE
do not run ceph-rest-api on nautilus and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 install:
   - sudo ./travis-builds/prepare_osd_fs.sh
-  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e RGW_FRONTEND_TYPE=beast -e RGW_CIVETWEB_OPTIONS="num_threads=100" -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e CLUSTER=test -e NETWORK_AUTO_DETECT=4 -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_VERSION=v0.1 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:"travis-build-$TRAVIS_BRANCH-$TRAVIS_COMMIT"-master-centos-7-x86_64 demo
+  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e RGW_FRONTEND_TYPE=beast -e RGW_CIVETWEB_OPTIONS="num_threads=100" -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e CLUSTER=test -e NETWORK_AUTO_DETECT=4 -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:"travis-build-$TRAVIS_BRANCH-$TRAVIS_COMMIT"-master-centos-7-x86_64 demo
   - sleep 5  # let's give the container 5sec to create its Ceph config file
 
 script:

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -381,7 +381,12 @@ function build_bootstrap {
         bootstrap_rbd_mirror
         ;;
       rest_api)
-        bootstrap_rest_api
+        if [[ "$CEPH_VERSION" == "jewel" ]] || [[ "$CEPH_VERSION" == "kraken" ]] || [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
+          bootstrap_rest_api
+        else
+          log "ERROR: ceph-rest-api is only available before Nautilus"
+          exit 1
+        fi
         ;;
       *)
         log "ERROR: unknown scenario!"

--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -118,8 +118,13 @@ case "$CEPH_DAEMON" in
     ;;
   restapi)
     # TAG: restapi
-    source start_restapi.sh
-    start_restapi
+    if [[ "$CEPH_VERSION" == "jewel" ]] || [[ "$CEPH_VERSION" == "kraken" ]] || [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
+      source start_restapi.sh
+      start_restapi
+    else
+      log "ERROR: ceph-rest-api is only available before Nautilus"
+      exit 1
+    fi
     ;;
   rbd_mirror)
     # TAG: rbd_mirror


### PR DESCRIPTION
The package has been removed.

Signed-off-by: Sébastien Han <seb@redhat.com>