### PR TITLE
daemon-base: Add ceph-grafana-dashboards

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -7,6 +7,7 @@
         ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
         __CEPH_MGR_PACKAGE__\
+	ceph-grafana-dashboards__ENV_[CEPH_POINT_RELEASE]__  \
         kmod \
         lvm2 \
         gdisk \


### PR DESCRIPTION
This is needed for full functionality of the mgr dashboard module.

Signed-off-by: Zack Cerza <zack@redhat.com>