### PR TITLE
osd: apply memory tuning on nautilus only

### DIFF
--- a/src/daemon/config.static.sh
+++ b/src/daemon/config.static.sh
@@ -23,7 +23,7 @@ function get_mon_config {
 [global]
 fsid = $fsid
 mon initial members = ${MON_NAME}
-mon host = ${MON_IP}
+mon host = v2:${MON_IP}:${MON_PORT}/0
 osd crush chooseleaf type = 0
 osd journal size = 100
 public network = ${CEPH_PUBLIC_NETWORK}
@@ -84,7 +84,7 @@ ENDHERE
       mv /etc/ceph/monmap "$MONMAP"
     else
       # Generate initial monitor map
-      monmaptool --create --add "${MON_NAME}" "${MON_IP}:6789" --fsid "${fsid}" "$MONMAP"
+      monmaptool --create --add "${MON_NAME}" "${MON_IP}:${MON_PORT}" --fsid "${fsid}" "$MONMAP"
     fi
     chown "${CHOWN_OPT[@]}" ceph. "$MONMAP"
   fi

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -62,6 +62,9 @@ fi
 # MON #
 #######
 function bootstrap_mon {
+  if [[ "$CEPH_VERSION" != "luminous" ]] && [[ "$CEPH_VERSION" != "mimic" ]] ; then
+    MON_PORT=3300
+  fi
   # shellcheck disable=SC1091
   source /opt/ceph-container/bin/start_mon.sh
   start_mon

--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -174,7 +174,10 @@ function start_mon {
     fi
   fi
 
-  tune_memory "$available_memory"
+  # Apply the tuning on Nautilus and above only since the values applied are causing the ceph-osd to crash on earlier versions
+  if [[ "$CEPH_VERSION" != "luminous" ]] && [[ "$CEPH_VERSION" != "mimic" ]] ; then
+    tune_memory "$available_memory"
+  fi
 
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then

--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -162,7 +162,7 @@ function start_mon {
       fi
       # Be sure that the mon name of the current monitor in the monmap is equal to ${MON_NAME}.
       # Names can be different in case of full qualifed hostnames
-      MON_ID=$(monmaptool --print "${MONMAP}" | sed -n "s/^.*${MON_IP}:6789.*mon\\.//p")
+      MON_ID=$(monmaptool --print "${MONMAP}" | sed -n "s/^.*${MON_IP}:${MON_PORT}.*mon\\.//p")
       if [[ -n "$MON_ID" && "$MON_ID" != "$MON_NAME" ]]; then
         monmaptool --rm "$MON_ID" "$MONMAP" >/dev/null
         monmaptool --add "$MON_NAME" "$MON_IP" "$MONMAP" >/dev/null
@@ -170,7 +170,7 @@ function start_mon {
       ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" -i "${MON_NAME}" --inject-monmap "$MONMAP" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
     fi
     if [[ "$CEPH_DAEMON" != demo ]]; then
-      timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}:6789" || true
+      timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}":"${MON_PORT}" || true
     fi
   fi
 
@@ -181,7 +181,7 @@ function start_mon {
 
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then
-    /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}:6789"
+    /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}":"${MON_PORT}"
 
     if [ -n "$NEW_USER_KEYRING" ]; then
       echo "$NEW_USER_KEYRING" | ceph "${CLI_OPTS[@]}" auth import -i -

--- a/travis-builds/validate_demo_cluster.sh
+++ b/travis-builds/validate_demo_cluster.sh
@@ -7,7 +7,7 @@ set -xe
 #############
 function get_cluster_name {
   cluster=$(docker exec ceph-demo grep -R fsid /etc/ceph/ | egrep -o '^[^.]*')
-  DOCKER_COMMAND="docker exec ceph-demo ceph --cluster $(basename $cluster)"
+  DOCKER_COMMAND="docker exec ceph-demo ceph --connect-timeout 3 --cluster $(basename $cluster)"
 }
 
 function wait_for_daemon () {


### PR DESCRIPTION
The values applied are causing the ceph-osd to crash on earlier versions
thus we perform the memory tuning on Nautilus and above only.

Closes: https://github.com/ceph/ceph-container/issues/1293
Signed-off-by: Sébastien Han <seb@redhat.com>