### PR TITLE
Add ceph-mgr-rook to nautilus images

### DIFF
--- a/ceph-releases/luminous/daemon-base/__CEPH_MGR_PACKAGE__
+++ b/ceph-releases/luminous/daemon-base/__CEPH_MGR_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-mgr__ENV_[CEPH_POINT_RELEASE]__

--- a/ceph-releases/mimic/daemon-base/__CEPH_MGR_PACKAGE__
+++ b/ceph-releases/mimic/daemon-base/__CEPH_MGR_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-mgr__ENV_[CEPH_POINT_RELEASE]__

--- a/src/daemon-base/__CEPH_MGR_PACKAGE__
+++ b/src/daemon-base/__CEPH_MGR_PACKAGE__
@@ -1,1 +1,2 @@
-ceph-mgr__ENV_[CEPH_POINT_RELEASE]__
+ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
We want ceph-mgr-rook to be installed on nautilus and later images, but
earlier releases didn't have that package. Add it to the base
`__CEPH_MGR_PACKAGE__` file and add override files for luminous and mimic.

Signed-off-by: Jeff Layton <jlayton@redhat.com>