### PR TITLE
contrib: add nautilus image to docker hub

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -12,7 +12,7 @@ LATEST_COMMIT_SHA=$(git rev-parse --short HEAD)
 TAGGED_HEAD=false # does HEAD is on a tag ?
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'master' position in the array, this will break the 'latest' tag
-  CEPH_RELEASES=(master luminous mimic)
+  CEPH_RELEASES=(master luminous mimic nautilus)
 fi
 
 HOST_ARCH=$(uname -m)


### PR DESCRIPTION
The first RCs are out and Nautilus is around the corner, so we can start
building images from the RC.

Signed-off-by: Sébastien Han <seb@redhat.com>