### PR TITLE
contrib: add arm64 image build for nautilus

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -14,7 +14,7 @@ trap 'exit $?' ERR
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
 X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
-AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7"
+AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
We now have packages for arm64 for Nautilus here:
http://download.ceph.com/rpm-nautilus/el7/aarch64/ so we can build that
new image.

Signed-off-by: Sébastien Han <seb@redhat.com>