### PR TITLE
maint-lib/replace.py: use utf-8 decoding on file

### DIFF
--- a/maint-lib/stagelib/replace.py
+++ b/maint-lib/stagelib/replace.py
@@ -22,8 +22,8 @@ PARENTHETICAL_LOGTEXT = '        {:>80}     {}'
 # Read text from the file
 def _get_file_text(file_path):
     try:
-        with open(file_path, 'r') as txtfile:
-            return txtfile.read()
+        with open(file_path, 'rb') as txtfile:
+            return txtfile.read().decode('UTF-8')
     except (OSError, IOError) as o:
         IOOSErrorGracefulFail(o, "Cannot read or decode {} \n".format(file_path))
 


### PR DESCRIPTION
The replace.py script doesn't work on python 3.6 because the content
of the file read is using the default ascii encoding.
We should for the utf-8 encoding instead.

Resolves: #1182

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>