### PR TITLE
Revert "contrib: add nautilus to ceph/ceph build scripts"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ FLAVORS ?= \
 	luminous,opensuse,42.3 \
 	luminous,centos,7 \
 	mimic,centos,7 \
-	nautilus,centos,7 \
 	master,centos,7
 
 TAG_REGISTRY ?= ceph

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
-AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
+X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
+AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
Reverts ceph/ceph-container#1316

We are reverting for multiple reasons:

* no package for ganesha on Nautilus yet
* no packages at all of arm64
* no ceph-release file, so no repo file can be fetched

Revert while requisite Nautilus packages are not available.