### PR TITLE
Pull in nfs-ganesha-rados-grace package

### DIFF
--- a/ceph-releases/luminous/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/luminous/daemon-base/__GANESHA_PACKAGES__
@@ -1,0 +1,1 @@
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw

--- a/ceph-releases/mimic/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/mimic/daemon-base/__GANESHA_PACKAGES__
@@ -1,0 +1,1 @@
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw

--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace


### PR DESCRIPTION
In order to deploy ganesha in a clustered configuration, we need the ganesha-rados-grace command. That's packaged separately in the nfs-ganesha-rados-grace package.

I'm not sure whether this is the correct fix however, as older versions of ganesha (before v2.7) didn't have this package, and so the installation attempt might fail.