### PR TITLE
centos: Update ceph-iscsi repo/pkgs for nautilus

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,1 +1,1 @@
-tcmu-runner ceph-iscsi-config ceph-iscsi-cli python-rtslib
+tcmu-runner ceph-iscsi python-rtslib

--- a/ceph-releases/luminous/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/luminous/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -14,9 +14,10 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi && \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    for repo in tcmu-runner python-rtslib ceph-iscsi; do \
+    for repo in tcmu-runner python-rtslib; do \
       curl -L https://shaman.ceph.com/api/repos/$repo/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/$repo.repo ; \
     done ; \
+    curl -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
   fi' && \
 yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \

--- a/ceph-releases/luminous/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/luminous/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,0 +1,1 @@
+tcmu-runner ceph-iscsi-config ceph-iscsi-cli python-rtslib

--- a/ceph-releases/mimic/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/mimic/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -14,9 +14,10 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi && \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    for repo in tcmu-runner python-rtslib ceph-iscsi; do \
+    for repo in tcmu-runner python-rtslib; do \
       curl -L https://shaman.ceph.com/api/repos/$repo/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/$repo.repo ; \
     done ; \
+    curl -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
   fi' && \
 yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \

--- a/ceph-releases/mimic/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/mimic/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,0 +1,1 @@
+tcmu-runner ceph-iscsi-config ceph-iscsi-cli python-rtslib


### PR DESCRIPTION
With nautilus we have to use ceph-iscsi 3.x which uses a combined
ceph-iscsi repository and package (ceph-iscsi).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>