### PR TITLE
Remove ganesha packages from luminous/mimic

### DIFF
--- a/ceph-releases/luminous/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/luminous/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw

--- a/ceph-releases/mimic/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/mimic/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw


### PR DESCRIPTION
Because of the override specificity (copied from docs below)
`__GANESHA_PACKAGES__` for centos-arm64 were getting pulled from
`ceph-releases/{luminous,mimic}/daemon-base` and not from
`ceph-releases/ALL/centos-arm64/daemon-base`. Since
`__GANESHA_PACKAGES__` exists in `src/daemon-base` and since the
contents of the file for luminous and mimic were both exactly the same,
there should be no more need to have these files. And this fixes the
centos-arm64 staging.

```
ceph-releases/<ceph release>/<base os repository>/<base os release>/{daemon-base,daemon}/FILE
ceph-releases/<ceph release>/<base os repository>/<base os release>/FILE
ceph-releases/<ceph release>/<base os repository>/{daemon-base,daemon}/FILE
ceph-releases/<ceph release>/<base os repository>/FILE
ceph-releases/<ceph release>/{daemon-base,daemon}/FILE
ceph-releases/<ceph release>/FILE
ceph-releases/ALL/<base os repository>/<base os release>/{daemon-base,daemon}/FILE
ceph-releases/ALL/<base os repository>/<base os release>/FILE
ceph-releases/ALL/<base os repository>/{daemon-base,daemon}/FILE
ceph-releases/ALL/<base os repository>/FILE
ceph-releases/ALL/{daemon-base,daemon}/FILE
ceph-releases/ALL/FILE
src/{daemon-base,daemon}/FILE
src/FILE
```

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
