### PR TITLE
contrib/commit-rhcs.sh: Nautilus on RHEL 8

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -50,7 +50,7 @@ pushd "$CEPH_CONTAINER_DIR"
   contrib/compose-rhcs.sh
 popd > /dev/null
 
-COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/luminous-rhel7-7-released-x86_64/composed
+COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/nautilus-rhel8-8-released-x86_64/composed
 
 if [ ! -d "$COMPOSED_DIR" ]; then
   fatal "There is no composed directory. Looks like the build failed !"


### PR DESCRIPTION
For the master branch, we just care about Nautilus and RHEL 8.
In addition of d2f524e.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>