### PR TITLE
src/daemon: Define path for when sourcing osd scripts

### DIFF
--- a/src/daemon/osd_scenarios/osd_directory.sh
+++ b/src/daemon/osd_scenarios/osd_directory.sh
@@ -66,6 +66,6 @@ function osd_directory {
     echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CLI_OPTS[*]} -f -i ${OSD_ID} --osd-journal ${OSD_J} -k $OSD_KEYRING" | tee -a /etc/forego/"${CLUSTER}"/Procfile
   done
   log "SUCCESS"
-  source osd_common.sh
+  source /opt/ceph-container/bin/osd_common.sh
   start_forego
 }

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC2034
 set -e
-source disk_list.sh
+source /opt/ceph-container/bin/disk_list.sh
 
 function osd_activate {
   if [[ -z "${OSD_DEVICE}" ]] || [[ ! -b "${OSD_DEVICE}" ]]; then

--- a/src/daemon/osd_scenarios/osd_disks.sh
+++ b/src/daemon/osd_scenarios/osd_disks.sh
@@ -60,6 +60,6 @@ function osd_disks {
 
   log "SUCCESS"
   # Actually, starting them as per forego configuration
-  source osd_common.sh
+  source /opt/ceph-container/bin/osd_common.sh
   start_forego
 }


### PR DESCRIPTION
Commit 207373b introduce a move of script files in /opt/ceph-container.
Some files were not updated correctly. This patch is about adding the right path when sourcing those files.

Original commit from Carlos Almeida (https://github.com/cmsalmeida)

Signed-off-by: Erwan Velu <evelu@redhat.com>

This is a takeover of #1267 to ensure a quick merge while keeping a good commit quality