### PR TITLE
contrib/build-push-ceph: Add arm64 for nautilus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ ALL_BUILDABLE_FLAVORS := \
 	luminous,opensuse,42.3 \
 	luminous,debian,9 \
 	mimic,centos,7 \
+	nautilus,centos,7 \
 	master,centos,7
 
 # ==============================================================================

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -5,7 +5,7 @@ set -ex
 # VARIABLES #
 #############
 
-CEPH_RELEASES=(luminous mimic)
+CEPH_RELEASES=(luminous mimic nautilus)
 
 
 #############

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -201,7 +201,7 @@ function create_registry_manifest {
   # This should normally work, by the time we get here the arm64 image should have been built and pushed
   # IIRC docker manisfest will fail if the image does not exist
   for image in daemon-base daemon; do
-    for ceph_release in luminous mimic; do
+    for ceph_release in ${CEPH_RELEASES[@]:1}; do
       TARGET_RELEASE="ceph/${image}:${RELEASE}-${ceph_release}-centos-7"
       DOCKER_IMAGES="$TARGET_RELEASE ${TARGET_RELEASE}-x86_64"
 


### PR DESCRIPTION
12ab4d2 adds arm64 to ceph-build-config script but there's some
missing pieces in order to build arm64 nautilus image.
This also adds nautilus to the registry manifest creation because
we now have multiple arch for that release too (the same way than
luminous and mimic)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>