### PR TITLE
daemon-base: Add ceph point release to csi pkgs

### DIFF
--- a/src/daemon-base/__CSI_PACKAGES__
+++ b/src/daemon-base/__CSI_PACKAGES__
@@ -1,1 +1,3 @@
-ceph-fuse attr rbd-nbd
+attr \
+ceph-fuse__ENV_[CEPH_POINT_RELEASE]__ \
+rbd-nbd__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
Whithout the ceph point release environment variable the CSI packages
create a dependency issue during container image build.
When trying to build an old release, all ceph packages are pinned to
that version except ceph-fuse and rbd-nbd that are using the latest
one.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>