### PR TITLE
Makefile: disable openSUSE 42.3 luminous build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	luminous,opensuse,42.3 \
 	luminous,centos,7 \
 	mimic,centos,7 \
 	nautilus,centos,7 \


### PR DESCRIPTION
The openSUSE 42.3 luminous build isn't working anymore preventing to
build the other container images.
This is temporary until the issue is resolved.

See: https://github.com/ceph/ceph-container/issues/1387

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>