### PR TITLE
daemon: Fix mds permissions to client.admin

### DIFF
--- a/src/daemon/config.kv.etcd.sh
+++ b/src/daemon/config.kv.etcd.sh
@@ -63,7 +63,7 @@ function get_mon_config {
       # Generate custom provided administrator key
       CLI+=("--add-key=$ADMIN_SECRET")
     fi
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw ${RBD_MIRROR_BOOTSTRAP_KEYRING}:Rbd; do

--- a/src/daemon/config.static.sh
+++ b/src/daemon/config.static.sh
@@ -67,7 +67,7 @@ ENDHERE
       # Generate custom provided administrator key
       CLI+=("--add-key=$ADMIN_SECRET")
     fi
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring -n client.admin "${CLI[@]}" --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring -n client.admin "${CLI[@]}" --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
   fi
 
   if [ ! -e "$MON_KEYRING" ]; then


### PR DESCRIPTION
The administrator keyring needs full capabilities on mds like mon,
osd and mgr.
Whithout this, the client.admin key won't be able to run commands
against mds (like ceph tell mds.0 session ls)

Resolves: #1333

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit bc192aea2e0057df13f2330073428f5eff7e1cff)