### PR TITLE
ceph-releases: Restoring rbd behavior for luminous/mimic

### DIFF
--- a/ceph-releases/luminous/daemon/config.static.sh
+++ b/ceph-releases/luminous/daemon/config.static.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+function get_admin_key {
+   # No-op for static
+   log "static: does not generate the admin key, so we can not get it."
+   log "static: make it available with the help of your configuration management system."
+   log "static: ceph-ansible is a good candidate to deploy a containerized version of Ceph."
+   log "static: ceph-ansible will help you fetching the keys and push them on the right nodes."
+   log "static: if you're interested, please visit: https://github.com/ceph/ceph-ansible"
+}
+
+function get_mon_config {
+  # IPv4 is the default unless we specify it
+  IP_LEVEL=${1:-4}
+
+  if [ ! -e /etc/ceph/"${CLUSTER}".conf ]; then
+    local fsid
+		fsid=$(uuidgen)
+    if [[ "$CEPH_DAEMON" == demo ]]; then
+      fsid=$(uuidgen)
+      cat <<ENDHERE >/etc/ceph/"${CLUSTER}".conf
+[global]
+fsid = $fsid
+mon initial members = ${MON_NAME}
+mon host = ${MON_IP}
+osd crush chooseleaf type = 0
+osd journal size = 100
+public network = ${CEPH_PUBLIC_NETWORK}
+cluster network = ${CEPH_PUBLIC_NETWORK}
+log file = /dev/null
+osd pool default size = 1
+ENDHERE
+
+      # For ext4
+      if [ "$(findmnt -n -o FSTYPE -T /var/lib/ceph)" = "ext4" ]; then
+      cat <<ENDHERE >> /etc/ceph/"${CLUSTER}".conf
+osd max object name len = 256
+osd max object namespace len = 64
+ENDHERE
+      fi
+    else
+      cat <<ENDHERE >/etc/ceph/"${CLUSTER}".conf
+[global]
+fsid = $fsid
+mon initial members = ${MON_NAME}
+mon host = ${MON_IP}
+public network = ${CEPH_PUBLIC_NETWORK}
+cluster network = ${CEPH_CLUSTER_NETWORK}
+osd journal size = ${OSD_JOURNAL_SIZE}
+log file = /dev/null
+ENDHERE
+    fi
+    if [ "$IP_LEVEL" -eq 6 ]; then
+      echo "ms bind ipv6 = true" >> /etc/ceph/"${CLUSTER}".conf
+    fi
+  else
+    # extract fsid from ceph.conf
+    fsid=$(grep "fsid" /etc/ceph/"${CLUSTER}".conf | awk '{print $NF}')
+  fi
+
+  if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
+    CLI+=("--set-uid=0")
+  fi
+
+  if [ ! -e "$ADMIN_KEYRING" ]; then
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring -n client.admin "${CLI[@]}" --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'
+  fi
+
+  if [ ! -e "$MON_KEYRING" ]; then
+    # Generate the mon. key
+    ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
+  fi
+
+  if [ ! -e "$OSD_BOOTSTRAP_KEYRING" ]; then
+    # Generate the OSD bootstrap key
+    ceph-authtool "$OSD_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-osd --cap mon 'allow profile bootstrap-osd'
+  fi
+
+  if [ ! -e "$MDS_BOOTSTRAP_KEYRING" ]; then
+    # Generate the MDS bootstrap key
+    ceph-authtool "$MDS_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-mds --cap mon 'allow profile bootstrap-mds'
+  fi
+
+  if [ ! -e "$RGW_BOOTSTRAP_KEYRING" ]; then
+    # Generate the RGW bootstrap key
+    ceph-authtool "$RGW_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-rgw --cap mon 'allow profile bootstrap-rgw'
+  fi
+
+  if [ ! -e "$RBD_MIRROR_BOOTSTRAP_KEYRING" ]; then
+    # Generate the RBD Mirror bootstrap key
+    ceph-authtool "$RBD_MIRROR_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-rbd --cap mon 'allow profile bootstrap-rbd'
+  fi
+    # Apply proper permissions to the keys
+    chown "${CHOWN_OPT[@]}" ceph. "$MON_KEYRING" "$OSD_BOOTSTRAP_KEYRING" "$MDS_BOOTSTRAP_KEYRING" "$RGW_BOOTSTRAP_KEYRING" "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+
+  if [ ! -e "$MONMAP" ]; then
+    if [ -e /etc/ceph/monmap ]; then
+      # Rename old monmap
+      mv /etc/ceph/monmap "$MONMAP"
+    else
+      # Generate initial monitor map
+      monmaptool --create --add "${MON_NAME}" "${MON_IP}:6789" --fsid "${fsid}" "$MONMAP"
+    fi
+    chown "${CHOWN_OPT[@]}" ceph. "$MONMAP"
+  fi
+}
+
+function get_config {
+   # No-op for static
+   log "static: does not generate config"
+}
+

