### PR TITLE
Makefile: Update flavors for stable-4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,7 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	luminous,centos,7 \
-	mimic,centos,7 \
-	nautilus,centos,7 \
-	master,centos,7
+	nautilus,centos,7
 
 TAG_REGISTRY ?= ceph
 
@@ -44,11 +41,7 @@ include maint-lib/makelib.mk
 
 # All flavor options that can be passed to FLAVORS
 ALL_BUILDABLE_FLAVORS := \
-	luminous,centos,7 \
-	luminous,opensuse,42.3 \
-	luminous,debian,9 \
-	mimic,centos,7 \
-	master,centos,7
+	nautilus,centos,7
 
 # ==============================================================================
 # Build targets


### PR DESCRIPTION
The stable-4.0 branch should only build nautilus release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>