### PR TITLE
base: add packages for ceph-csi

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -12,4 +12,5 @@
         gdisk \
         __RADOSGW_PACKAGE__ \
         __GANESHA_PACKAGES__ \
-        __ISCSI_PACKAGES__
+        __ISCSI_PACKAGES__ \
+        __CSI_PACKAGES__

--- a/src/daemon-base/__CSI_PACKAGES__
+++ b/src/daemon-base/__CSI_PACKAGES__
@@ -1,0 +1,1 @@
+ceph-fuse attr rbd-nbd


### PR DESCRIPTION
We want to use our base image for ceph-csi. ceph-csi needs extra
packages so we are adding them.

Signed-off-by: Sébastien Han <seb@redhat.com>