--- a/ceph-releases/luminous/daemon/config.static.sh
+++ b/ceph-releases/luminous/daemon/config.static.sh
@@ -59,9 +59,7 @@ ENDHERE
     fsid=$(grep "fsid" /etc/ceph/"${CLUSTER}".conf | awk '{print $NF}')
   fi
 
-  if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
-    CLI+=("--set-uid=0")
-  fi
+  CLI+=("--set-uid=0")
 
   if [ ! -e "$ADMIN_KEYRING" ]; then
     if [ -z "$ADMIN_SECRET" ]; then

--- a/ceph-releases/luminous/daemon/start_rbd_mirror.sh
+++ b/ceph-releases/luminous/daemon/start_rbd_mirror.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+function start_rbd_mirror {
+  get_config
+  check_config
+
+  if [ "${CEPH_GET_ADMIN_KEY}" -eq 1 ]; then
+    # ensure we have the admin key
+    get_admin_key
+    check_admin_key
+  fi
+
+  if [ ! -e "$RBD_MIRROR_KEYRING" ]; then
+
+    if [ ! -e "$RBD_MIRROR_BOOTSTRAP_KEYRING" ]; then
+      log "ERROR- $RBD_MIRROR_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-rbd -o $RBD_MIRROR_BOOTSTRAP_KEYRING'"
+      exit 1
+    fi
+
+    ceph_health client.bootstrap-rbd "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+
+    # Generate the rbd mirror key
+    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd' osd 'profile rbd' -o "$RBD_MIRROR_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$RBD_MIRROR_KEYRING"
+    chmod 0600 "$RBD_MIRROR_KEYRING"
+  fi
+
+  log "SUCCESS"
+  # start rbd-mirror
+  exec /usr/bin/rbd-mirror "${DAEMON_OPTS[@]}" -n client.rbd-mirror."${RBD_MIRROR_NAME}"
+}

