### PR TITLE
daemon/variables_entrypoint Fix python detection

### DIFF
--- a/ceph-releases/luminous/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/daemon/variables_entrypoint.sh
@@ -100,6 +100,12 @@ if [[ "$KV_TYPE" == "etcd" ]]; then
   ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
 fi
 
+if command -v python &>/dev/null; then
+  PYTHON=python
+else
+  PYTHON=python3
+fi
+
 # Internal variables
 MDS_KEYRING=/var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
 ADMIN_KEYRING=/etc/ceph/${CLUSTER}.client.admin.keyring

--- a/ceph-releases/mimic/daemon/variables_entrypoint.sh
+++ b/ceph-releases/mimic/daemon/variables_entrypoint.sh
@@ -100,6 +100,12 @@ if [[ "$KV_TYPE" == "etcd" ]]; then
   ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
 fi
 
+if command -v python &>/dev/null; then
+  PYTHON=python
+else
+  PYTHON=python3
+fi
+
 # Internal variables
 MDS_KEYRING=/var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
 ADMIN_KEYRING=/etc/ceph/${CLUSTER}.client.admin.keyring

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -102,7 +102,7 @@ if [[ "$KV_TYPE" == "etcd" ]]; then
   ETCDCTL_OPTS=(--peers ${ETCD_SCHEMA}${KV_IP}:${KV_PORT})
 fi
 
-if is_available python; then
+if command -v python &>/dev/null; then
   PYTHON=python
 else
   PYTHON=python3


### PR DESCRIPTION
778c7f9 introduces the python binary detection based on the
is_available function. Unfortunately this function is source after
variables_entrypoint.sh in the entrypoint so it's not possible to
use it.
Also Luminous and Mimic release have a different variables entrypoint
script they're modified to reflect the python change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>