### PR TITLE
[skip ci] contrib: Do not show HEAD ref in git ls-remote

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -65,7 +65,7 @@ function download_cn {
 
 function compare_docker_hub_and_github_tags {
   # build an array with the list of tags from github
-  for tag_github in $(grep_sort_tags git ls-remote --tags 2>/dev/null); do
+  for tag_github in $(grep_sort_tags git ls-remote --tags --refs 2>/dev/null); do
     tags_github_array+=("$tag_github")
   done
 


### PR DESCRIPTION
When the latest tag is the same than the HEAD ref we have two refs to
that tag causing the script to not build the avaiblable tag.

```console
$ git ls-remote --tags
(...)
4101899ab55e916ad7da625daf330d6ea5a11d09	refs/tags/v4.0.0rc1
15d8573c1d9dfedbda9ca012f3609497704e34af	refs/tags/v4.0.0rc1^{}
```

This build script will then throw an error like:

```console
+ echo 'ERROR: it looks like more than one tag are not built, see
v4.0.0rc1 v4.0.0rc1.'
ERROR: it looks like more than one tag are not built, see v4.0.0rc1
v4.0.0rc1.
+ git checkout 'refs/tags/v4.0.0rc1 v4.0.0rc1'
error: pathspec 'refs/tags/v4.0.0rc1 v4.0.0rc1' did not match any
file(s) known to git.
++ git branch -r --contains 'tags/v4.0.0rc1 v4.0.0rc1'
++ grep -Eo 'stable-[0-9].[0-9]'
error: malformed object name tags/v4.0.0rc1 v4.0.0rc1
```

Using the --refs option with git ls-remote will not display the HEAD
ref.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>