### PR TITLE
rbd-mirror: apply the right profile to the key

### DIFF
--- a/src/daemon/start_rbd_mirror.sh
+++ b/src/daemon/start_rbd_mirror.sh
@@ -18,10 +18,10 @@ function start_rbd_mirror {
       exit 1
     fi
 
-    ceph_health client.bootstrap-rbd "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+    ceph_health client.bootstrap-rbd-mirror "$RBD_MIRROR_BOOTSTRAP_KEYRING"
 
     # Generate the rbd mirror key
-    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd' osd 'profile rbd' -o "$RBD_MIRROR_KEYRING"
+    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd-mirror --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd-mirror' -o "$RBD_MIRROR_KEYRING"
     chown "${CHOWN_OPT[@]}" ceph. "$RBD_MIRROR_KEYRING"
     chmod 0600 "$RBD_MIRROR_KEYRING"
   fi


### PR DESCRIPTION
Don't use the rbd profile but the rbd-mirror one

Signed-off-by: Sébastien Han <seb@redhat.com>