### PR TITLE
daemon-base: Add ceph-mgr-diskprediction-local pkg

### DIFF
--- a/src/daemon-base/__CEPH_MGR_PACKAGE__
+++ b/src/daemon-base/__CEPH_MGR_PACKAGE__
@@ -1,3 +1,4 @@
 ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
Add diskprediction_local mgr module in order to have the same default
modules present in ceph-ansible and ceph-container.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>