### PR TITLE
fix broken symlink for centos-arm64 __RADOSGW_PACKAGES__ override

### DIFF
--- a/ceph-releases/ALL/centos-arm64/daemon-base/__RADOSGW_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__RADOSGW_PACKAGES__
@@ -1,1 +1,1 @@
-../../centos/daemon-base/__RADOSGW_PACKAGE__
+../../centos/daemon-base/__RADOSGW_PACKAGES__


### PR DESCRIPTION
58d2eea161691f1a1b444c464f2ad2ca790a4c5e missed to fix this symlink.
This commit fixes it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>