### PR TITLE
Makefile: Update flavors for stable-3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
 	luminous,centos,7 \
-	mimic,centos,7 \
-	master,centos,7
+	mimic,centos,7
 
 TAG_REGISTRY ?= ceph
 
@@ -46,8 +45,7 @@ ALL_BUILDABLE_FLAVORS := \
 	luminous,centos,7 \
 	luminous,opensuse,42.3 \
 	luminous,debian,9 \
-	mimic,centos,7 \
-	master,centos,7
+	mimic,centos,7
 
 # ==============================================================================
 # Build targets


### PR DESCRIPTION
The stable-3.2 branch should only build luminous and mimic releases.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>