--- a/ceph-releases/luminous/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/daemon/variables_entrypoint.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+
+###################################
+# LIST OF ALL SCENARIOS AVAILABLE #
+###################################
+
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+
+
+#########################
+# LIST OF ALL VARIABLES #
+#########################
+
+HOSTNAME=$(uname -n | cut -d'.' -f1)
+HOST_FQDN=$(</proc/sys/kernel/hostname) # read a potential FQDN configuration, if a FQDN is configured this file will contain it instead of the shortname
+: "${CLUSTER:=ceph}"
+if [[ "$HOSTNAME" != "$HOST_FQDN" ]]; then
+  for daemon in mon mgr mds radosgw; do
+    if [ -d "/var/lib/ceph/${daemon}/${CLUSTER}-${HOST_FQDN}" ]; then
+      echo "Found an FQDN configuration, keep the value of '$HOSTNAME'."
+      HOSTNAME=$HOST_FQDN
+    fi
+  done
+fi
+: "${MON_NAME:=${HOSTNAME}}"
+: "${RGW_NAME:=${HOSTNAME}}"
+: "${RBD_MIRROR_NAME:=${HOSTNAME}}"
+: "${MGR_NAME:=${HOSTNAME}}"
+: "${MDS_NAME:=${HOSTNAME}}"
+: "${MON_DATA_DIR:=/var/lib/ceph/mon/${CLUSTER}-${MON_NAME}}"
+: "${CLUSTER_PATH:=ceph-config/${CLUSTER}}" # For KV config
+: "${CEPH_CLUSTER_NETWORK:=${CEPH_PUBLIC_NETWORK}}"
+: "${CEPH_DAEMON:=${1}}" # default daemon to first argument
+: "${CEPH_GET_ADMIN_KEY:=0}"
+: "${K8S_HOST_NETWORK:=0}"
+: "${K8S_MON_SELECTOR:=app=ceph,daemon=mon}"
+: "${NETWORK_AUTO_DETECT:=0}"
+: "${OSD_JOURNAL_SIZE:=100}"
+: "${OSD_BLUESTORE:=1}"
+: "${OSD_FILESTORE:=0}"
+: "${OSD_BLUESTORE_BLOCK_UUID:=$(uuidgen)}"
+: "${OSD_BLUESTORE_BLOCK_DB:=$OSD_DEVICE}"
+: "${OSD_BLUESTORE_BLOCK_DB_UUID:=$(uuidgen)}"
+: "${OSD_BLUESTORE_BLOCK_WAL:=$OSD_DEVICE}"
+: "${OSD_BLUESTORE_BLOCK_WAL_UUID:=$(uuidgen)}"
+: "${OSD_DMCRYPT:=0}"
+: "${OSD_JOURNAL_UUID:=$(uuidgen)}"
+: "${OSD_LOCKBOX_UUID:=$(uuidgen)}"
+: "${CEPHFS_CREATE:=0}"
+: "${CEPHFS_NAME:=cephfs}"
+: "${CEPHFS_DATA_POOL:=${CEPHFS_NAME}_data}"
+: "${CEPHFS_DATA_POOL_PG:=8}"
+: "${CEPHFS_METADATA_POOL:=${CEPHFS_NAME}_metadata}"
+: "${CEPHFS_METADATA_POOL_PG:=8}"
+: "${RGW_USER:="cephnfs"}"
+: "${RESTAPI_IP:=0.0.0.0}"
+: "${RESTAPI_PORT:=5000}"
+: "${RESTAPI_BASE_URL:=/api/v0.1}"
+: "${RESTAPI_LOG_LEVEL:=warning}"
+: "${RESTAPI_LOG_FILE:=/var/log/ceph/ceph-restapi.log}"
+: "${KV_TYPE:=none}" # valid options: etcd, k8s|kubernetes or none
+: "${KV_IP:=127.0.0.1}"
+: "${KV_PORT:=2379}"
+: "${GANESHA_OPTIONS:=""}"
+: "${GANESHA_EPOCH:=""}" # For restarting
+: "${MGR_IP:=0.0.0.0}"
+
+# Make sure to change the value of one another if user changes some of the default values
+while read -r line; do
+  if [[ "$line" == "OSD_FILESTORE=1" ]]; then
+    OSD_BLUESTORE=0
+  elif [[ "$line" == "OSD_BLUESTORE=1" ]]; then
+    OSD_FILESTORE=0
+  fi
+done < <(env)
+
+# Create a default array
+CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
+[[ -n "$CRUSH_LOCATION" ]] || read -ra CRUSH_LOCATION <<< "${CRUSH_LOCATION_DEFAULT[@]}"
+
+# This is ONLY used for the CLI calls, e.g: ceph $CLI_OPTS health
+CLI_OPTS=(--cluster ${CLUSTER})
+
+# This is ONLY used for the daemon's startup, e.g: ceph-osd $DAEMON_OPTS
+DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph -d)
+
+MOUNT_OPTS=(-t xfs -o noatime,inode64)
+
+# make sure etcd uses http or https as a prefix
+if [[ "$KV_TYPE" == "etcd" ]]; then
+  if [ -n "${KV_CA_CERT}" ]; then
+    CONFD_NODE_SCHEMA="https://"
+    KV_TLS=(--ca-file=${KV_CA_CERT} --cert-file=${KV_CLIENT_CERT} --key-file=${KV_CLIENT_KEY})
+    CONFD_KV_TLS=(-scheme=https -client-ca-keys=${KV_CA_CERT} -client-cert=${KV_CLIENT_CERT} -client-key=${KV_CLIENT_KEY})
+  else
+    CONFD_NODE_SCHEMA="http://"
+  fi
+  ETCD_SCHEMA=${CONFD_NODE_SCHEMA}
+  ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
+fi
+
+# Internal variables
+MDS_KEYRING=/var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
+ADMIN_KEYRING=/etc/ceph/${CLUSTER}.client.admin.keyring
+MON_KEYRING=/etc/ceph/${CLUSTER}.mon.keyring
+RGW_KEYRING=/var/lib/ceph/radosgw/${CLUSTER}-rgw.${RGW_NAME}/keyring
+MDS_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring
+RGW_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring
+OSD_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-osd/${CLUSTER}.keyring
+RBD_MIRROR_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-rbd/${CLUSTER}.keyring
+OSD_PATH_BASE=/var/lib/ceph/osd/${CLUSTER}
+MONMAP=/etc/ceph/monmap-${CLUSTER}
+MGR_KEYRING=/var/lib/ceph/mgr/${CLUSTER}-${MGR_NAME}/keyring
+RBD_MIRROR_KEYRING=/etc/ceph/${CLUSTER}.client.rbd-mirror.${HOSTNAME}.keyring

