### PR TITLE
ceph_volume_active: auto discover of osd type

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -4,16 +4,26 @@ set -e
 function osd_volume_activate {
   : "${OSD_ID:?Give me an OSD ID to activate, eg: -e OSD_ID=0}"
 
+  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
+
+  if ! echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
+    log "OSD id $OSD_ID does not exist"
+    exit 1
+  fi
+
   # Find the OSD FSID from the OSD ID
-  OSD_FSID="$(ceph-volume lvm list --format json | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
+  OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
+
+  # Find the OSD type
+  OSD_TYPE="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"type\"])")"
 
   # Discover the objectstore
-  if [[ "OSD_FILESTORE" -eq 1 ]]; then
+  if [[ "data journal" =~ $OSD_TYPE ]]; then
     OSD_OBJECTSTORE=(--filestore)
-  elif [[ "OSD_BLUESTORE" -eq 1 ]]; then
+  elif [[ "block wal db" =~ $OSD_TYPE ]]; then
     OSD_OBJECTSTORE=(--bluestore)
   else
-    log "Either OSD_FILESTORE or OSD_BLUESTORE must be set to 1."
+    log "Unable to discover osd objectstore for OSD type: $OSD_TYPE"
     exit 1
   fi
 


### PR DESCRIPTION
Instead of requiring OSD_OBJECTSTORE to be set for activation we now
discover the objectstore on the fly.

Signed-off-by: Sébastien Han <seb@redhat.com>