### PR TITLE
daemon: enable force ext4 osd flags

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -137,6 +137,7 @@ Options for OSDs (TODO: consolidate these options between the types):
 - `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default). This is currently only supported by the `directory` OSD type
 - `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
 - `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
+- `OSD_FORCE_EXT4` - in case the osd data on ext4 is not automatically recognized (i.e. hidden by overlayfs) you can force them by settings this to `yes`.
 
 ### Without OSD_TYPE
 

--- a/src/daemon/config.static.sh
+++ b/src/daemon/config.static.sh
@@ -33,7 +33,7 @@ osd pool default size = 1
 ENDHERE
 
       # For ext4
-      if [ "$(findmnt -n -o FSTYPE -T /var/lib/ceph)" = "ext4" ]; then
+      if [ "$(findmnt -n -o FSTYPE -T /var/lib/ceph)" = "ext4" -o "$OSD_FORCE_EXT4" == "yes" ]; then
       cat <<ENDHERE >> /etc/ceph/"${CLUSTER}".conf
 osd max object name len = 256
 osd max object namespace len = 64


### PR DESCRIPTION
Description of your changes: My usecase is launching the ceph demo for every CI job. The CI is run fully in docker engine, which has standard configuration ext4 with overlayfs. Automatic osd param tunnigs in https://github.com/ceph/ceph-container/blob/master/src/daemon/config.static.sh#L36 can detect ext4 because of the overlayfs. Creating separate xfs volume for this simple usecase is kind of overkill. So it's usefull to tell the osd to use ext4 params.

I've found the FORCE flag loitering in earlier code versions.

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.