### PR TITLE
src/daemon/demo.sh: Dynamic sleep instead of harcoded value

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -220,9 +220,9 @@ function bootstrap_demo_user {
 
     if [ -n "$CEPH_DEMO_BUCKET" ]; then
       log "Creating bucket..."
-      # waiting for rgw to be ready, 5 seconds is usually enough
-      sleep 5
-      s3cmd mb s3://"$CEPH_DEMO_BUCKET"
+
+      # Trying to create a s3cmd within 5 seconds
+      timeout 5 bash -c "until s3cmd mb s3://$CEPH_DEMO_BUCKET; do sleep .1; done"
     fi
   fi
 }


### PR DESCRIPTION
The current code was waiting for 5 secs before trying to create the bucket.

The whole container usually starts in 25 secs meaning that a 1/5th is spent here.

This patch is poking the s3 service to see if it's available.
The loop is waiting up to 5 seconds.

Once the radosgw is ready, the bucket is created.

Tests on a private server showed that a single loop is enough, saving 5 seconds on the start process.

Signed-off-by: Erwan Velu <evelu@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
