### PR TITLE
travis: Remove civetweb references for demo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 install:
   - sudo ./travis-builds/prepare_osd_fs.sh
-  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e RGW_FRONTEND_TYPE=beast -e RGW_CIVETWEB_OPTIONS="num_threads=100" -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_CIVETWEB_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=test -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_VERSION=v0.1 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:"travis-build-$TRAVIS_BRANCH-$TRAVIS_COMMIT"-master-centos-7-x86_64 demo
+  - docker run -d --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -e RGW_FRONTEND_TYPE=beast -e BLUESTORE_BLOCK_SIZE=15GB -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=test -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_VERSION=v0.1 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=travis ceph/daemon:"travis-build-$TRAVIS_BRANCH-$TRAVIS_COMMIT"-master-centos-7-x86_64 demo
   - sleep 5  # let's give the container 5sec to create its Ceph config file
 
 script:

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -222,8 +222,8 @@ function bootstrap_demo_user {
     radosgw-admin "${CLI_OPTS[@]}" caps add --caps="buckets=*;users=*;usage=*;metadata=*" --uid="$CEPH_DEMO_UID"
 
     # Use rgw port
-    sed -i "s/host_base = localhost/host_base = ${RGW_NAME}:${RGW_CIVETWEB_PORT}/" /root/.s3cfg
-    sed -i "s/host_bucket = localhost/host_bucket = ${RGW_NAME}:${RGW_CIVETWEB_PORT}/" /root/.s3cfg
+    sed -i "s/host_base = localhost/host_base = ${RGW_NAME}:${RGW_FRONTEND_PORT}/" /root/.s3cfg
+    sed -i "s/host_bucket = localhost/host_bucket = ${RGW_NAME}:${RGW_FRONTEND_PORT}/" /root/.s3cfg
 
     if [ -n "$CEPH_DEMO_BUCKET" ]; then
       log "Creating bucket..."
@@ -318,11 +318,11 @@ function bootstrap_sree {
     SECRET_KEY=$(awk '/Secret key/ {print $3}' /opt/ceph-container/tmp/ceph-demo-user)
 
     pushd "$SREE_DIR"
-    sed -i "s|ENDPOINT|http://${EXPOSED_IP}:${RGW_CIVETWEB_PORT}|" static/js/base.js
+    sed -i "s|ENDPOINT|http://${EXPOSED_IP}:${RGW_FRONTEND_PORT}|" static/js/base.js
     sed -i "s/ACCESS_KEY/$ACCESS_KEY/" static/js/base.js
     sed -i "s/SECRET_KEY/$SECRET_KEY/" static/js/base.js
     mv sree.cfg.sample sree.cfg
-    sed -i "s/RGW_CIVETWEB_PORT_VALUE/$RGW_CIVETWEB_PORT/" sree.cfg
+    sed -i "s/RGW_CIVETWEB_PORT_VALUE/$RGW_FRONTEND_PORT/" sree.cfg
     sed -i "s/SREE_PORT_VALUE/$SREE_PORT/" sree.cfg
     popd
   fi


### PR DESCRIPTION
We now are using beast as radosgw frontend so it doesn't make sense
to keep the civetweb environment variables.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>