### PR TITLE
Add CEPH_DEVEL flag for using ceph devel packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ BASEOS_REGISTRY ?= ""
 BASEOS_REPO ?= ""
 BASEOS_TAG ?= ""
 
+# Use Ceph development build packages from shaman/chacra repositories.
+CEPH_DEVEL ?= false
+
 
 # ==============================================================================
 # Internal definitions
@@ -175,6 +178,7 @@ OPTIONS:
 
   RELEASE - The release version to integrate in the tag. If omitted, set to the branch name.
 
+  CEPH_DEVEL - Use the ceph development packages from shaman/chacra instead of stable (default false).
 
 ADVANCED OPTIONS:
     It is advised only to use the below options for builds of a single flavor. These options are

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Alternatively, you can build a container image based on `wip-*` branch:
 
 To build your branch on Centos 7 on the `wip-super-code` branch.
 
+It's also possible to use the Ceph development builds instead of the stable one (except for master).
+The ceph packages will be pulled from shaman/chacra repositories.
+The Ceph development images are using the `latest-<release>-devel` tag where release is the ceph
+release name (ie: luminous, mimic, nautilus)
+
+`make CEPH_DEVEL=true FLAVORS="nautilus,centos,7" build`
+
+This will generate the following container images:
+
+```
+ceph/daemon:latest-nautilus-devel
+ceph/daemon-base:latest-nautilus-devel
+```
+
 Core Components
 ---------------
 

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -26,7 +26,7 @@ bash -c ' \
 yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
 bash -c ' \
-  if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
+  if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
   else \

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -19,6 +19,7 @@ $(shell bash -c 'set -eu ; \
 	ceph_version_spec="$(word 2, $(subst $(comma), ,$(1)))" ; \
 	set_var CEPH_VERSION       "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_VERSION)" ; \
 	set_var CEPH_POINT_RELEASE "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_POINT_RELEASE)" ; \
+	set_var CEPH_DEVEL         "$(CEPH_DEVEL)" ; \
 	set_var DISTRO             "$(word 3, $(subst $(comma), , $(1)))" ; \
 	set_var DISTRO_VERSION     "$(word 4, $(subst $(comma), , $(1)))" ; \
 	\

--- a/maint-lib/stage.py
+++ b/maint-lib/stage.py
@@ -70,6 +70,7 @@ def main(CORE_FILES_DIR, CEPH_RELEASES_DIR):
     logging.info('GO_ARCH: {}'.format(getEnvVar('GO_ARCH')))
 
     CEPH_VERSION = getEnvVar('CEPH_VERSION')
+    CEPH_DEVEL = getEnvVar('CEPH_DEVEL')
     DISTRO = getEnvVar('DISTRO')
     DISTRO_VERSION = getEnvVar('DISTRO_VERSION')
     IMAGES_TO_BUILD = getEnvVar('IMAGES_TO_BUILD').split(' ')

--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -17,6 +17,7 @@ REQUIRED_ENV_VARS = OrderedDict([
     ('CEPH_VERSION',       'Ceph named version part of the ceph-releases source path' +  # noqa: E241,E501
                             ALIGNED_NEWLINE + '(e.g., luminous, mimic)'),  # noqa: E241
     ('CEPH_POINT_RELEASE', 'Points to specific version of Ceph (e.g -12.2.0) or empty'),  # noqa: E241,E501
+    ('CEPH_DEVEL',         'Flag to enable ceph development packages (default false)'), # noqa: E241,E501
     ('DISTRO',             'Distro part of the ceph-releases source path (e.g., opensuse, centos)'),  # noqa: E241,E501
     ('DISTRO_VERSION',     'Distro version part of the ceph-releases source path' +  # noqa: E241,E501
                             ALIGNED_NEWLINE + '(e.g. in quotes, opensuse/"42.3", centos/"7")'),

--- a/src/STAGING_ENV_VARS.md
+++ b/src/STAGING_ENV_VARS.md
@@ -3,6 +3,7 @@ See `ceph-container/maint-lib/stagelib/envglobals.py` for most updated list and 
 
 ## Required as input to staging
  - CEPH_VERSION
+ - CEPH_DEVEL
  - DISTRO
  - DISTRO_VERSION
  - CEPH_POINT_RELEASE

--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -6,6 +6,7 @@ __DOCKERFILE_TRACEABILITY_LABELS__
 
 ENV CEPH_VERSION __ENV_[CEPH_VERSION]__
 ENV CEPH_POINT_RELEASE "__ENV_[CEPH_POINT_RELEASE]__"
+ENV CEPH_DEVEL __ENV_[CEPH_DEVEL]__
 
 #======================================================
 # Install ceph and dependencies, and clean up


### PR DESCRIPTION
We currently use the ceph packages for stable releases from [1] except
for master.
But in same case, we might want to test features/bugs merged into ceph
upstream but unreleased.
The CEPH_DEVEL flag allows to switch the ceph packages content to
shaman/chacra repositories when enabled.

make CEPH_DEVEL=true FLAVORS="nautilus,centos,7" build

The default value remains false for backward compatibility.

The build-push-ceph-container-imgs.sh script is also updated to be able
to build all ceph container images with that flag.

[1] http://download.ceph.com/

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>