### PR TITLE
variables_entrypoint.sh: improve logging

### DIFF
--- a/src/daemon/config.static.sh
+++ b/src/daemon/config.static.sh
@@ -28,7 +28,6 @@ osd crush chooseleaf type = 0
 osd journal size = 100
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_PUBLIC_NETWORK}
-log file = /dev/null
 osd pool default size = 1
 ENDHERE
 
@@ -48,7 +47,6 @@ mon host = ${MON_IP}
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_CLUSTER_NETWORK}
 osd journal size = ${OSD_JOURNAL_SIZE}
-log file = /dev/null
 ENDHERE
     fi
     if [ "$IP_LEVEL" -eq 6 ]; then

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -80,7 +80,7 @@ CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
 CLI_OPTS=(--cluster ${CLUSTER})
 
 # This is ONLY used for the daemon's startup, e.g: ceph-osd $DAEMON_OPTS
-DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph -d)
+DAEMON_OPTS=(--cluster ${CLUSTER} --default-log-to-file=false --default-mon-cluster-log-to-file=false --setuser ceph --setgroup ceph -d)
 
 MOUNT_OPTS=(-t xfs -o noatime,inode64)
 


### PR DESCRIPTION
sosreport does not export logs from journald, so the idea here is to
have an alternative to retrieve logs in a containerized context.

Related ceph-ansible PR: ceph/ceph-ansible#4166

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1710548

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>