### PR TITLE
contrib: Add alpha/beta tag filtering

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -50,7 +50,7 @@ function enable_experimental_docker_cli {
 }
 
 function grep_sort_tags {
-  "$@" | grep -oE 'v[3-9].[0-9]*.[0-9]|v[3-9].[0-9]*.[0-9][rc]{2}?[0-9]{1,2}?' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
+  "$@" | grep -oE 'v[3-9].[0-9]*.[0-9]|v[3-9].[0-9]*.[0-9](alpha|beta|rc)[0-9]{1,2}?' | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
 }
 
 function download_cn {


### PR DESCRIPTION
We currently only filter image tags that are like:
  - vX.X.X
  - vX.X.XrcX

Unfortunately we have a v4.0.0beta tag present on docker hub. Due
to the regex this tag is considered as v4.0.0 so we can build this
tag.
This commit update the tags regex and add alpha and beta suffix like
for rc.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>