--- a/ceph-releases/mimic/daemon/config.static.sh
+++ b/ceph-releases/mimic/daemon/config.static.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+function get_admin_key {
+   # No-op for static
+   log "static: does not generate the admin key, so we can not get it."
+   log "static: make it available with the help of your configuration management system."
+   log "static: ceph-ansible is a good candidate to deploy a containerized version of Ceph."
+   log "static: ceph-ansible will help you fetching the keys and push them on the right nodes."
+   log "static: if you're interested, please visit: https://github.com/ceph/ceph-ansible"
+}
+
+function get_mon_config {
+  # IPv4 is the default unless we specify it
+  IP_LEVEL=${1:-4}
+
+  if [ ! -e /etc/ceph/"${CLUSTER}".conf ]; then
+    local fsid
+		fsid=$(uuidgen)
+    if [[ "$CEPH_DAEMON" == demo ]]; then
+      fsid=$(uuidgen)
+      cat <<ENDHERE >/etc/ceph/"${CLUSTER}".conf
+[global]
+fsid = $fsid
+mon initial members = ${MON_NAME}
+mon host = ${MON_IP}
+osd crush chooseleaf type = 0
+osd journal size = 100
+public network = ${CEPH_PUBLIC_NETWORK}
+cluster network = ${CEPH_PUBLIC_NETWORK}
+log file = /dev/null
+osd pool default size = 1
+ENDHERE
+
+      # For ext4
+      if [ "$(findmnt -n -o FSTYPE -T /var/lib/ceph)" = "ext4" ]; then
+      cat <<ENDHERE >> /etc/ceph/"${CLUSTER}".conf
+osd max object name len = 256
+osd max object namespace len = 64
+ENDHERE
+      fi
+    else
+      cat <<ENDHERE >/etc/ceph/"${CLUSTER}".conf
+[global]
+fsid = $fsid
+mon initial members = ${MON_NAME}
+mon host = ${MON_IP}
+public network = ${CEPH_PUBLIC_NETWORK}
+cluster network = ${CEPH_CLUSTER_NETWORK}
+osd journal size = ${OSD_JOURNAL_SIZE}
+log file = /dev/null
+ENDHERE
+    fi
+    if [ "$IP_LEVEL" -eq 6 ]; then
+      echo "ms bind ipv6 = true" >> /etc/ceph/"${CLUSTER}".conf
+    fi
+  else
+    # extract fsid from ceph.conf
+    fsid=$(grep "fsid" /etc/ceph/"${CLUSTER}".conf | awk '{print $NF}')
+  fi
+
+  if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
+    CLI+=("--set-uid=0")
+  fi
+
+  if [ ! -e "$ADMIN_KEYRING" ]; then
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring -n client.admin "${CLI[@]}" --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'
+  fi
+
+  if [ ! -e "$MON_KEYRING" ]; then
+    # Generate the mon. key
+    ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
+  fi
+
+  if [ ! -e "$OSD_BOOTSTRAP_KEYRING" ]; then
+    # Generate the OSD bootstrap key
+    ceph-authtool "$OSD_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-osd --cap mon 'allow profile bootstrap-osd'
+  fi
+
+  if [ ! -e "$MDS_BOOTSTRAP_KEYRING" ]; then
+    # Generate the MDS bootstrap key
+    ceph-authtool "$MDS_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-mds --cap mon 'allow profile bootstrap-mds'
+  fi
+
+  if [ ! -e "$RGW_BOOTSTRAP_KEYRING" ]; then
+    # Generate the RGW bootstrap key
+    ceph-authtool "$RGW_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-rgw --cap mon 'allow profile bootstrap-rgw'
+  fi
+
+  if [ ! -e "$RBD_MIRROR_BOOTSTRAP_KEYRING" ]; then
+    # Generate the RBD Mirror bootstrap key
+    ceph-authtool "$RBD_MIRROR_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-rbd --cap mon 'allow profile bootstrap-rbd'
+  fi
+    # Apply proper permissions to the keys
+    chown "${CHOWN_OPT[@]}" ceph. "$MON_KEYRING" "$OSD_BOOTSTRAP_KEYRING" "$MDS_BOOTSTRAP_KEYRING" "$RGW_BOOTSTRAP_KEYRING" "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+
+  if [ ! -e "$MONMAP" ]; then
+    if [ -e /etc/ceph/monmap ]; then
+      # Rename old monmap
+      mv /etc/ceph/monmap "$MONMAP"
+    else
+      # Generate initial monitor map
+      monmaptool --create --add "${MON_NAME}" "${MON_IP}:6789" --fsid "${fsid}" "$MONMAP"
+    fi
+    chown "${CHOWN_OPT[@]}" ceph. "$MONMAP"
+  fi
+}
+
+function get_config {
+   # No-op for static
+   log "static: does not generate config"
+}
+

