### PR TITLE
populate_kv.sh: create client_host directory once

### DIFF
--- a/src/daemon/populate_kv.sh
+++ b/src/daemon/populate_kv.sh
@@ -8,7 +8,6 @@ function kv {
   read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
-  etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}/client_host" || log "client_host already exists"
 }
 
 function populate_kv {
@@ -18,6 +17,7 @@ function populate_kv {
   fi
   case "$KV_TYPE" in
     etcd)
+      etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" mkdir "${CLUSTER_PATH}/client_host" || log "client_host already exists"
       # if ceph.defaults found in /etc/ceph/ use that
       if [[ -e "/etc/ceph/ceph.defaults" ]]; then
         local defaults_path="/etc/ceph/ceph.defaults"


### PR DESCRIPTION
The client_host directory command creation is called for every keys
present in the ceph configuration.
We only need to call the mkdir command once outsite the kv function.

Resolves: #1197

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>