### PR TITLE
Add dashboard mgr module by default

### DIFF
--- a/src/daemon-base/__CEPH_MGR_PACKAGE__
+++ b/src/daemon-base/__CEPH_MGR_PACKAGE__
@@ -1,2 +1,3 @@
 ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
rook expects the dashboard to be available.

Signed-off-by: Jeff Layton <jlayton@redhat.com>