### PR TITLE
set `noninteractive` when installing with apt-get

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -13,7 +13,7 @@ CEPH_RELEASES=(luminous mimic)
 #############
 
 function install_docker {
-  sudo apt-get install -y --force-yes docker.io
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker.io
   sudo systemctl start docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -32,7 +32,7 @@ function install_docker {
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   sudo apt-get update
-  sudo apt-get install -y --force-yes docker-ce
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
   sudo systemctl start docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes: sets the `noninteractive` value when calling out to `apt-get` so that the system doesn't need to prompt for anything, preventing potential hangs

Which issue is resolved by this Pull Request: https://github.com/ceph/ceph-container/issues/1306
Resolves #

