### PR TITLE
centos: Enabling CR repository on Centos

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,4 @@
+yum-config-manager --enable cr && \
 yum install -y epel-release && \
 yum install -y jq && \
 bash -c ' \


### PR DESCRIPTION
Testing on master could trigger some racing between the specfile descriptions and the state of the Centos repository.

The Travis CI ran and reported an issue like :

    Error: Package: 2:ceph-selinux-14.0.1-1009.g1756025.el7.x86_64 (Ceph)
           Requires: selinux-policy-base >= 3.13.1-229.el7_6.5
           Available: selinux-policy-minimum-3.13.1-192.el7.noarch (base)

The -229.el7_6.5 version of the package is required by ceph-selinux but is not yet available on the update repository.

The CR repository (https://wiki.centos.org/AdditionalResources/Repositories/CR) can be used to reach the packages before they get into the update repo.
    "[CR] makes generally available packages that will appear in the next point release of CentOS"

This commit is about enabling CR so yum can reach the latest version of the packages.

Signed-off-by: Erwan Velu <erwan@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
