### PR TITLE
daemon: Add support for python3

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -135,7 +135,7 @@ function bootstrap_osd {
 
   # activate OSD
   if [[ -n "$OSD_DEVICE" ]]; then
-    OSD_FSID="$(ceph-volume lvm list --format json | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
+    OSD_FSID="$(ceph-volume lvm list --format json | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
     ceph-volume lvm activate --no-systemd --bluestore "${OSD_ID}" "${OSD_FSID}"
   fi
 
@@ -329,7 +329,7 @@ function bootstrap_sree {
 
   # start Sree
   pushd "$SREE_DIR"
-  python app.py &
+  $PYTHON app.py &
   popd
 }
 

--- a/src/daemon/osd_scenarios/osd_directory_single.sh
+++ b/src/daemon/osd_scenarios/osd_directory_single.sh
@@ -18,7 +18,7 @@ function osd_directory_single {
     else
       # check if the osd has a lock, if yes moving on, if not we run it
       # many thanks to Julien Danjou for the python piece
-      if python -c "import sys, fcntl, struct; l = fcntl.fcntl(open('${OSD_PATH}/fsid', 'a'), fcntl.F_GETLK, struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)); l_type, l_whence, l_start, l_len, l_pid, l_sysid = struct.unpack('hhllhh', l); sys.exit(0 if l_type == fcntl.F_UNLCK else 1)"; then
+      if $PYTHON -c "import sys, fcntl, struct; l = fcntl.fcntl(open('${OSD_PATH}/fsid', 'a'), fcntl.F_GETLK, struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)); l_type, l_whence, l_start, l_len, l_pid, l_sysid = struct.unpack('hhllhh', l); sys.exit(0 if l_type == fcntl.F_UNLCK else 1)"; then
         log "Looks like OSD: ${OSD_ID} is not started, starting it..."
         log "SUCCESS"
         exec ceph-osd "${DAEMON_OPTS[@]}" -i "${OSD_ID}" -k "$OSD_KEYRING"

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -6,16 +6,16 @@ function osd_volume_activate {
 
   CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
 
-  if ! echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
+  if ! echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
     log "OSD id $OSD_ID does not exist"
     exit 1
   fi
 
   # Find the OSD FSID from the OSD ID
-  OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
+  OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
 
   # Find the OSD type
-  OSD_TYPE="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"type\"])")"
+  OSD_TYPE="$(echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"type\"])")"
 
   # Discover the objectstore
   if [[ "data journal" =~ $OSD_TYPE ]]; then

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -102,6 +102,12 @@ if [[ "$KV_TYPE" == "etcd" ]]; then
   ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
 fi
 
+if is_available python; then
+  PYTHON=python
+else
+  PYTHON=python3
+fi
+
 # Internal variables
 MDS_KEYRING=/var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
 ADMIN_KEYRING=/etc/ceph/${CLUSTER}.client.admin.keyring

--- a/src/daemon/watch_mgr_health.sh
+++ b/src/daemon/watch_mgr_health.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IS_MGR_AVAIL=$(ceph "${CLI_OPTS[@]}" mgr dump | python -c "import json, sys; print json.load(sys.stdin)['available']")
+IS_MGR_AVAIL=$(ceph "${CLI_OPTS[@]}" mgr dump | $PYTHON -c "import json, sys; print(json.load(sys.stdin)['available'])")
 if [ "${IS_MGR_AVAIL}" == "True" ]; then
   exit 0
 else


### PR DESCRIPTION
Currently some entrypoint scripts were using python command. This
will in most of case refers to python 2 and not python 3.
Instead of hardcoding the python binary in the shell scripts we can
test if the binary exist and set the PYTHON variable.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1690093

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
