### PR TITLE
daemon-base: install kubernetes python module

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -30,4 +30,6 @@ bash -c ' \
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum install -y __CEPH_BASE_PACKAGES__ python-pip && \
+pip install kubernetes && \
+yum remove -y python-pip


### PR DESCRIPTION
This module is necessary for the ceph-mgr rook orchestrator module,
so we should ensure that it's installed in this case.

Signed-off-by: Jeff Layton <jlayton@redhat.com>