### PR TITLE
base: fix lang.sh removal on RHEL

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -2,5 +2,5 @@ echo 'Postinstall cleanup' && \
  ( yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf \
+   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \
    rm -f /etc/profile.d/lang.sh )

--- a/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,5 @@
 echo 'Postinstall cleanup' && \
  ( yum clean all && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf \
+   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \
    rm -f /etc/profile.d/lang.sh )


### PR DESCRIPTION
Commit 15d8573c1d9dfedbda9ca012f3609497704e34af introduced a syntax error because we omitted the `&&`, so `sed` was trying to interpret the `rm`, `-f` etc. as additional arguments.

Add the `&&` so the shell interprets the `sed` and `rm` as two separate commands.
