### PR TITLE
mon: ability to change mon listening port

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -183,6 +183,6 @@ function start_mon {
     # DO NOT TOUCH IT, IT MUST BE PRESENT
     DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
     log "SUCCESS"
-    exec /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}:6789"
+    exec /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}:${MON_PORT}"
   fi
 }

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -66,6 +66,7 @@ fi
 : "${GANESHA_EPOCH:=""}" # For restarting
 : "${MGR_IP:=0.0.0.0}"
 : "${CEPH_ARCH:=$(uname -m)}"
+: "${MON_PORT:=6789}"
 
 # Make sure to change the value of one another if user changes some of the default values
 while read -r line; do


### PR DESCRIPTION
You can now set '-e MON_PORT' to anything and the monitor will listen on
that port if possible.

Signed-off-by: Sébastien Han <seb@redhat.com>