### PR TITLE
Fix monmap_command for MON_HEALTH daemon

### DIFF
--- a/src/daemon/check_zombie_mons.py
+++ b/src/daemon/check_zombie_mons.py
@@ -17,8 +17,8 @@ else:
         '-o template' \
         ' --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'  # noqa E501
 
-monmap_command = "ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && '\
-    'monmaptool -f /tmp/monmap --print"
+monmap_command = 'ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && '\
+    'monmaptool -f /tmp/monmap --print'
 
 
 def extract_mons_from_monmap():


### PR DESCRIPTION
Hi, for me the MON_HEALTH daemon  is not working.

The error:
```2019-05-14 16:05:44  /opt/ceph-container/bin/entrypoint.sh: Checking for zombie mons
got monmap epoch 9
/bin/sh:     monmaptool: command not found
Traceback (most recent call last):
  File "/opt/ceph-container/bin/check_zombie_mons.py", line 39, in <module>
    current_mons = extract_mons_from_monmap()
  File "/opt/ceph-container/bin/check_zombie_mons.py", line 25, in extract_mons_from_monmap
    monmap = subprocess.check_output(monmap_command, shell=True)
  File "/usr/lib64/python2.7/subprocess.py", line 575, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && '    'monmaptool -f /tmp/monmap --print' returned non-zero exit status 127```

The error is fixed by this pull request.