### PR TITLE
daemon: create log directories for rbd target

### DIFF
--- a/src/daemon/start_rbd_target_api.sh
+++ b/src/daemon/start_rbd_target_api.sh
@@ -16,6 +16,9 @@ function start_rbd_target_api {
   # mount configfs at /sys/kernel/config
   mount -t configfs none /sys/kernel/config
 
+  # create the log directory
+  mkdir -p /var/log/rbd-target-api
+
   log "SUCCESS"
   # start rbd-target-api
   exec /usr/bin/rbd-target-api

--- a/src/daemon/start_rbd_target_gw.sh
+++ b/src/daemon/start_rbd_target_gw.sh
@@ -16,6 +16,9 @@ function start_rbd_target_gw {
   # mount configfs at /sys/kernel/config
   mount -t configfs none /sys/kernel/config
 
+  # create the log directory
+  mkdir -p /var/log/rbd-target-gw
+
   log "SUCCESS"
   # start rbd-target-gw
   exec /usr/bin/rbd-target-gw


### PR DESCRIPTION
With ceph-iscsi 3.x release, the log directory for rbd target api/gw
are required when the process starts.
Ideally this needs to be done via a bind mount on the container
engine side to avoid logging in the container.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>