### PR TITLE
contrib/ceph-build-config.sh: Fix version sort

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -238,13 +238,13 @@ function get_ceph_versions_on_server () {
   local pkg_regex=">ceph-[0-9.]+-[0-9]+"
   # pkg_list is returned in the form ">ceph-12.0.0 >ceph-12.0.1 >ceph-12.0.2 ..."
   local pkg_list
-  pkg_list="$(curl --silent "${server_url}" | grep --extended-regexp --only-matching "${pkg_regex}")"
+  # Make sure the versions are sorted. This should always be the case, but it's better to be safe.
+  pkg_list="$(curl --silent "${server_url}" | grep --extended-regexp --only-matching "${pkg_regex}" | sort --version-sort)"
   local version_list=""  # version strings only
   for pkg in $pkg_list; do
     version_list="${version_list} ${pkg#>ceph-}"  # strip '>ceph-' text from beginning of pkg names
   done
-  # Make sure the versions are sorted. This should always be the case, but it's better to be safe.
-  echo "${version_list}" | sort --version-sort
+  echo "${version_list}"
 }
 
 


### PR DESCRIPTION
Version sort doesn't work for list as a string. You need a new line
between each element.

```console
$ echo "12.2.0 12.1.9 12.2.3" | sort --version-sort
12.2.0 12.1.9 12.2.3

$ echo -e "12.2.0\n12.1.9\n12.2.3" | sort --version-sort
12.1.9
12.2.0
12.2.3
```

Due to this issue the package version are not listed correctly on the
z release (double z digit aren't take in count).

Before:
12.2.1-0 12.2.10-0 12.2.11-0 12.2.2-0 12.2.3-0
After:
12.2.1-0 12.2.2-0 12.2.3-0 12.2.10-0 12.2.11-0

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>