--- a/ceph-releases/mimic/daemon/config.static.sh
+++ b/ceph-releases/mimic/daemon/config.static.sh
@@ -59,9 +59,7 @@ ENDHERE
     fsid=$(grep "fsid" /etc/ceph/"${CLUSTER}".conf | awk '{print $NF}')
   fi
 
-  if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
-    CLI+=("--set-uid=0")
-  fi
+  CLI+=("--set-uid=0")
 
   if [ ! -e "$ADMIN_KEYRING" ]; then
     if [ -z "$ADMIN_SECRET" ]; then

--- a/ceph-releases/mimic/daemon/start_rbd_mirror.sh
+++ b/ceph-releases/mimic/daemon/start_rbd_mirror.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+function start_rbd_mirror {
+  get_config
+  check_config
+
+  if [ "${CEPH_GET_ADMIN_KEY}" -eq 1 ]; then
+    # ensure we have the admin key
+    get_admin_key
+    check_admin_key
+  fi
+
+  if [ ! -e "$RBD_MIRROR_KEYRING" ]; then
+
+    if [ ! -e "$RBD_MIRROR_BOOTSTRAP_KEYRING" ]; then
+      log "ERROR- $RBD_MIRROR_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-rbd -o $RBD_MIRROR_BOOTSTRAP_KEYRING'"
+      exit 1
+    fi
+
+    ceph_health client.bootstrap-rbd "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+
+    # Generate the rbd mirror key
+    ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd' osd 'profile rbd' -o "$RBD_MIRROR_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$RBD_MIRROR_KEYRING"
+    chmod 0600 "$RBD_MIRROR_KEYRING"
+  fi
+
+  log "SUCCESS"
+  # start rbd-mirror
+  exec /usr/bin/rbd-mirror "${DAEMON_OPTS[@]}" -n client.rbd-mirror."${RBD_MIRROR_NAME}"
+}

