### PR TITLE
daemon: add support for cn-core bootstapper

### DIFF
--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -56,6 +56,10 @@ ADD ceph.defaults /opt/ceph-container/etc/
 # We use COPY instead of ADD for tarball so that it does not get extracted automatically at build time
 COPY Sree-0.1.tar.gz /opt/ceph-container/tmp/sree.tar.gz
 
+# Fetch the cn-core binary
+RUN curl -SL https://github.com/ceph/cn-core/releases/download/v0.7/cn-core-v0.7-linux-amd64 -o /usr/local/bin/cn-core && \
+  chmod +x /usr/local/bin/cn-core
+
 # Modify the entrypoint
 RUN bash "/opt/ceph-container/bin/generate_entrypoint.sh" && \
   rm -f /opt/ceph-container/bin/generate_entrypoint.sh && \

--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -157,7 +157,8 @@ case "$CEPH_DAEMON" in
     ;;
   demo)
     # TAG: demo
-    source /opt/ceph-container/bin/demo.sh
+    # Deploying mon, mgr, osd, rgw, dash using cn-core (https://github.com/ceph/cn-core)
+    cn-core init
     ;;
   disk_list)
     # TAG: disk_list


### PR DESCRIPTION
This commit
- modifies the Dockerfile to download the cn-core binary.
- modifies the entrypoint.sh script to replace demo.sh with cn-core as a value for CEPH_DAEMON=demo option. Thus cn-core (https://github.com/ceph/cn-core) binary is used to bootstrap the ceph daemons.

Fixes: ceph/cn-core#22
Signed-off-by: Deepika Joshi <djoshi@redhat.com>