### PR TITLE
daemon/osd: Allow to override tcmalloc value

### DIFF
--- a/src/daemon/start_osd.sh
+++ b/src/daemon/start_osd.sh
@@ -2,6 +2,9 @@
 set -e
 
 if is_redhat; then
+  if [[ -n "${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}" ]]; then
+    sed -i -e "s/^\(TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES\)=.*/\1=${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}/" /etc/sysconfig/ceph
+  fi
   source /etc/sysconfig/ceph
 fi
 


### PR DESCRIPTION
The TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES variable is defined in the
/etc/sysconfig/ceph file and sourced during the start_osd.sh script
execution.
If this variable has been set using ceph-ansible (via the variable
called ceph_tcmalloc_max_total_thread_cache), the container will have
this variable defined as an environment variable.
Unfortunately the source of the /etc/sysconfig/ceph file will
override the value defined by the environment variable.

This commit aims to set the right tcmalloc value when the environment
variable is present.