### PR TITLE
suse: remove gdisk package

### DIFF
--- a/ceph-releases/ALL/opensuse/__CEPH_BASE_PACKAGES__
+++ b/ceph-releases/ALL/opensuse/__CEPH_BASE_PACKAGES__
@@ -1,0 +1,14 @@
+\
+        ca-certificates \
+        e2fsprogs \
+        ceph-common__ENV_[CEPH_POINT_RELEASE]__  \
+        ceph-mon__ENV_[CEPH_POINT_RELEASE]__  \
+        ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
+        ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
+        rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
+        __CEPH_MGR_PACKAGE__\
+        kmod \
+        lvm2 \
+        __RADOSGW_PACKAGE__ \
+        __GANESHA_PACKAGES__ \
+        __ISCSI_PACKAGES__


### PR DESCRIPTION
The current repos do not provide the 'gdisk' package, so removing it
temporarily until this is fixed. This is breaking the image build CI.

Signed-off-by: Sébastien Han <seb@redhat.com>