--- a/ceph-releases/mimic/daemon/variables_entrypoint.sh
+++ b/ceph-releases/mimic/daemon/variables_entrypoint.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+
+###################################
+# LIST OF ALL SCENARIOS AVAILABLE #
+###################################
+
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+
+
+#########################
+# LIST OF ALL VARIABLES #
+#########################
+
+HOSTNAME=$(uname -n | cut -d'.' -f1)
+HOST_FQDN=$(</proc/sys/kernel/hostname) # read a potential FQDN configuration, if a FQDN is configured this file will contain it instead of the shortname
+: "${CLUSTER:=ceph}"
+if [[ "$HOSTNAME" != "$HOST_FQDN" ]]; then
+  for daemon in mon mgr mds radosgw; do
+    if [ -d "/var/lib/ceph/${daemon}/${CLUSTER}-${HOST_FQDN}" ]; then
+      echo "Found an FQDN configuration, keep the value of '$HOSTNAME'."
+      HOSTNAME=$HOST_FQDN
+    fi
+  done
+fi
+: "${MON_NAME:=${HOSTNAME}}"
+: "${RGW_NAME:=${HOSTNAME}}"
+: "${RBD_MIRROR_NAME:=${HOSTNAME}}"
+: "${MGR_NAME:=${HOSTNAME}}"
+: "${MDS_NAME:=${HOSTNAME}}"
+: "${MON_DATA_DIR:=/var/lib/ceph/mon/${CLUSTER}-${MON_NAME}}"
+: "${CLUSTER_PATH:=ceph-config/${CLUSTER}}" # For KV config
+: "${CEPH_CLUSTER_NETWORK:=${CEPH_PUBLIC_NETWORK}}"
+: "${CEPH_DAEMON:=${1}}" # default daemon to first argument
+: "${CEPH_GET_ADMIN_KEY:=0}"
+: "${K8S_HOST_NETWORK:=0}"
+: "${K8S_MON_SELECTOR:=app=ceph,daemon=mon}"
+: "${NETWORK_AUTO_DETECT:=0}"
+: "${OSD_JOURNAL_SIZE:=100}"
+: "${OSD_BLUESTORE:=1}"
+: "${OSD_FILESTORE:=0}"
+: "${OSD_BLUESTORE_BLOCK_UUID:=$(uuidgen)}"
+: "${OSD_BLUESTORE_BLOCK_DB:=$OSD_DEVICE}"
+: "${OSD_BLUESTORE_BLOCK_DB_UUID:=$(uuidgen)}"
+: "${OSD_BLUESTORE_BLOCK_WAL:=$OSD_DEVICE}"
+: "${OSD_BLUESTORE_BLOCK_WAL_UUID:=$(uuidgen)}"
+: "${OSD_DMCRYPT:=0}"
+: "${OSD_JOURNAL_UUID:=$(uuidgen)}"
+: "${OSD_LOCKBOX_UUID:=$(uuidgen)}"
+: "${CEPHFS_CREATE:=0}"
+: "${CEPHFS_NAME:=cephfs}"
+: "${CEPHFS_DATA_POOL:=${CEPHFS_NAME}_data}"
+: "${CEPHFS_DATA_POOL_PG:=8}"
+: "${CEPHFS_METADATA_POOL:=${CEPHFS_NAME}_metadata}"
+: "${CEPHFS_METADATA_POOL_PG:=8}"
+: "${RGW_USER:="cephnfs"}"
+: "${RESTAPI_IP:=0.0.0.0}"
+: "${RESTAPI_PORT:=5000}"
+: "${RESTAPI_BASE_URL:=/api/v0.1}"
+: "${RESTAPI_LOG_LEVEL:=warning}"
+: "${RESTAPI_LOG_FILE:=/var/log/ceph/ceph-restapi.log}"
+: "${KV_TYPE:=none}" # valid options: etcd, k8s|kubernetes or none
+: "${KV_IP:=127.0.0.1}"
+: "${KV_PORT:=2379}"
+: "${GANESHA_OPTIONS:=""}"
+: "${GANESHA_EPOCH:=""}" # For restarting
+: "${MGR_IP:=0.0.0.0}"
+
+# Make sure to change the value of one another if user changes some of the default values
+while read -r line; do
+  if [[ "$line" == "OSD_FILESTORE=1" ]]; then
+    OSD_BLUESTORE=0
+  elif [[ "$line" == "OSD_BLUESTORE=1" ]]; then
+    OSD_FILESTORE=0
+  fi
+done < <(env)
+
+# Create a default array
+CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
+[[ -n "$CRUSH_LOCATION" ]] || read -ra CRUSH_LOCATION <<< "${CRUSH_LOCATION_DEFAULT[@]}"
+
+# This is ONLY used for the CLI calls, e.g: ceph $CLI_OPTS health
+CLI_OPTS=(--cluster ${CLUSTER})
+
+# This is ONLY used for the daemon's startup, e.g: ceph-osd $DAEMON_OPTS
+DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph -d)
+
+MOUNT_OPTS=(-t xfs -o noatime,inode64)
+
+# make sure etcd uses http or https as a prefix
+if [[ "$KV_TYPE" == "etcd" ]]; then
+  if [ -n "${KV_CA_CERT}" ]; then
+    CONFD_NODE_SCHEMA="https://"
+    KV_TLS=(--ca-file=${KV_CA_CERT} --cert-file=${KV_CLIENT_CERT} --key-file=${KV_CLIENT_KEY})
+    CONFD_KV_TLS=(-scheme=https -client-ca-keys=${KV_CA_CERT} -client-cert=${KV_CLIENT_CERT} -client-key=${KV_CLIENT_KEY})
+  else
+    CONFD_NODE_SCHEMA="http://"
+  fi
+  ETCD_SCHEMA=${CONFD_NODE_SCHEMA}
+  ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
+fi
+
+# Internal variables
+MDS_KEYRING=/var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
+ADMIN_KEYRING=/etc/ceph/${CLUSTER}.client.admin.keyring
+MON_KEYRING=/etc/ceph/${CLUSTER}.mon.keyring
+RGW_KEYRING=/var/lib/ceph/radosgw/${CLUSTER}-rgw.${RGW_NAME}/keyring
+MDS_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring
+RGW_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring
+OSD_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-osd/${CLUSTER}.keyring
+RBD_MIRROR_BOOTSTRAP_KEYRING=/var/lib/ceph/bootstrap-rbd/${CLUSTER}.keyring
+OSD_PATH_BASE=/var/lib/ceph/osd/${CLUSTER}
+MONMAP=/etc/ceph/monmap-${CLUSTER}
+MGR_KEYRING=/var/lib/ceph/mgr/${CLUSTER}-${MGR_NAME}/keyring
+RBD_MIRROR_KEYRING=/etc/ceph/${CLUSTER}.client.rbd-mirror.${HOSTNAME}.keyring

--- a/src/daemon/config.static.sh
+++ b/src/daemon/config.static.sh
@@ -59,10 +59,6 @@ ENDHERE
     fsid=$(grep "fsid" /etc/ceph/"${CLUSTER}".conf | awk '{print $NF}')
   fi
 
-  if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
-    CLI+=("--set-uid=0")
-  fi
-
   if [ ! -e "$ADMIN_KEYRING" ]; then
     if [ -z "$ADMIN_SECRET" ]; then
       # Automatically generate administrator key


### PR DESCRIPTION
Commits f0cc4c743073aaf83b186a6e4363f580d1fac35c, f5c404f62f6e5ec7f0ad80a3d96f134614cf00f9, 91b76d868fd14e41cfdc7d167f7332fc2b38f352 introduced some changes that are effective starting nautilus.

They put those changes inside src/ meaning all versions are affected breaking luminous & mimic builds.

This PR is about restoring the files priori this commits inside the luminous & mimic directories.
This way, src/ remains all versions and support the "future" code while ceph-releases/{luminous,mimic} keep the exceptions that will vanish once they will be EOL.

Signed-off-by: Erwan Velu <evelu@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
