### PR TITLE
daemon-base: add gdisk to ceph base packages

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -9,6 +9,7 @@
         __CEPH_MGR_PACKAGE__\
         kmod \
         lvm2 \
+        sgdisk \
         __RADOSGW_PACKAGE__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__


### PR DESCRIPTION
Rook expects sgdisk to be in images alongside Ceph. Add this to the base
packages list.

**Note:** The ideal fix for the situation is to allow Rook to use its own sgdisk, but this is the quickest option to get it fixed in Rook v0.9

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>
