### PR TITLE
rhel8: rm ubi.repo

### DIFF
--- a/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -1,5 +1,7 @@
 RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
 
+RUN rm -f /etc/yum.repos.d/ubi.repo
+
 # Editing /etc/redhat-storage-server release file
 RUN echo "Red Hat Ceph Storage Server 4 (Container)" > /etc/redhat-storage-release
 


### PR DESCRIPTION
The RHEL 8's UBI (universal base image) has a `ubi.repo` file that points at repositories that are only available with subscription-manager.

If these repositories are not available, dnf will exit with an error ([rhbz#1701290](https://bugzilla.redhat.com/show_bug.cgi?id=1701290)). We currently build the Ceph RHEL images in an environment that does not use subscription-manager, so dnf cannot access the UBI content, and it bails out at this point.

We already get RHEL 8 build content dynamically from OSBS's Yum repository injection feature, so we do not need anything in this ubi.repo file.

Delete the ubi.repo file entirely to avoid the errors associated with the repositories here.

UBI is a new initiative, so maybe we will find a better workaround in the future.