### PR TITLE
build: ability to build an image on a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ It is possible to build a container running the latest development release (mast
 This is only available on CentOS with the following command :
 `make FLAVORS="master,centos,7" build`
 
+Alternatively, you can build a container image based on `wip-*` branch:
 
+`make FLAVORS="wip-super-code,centos,7" build`
+
+To build your branch on Centos 7 on the `wip-super-code` branch.
 
 Core Components
 ---------------

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -4,7 +4,7 @@ bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-    if [ "${CEPH_VERSION}" == "master" ]; then \
+    if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
       REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
       echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \
@@ -22,8 +22,8 @@ bash -c ' \
 yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
 bash -c ' \
-  if [ "${CEPH_VERSION}" == "master" ]; then \
-    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=master&sha1=latest" | jq -a ".[0] | .url"); \
+  if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
   else \
     RELEASE_VER=1 ;\

--- a/maint-lib/ceph_version.sh
+++ b/maint-lib/ceph_version.sh
@@ -9,6 +9,19 @@ WHAT_TO_EXTRACT=$2
 CEPH_POINT_RELEASE=""
 CEPH_VERSION="${CEPH_VERSION_SPEC}"
 
+# If we pass a dev branch, we don't know the version so let's use the branch name as the ceph version
+if [[ $WHAT_TO_EXTRACT == "CEPH_POINT_RELEASE" ]]; then
+  if [[ $CEPH_VERSION =~ ^wip* ]]; then
+    echo $CEPH_POINT_RELEASE
+    exit 0
+  fi
+else
+  if [[ $CEPH_VERSION =~ ^wip* ]]; then
+    echo "$CEPH_VERSION"
+    exit 0
+  fi
+fi
+
 # Search for the two possible separators between CEPH_VERSION and CEPH_POINT_RELEASE
 # Let's consider CEPH_VERSION_SPEC=luminous-12.2.0-1
 for separator in "=" "-"; do


### PR DESCRIPTION
You can now build an image out of a branch like so:

`make FLAVORS="wip-dev,centos,7" build`

The branch name MUST start with 'wip'.

Signed-off-by: Sébastien Han <seb@redhat.com>