### PR TITLE
Makefile: disable openSUSE 42.3 luminous build (bp #1390)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	luminous,opensuse,42.3 \
 	luminous,centos,7 \
 	mimic,centos,7 \
 	master,centos,7

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@
 FLAVORS ?= \
 	luminous,opensuse,42.3 \
 	luminous,centos,7 \
-	luminous,debian,9 \
 	mimic,centos,7 \
 	master,centos,7
 


### PR DESCRIPTION
The openSUSE 42.3 luminous build isn't working anymore preventing to
build the other container images.
This is temporary until the issue is resolved.

See: #1387

Signed-off-by: Dimitri Savineau dsavinea@redhat.com
(cherry picked from commit a4d4a0d)