### PR TITLE
Only check RGW_FRONTEND if rgw is used

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -33,26 +33,6 @@ MGR_IP=$MON_IP
 : "${RBD_POOL:="rbd"}"
 
 
-if [[ "$RGW_FRONTEND_TYPE" == "civetweb" ]]; then
-  RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS port=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
-elif [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
-  RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS endpoint=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
-else
-  log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE"
-  exit 1
-fi
-
-: "${RGW_FRONTEND:="$RGW_FRONTEND_TYPE $RGW_FRONTED_OPTIONS"}"
-
-if [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
-  if [[ "$CEPH_VERSION" == "luminous" ]]; then
-    RGW_FRONTEND_TYPE=beast
-    log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE for your Ceph release $CEPH_VERSION, use at least the Mimic version."
-    exit 1
-  fi
-fi
-
-
 #######
 # MON #
 #######
@@ -166,6 +146,25 @@ function bootstrap_mds {
 # RGW #
 #######
 function bootstrap_rgw {
+  if [[ "$RGW_FRONTEND_TYPE" == "civetweb" ]]; then
+    RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS port=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
+  elif [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
+    RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS endpoint=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
+  else
+    log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE"
+    exit 1
+  fi
+
+  : "${RGW_FRONTEND:="$RGW_FRONTEND_TYPE $RGW_FRONTED_OPTIONS"}"
+
+  if [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
+    if [[ "$CEPH_VERSION" == "luminous" ]]; then
+      RGW_FRONTEND_TYPE=beast
+      log "ERROR: unsupported rgw backend type $RGW_FRONTEND_TYPE for your Ceph release $CEPH_VERSION, use at least the Mimic version."
+      exit 1
+    fi
+  fi
+
   if [ ! -e "$RGW_PATH"/keyring ]; then
     # bootstrap RGW
     mkdir -p "$RGW_PATH" /var/log/ceph


### PR DESCRIPTION
If rgw is not used at all (eg when running a minimal demo container with
only osd/mds) it still needs RGW_FRONTEND to be set when using Luminous.

This patch only tests/warns if rgw will be used.

Closes ceph/ceph-container#1358

Signed-off-by: Christian Schwede <cschwede@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
