### PR TITLE
maint-lib/makelib.mk: long-form not supported on mac os

### DIFF
--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -2,7 +2,7 @@
 # Can be overridden, but don't change the ordering, because the images are built atop each other
 IMAGES_TO_BUILD ?= daemon-base daemon
 
-HOST_ARCH ?= $(shell uname --machine)
+HOST_ARCH ?= $(shell uname -m)
 
 
 # Export all relevant environment variables from a flavor spec in the format:


### PR DESCRIPTION
Description of your changes: Allows to build images from Mac OS

Checklist:
- Documentation has been updated, if necessary: not needed
- Pending release notes updated with breaking and/or notable changes, if necessary: not needed 
