### PR TITLE
base: remove lang.sh

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,5 @@
 echo 'Postinstall cleanup' && \
- ( rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt}" && \
+ (rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
    yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__)

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -2,4 +2,5 @@ echo 'Postinstall cleanup' && \
  ( yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf )
+   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf \
+   rm -f /etc/profile.d/lang.sh )

--- a/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,4 +1,5 @@
 echo 'Postinstall cleanup' && \
  ( yum clean all && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf )
+   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf \
+   rm -f /etc/profile.d/lang.sh )


### PR DESCRIPTION
When entering the container we always get this annoying warning:

bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_COLLATE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_MESSAGES: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_NUMERIC: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_TIME: cannot change locale (en_US.UTF-8): No such file or directory

Because the locale is not available, to fix this issue let's remove the
lang file which contains the local to set.

Signed-off-by: Sébastien Han <seb@redhat.com>