### PR TITLE
travis: remove sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ branches:
   only:
     - master
 
-sudo: required
-
 dist: xenial
 
 services:


### PR DESCRIPTION
The sudo keyword will be fully deprecated.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>