### PR TITLE
rhel8: drop "-rhel8" from component label

### DIFF
--- a/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/rhel8/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -11,7 +11,7 @@ EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 LABEL version=4
 
 # Build specific labels
-LABEL com.redhat.component="rhceph-rhel8-container"
+LABEL com.redhat.component="rhceph-container"
 LABEL name="rhceph"
 LABEL description="Red Hat Ceph Storage 4"
 LABEL summary="Provides the latest Red Hat Ceph Storage 4 on RHEL 8 in a fully featured and supported base image."


### PR DESCRIPTION
For the latest RH Ceph Storage on RHEL 8, we're going to simplify the
component name to avoid the "rhel" string and just go with "rhceph".
This matches what other products are doing for el8.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 425bc9a6724fd6b82c042aff0967df51239c62e5)