### PR TITLE
rbd-mirror: add missing rbd profile for osd

### DIFF
--- a/src/daemon/start_rbd_mirror.sh
+++ b/src/daemon/start_rbd_mirror.sh
@@ -21,7 +21,7 @@ function start_rbd_mirror {
     ceph_health client.bootstrap-rbd-mirror "$RBD_MIRROR_BOOTSTRAP_KEYRING"
 
     # Generate the rbd mirror key
-    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd-mirror --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd-mirror' -o "$RBD_MIRROR_KEYRING"
+    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd-mirror --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd-mirror' osd 'profile rbd' -o "$RBD_MIRROR_KEYRING"
     chown "${CHOWN_OPT[@]}" ceph. "$RBD_MIRROR_KEYRING"
     chmod 0600 "$RBD_MIRROR_KEYRING"
   fi


### PR DESCRIPTION
The flag is required since the rbd-mirror accesses the OSDs.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
