### PR TITLE
osd_disk_prepare: Don't always create db and wal

### DIFF
--- a/src/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/src/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -37,11 +37,13 @@ function osd_disk_prepare {
   fi
   if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
     CEPH_DISK_CLI_OPTS+=(--bluestore)
+    if [[ "${OSD_BLUESTORE_BLOCK_WAL}" != "${OSD_DEVICE}" ]]; then
+      CEPH_DISK_CLI_OPTS+=(--block.wal "${OSD_BLUESTORE_BLOCK_WAL}" --block.wal-uuid "${OSD_BLUESTORE_BLOCK_WAL_UUID}")
+    fi
+    if [[ "${OSD_BLUESTORE_BLOCK_DB}" != "${OSD_DEVICE}" ]]; then
+      CEPH_DISK_CLI_OPTS+=(--block.db "${OSD_BLUESTORE_BLOCK_DB}" --block.db-uuid "${OSD_BLUESTORE_BLOCK_DB_UUID}")
+    fi
     ceph-disk -v prepare "${CEPH_DISK_CLI_OPTS[@]}" \
-    --block.wal "${OSD_BLUESTORE_BLOCK_WAL}" \
-    --block.wal-uuid "${OSD_BLUESTORE_BLOCK_WAL_UUID}" \
-    --block.db "${OSD_BLUESTORE_BLOCK_DB}" \
-    --block.db-uuid "${OSD_BLUESTORE_BLOCK_DB_UUID}" \
     --block-uuid "${OSD_BLUESTORE_BLOCK_UUID}" \
     "${OSD_DEVICE}"
   elif [[ "${OSD_FILESTORE}" -eq 1 ]]; then


### PR DESCRIPTION
We only need to create the block.db and block.wal partitions when
there's a dedicated devices for them.
This is only for bluestore objectstore.

* Collocated scenario now:
```console
/dev/sdb :
 /dev/sdb1 ceph data, active, cluster ceph, osd.0, block /dev/sdb2, block.db /dev/sdb3, block.wal /dev/sdb4
 /dev/sdb2 ceph block, for /dev/sdb1
 /dev/sdb3 ceph block.db, for /dev/sdb1
 /dev/sdb4 ceph block.wal, for /dev/sdb1
```

* Collocated scenario should be (the same than non containerized):
```console
/dev/sdb :
 /dev/sdb1 ceph data, active, cluster ceph, osd.0, block /dev/sdb2
 /dev/sdb2 ceph block, for /dev/sdb1
```

* Non-collocated scenario now:
```console
/dev/sdb :
 /dev/sdb1 ceph data, active, cluster ceph, osd.0, block /dev/sdb2, block.db /dev/sde1, block.wal /dev/sdb4
 /dev/sdb2 ceph block, for /dev/sdb1
 /dev/sdb4 ceph block.wal, for /dev/sdb1
/dev/sde :
 /dev/sde1 ceph block.db, for /dev/sdb1
```

* Non-collocated scenario should be (the same than non containerized):
```console
/dev/sdb :
 /dev/sdb1 ceph data, active, cluster ceph, osd.0, block /dev/sdb2, block.db /dev/sde1
 /dev/sdb2 ceph block, for /dev/sdb1
/dev/sde :
 /dev/sde1 ceph block.db, for /dev/sdb1
```

See also https://github.com/ceph/ceph-ansible/pull/3922

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1685253

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>