### PR TITLE
contrib: Update ceph nano to v2.3.1

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -17,6 +17,7 @@ fi
 
 HOST_ARCH=$(uname -m)
 BUILD_ARM= # Set this variable to anything if you want to build the ARM images too
+CN_RELEASE="v2.3.1"
 
 
 #############
@@ -55,9 +56,9 @@ function grep_sort_tags {
 
 function download_cn {
   local cn_link
-  cn_link="https://github.com/ceph/cn/releases/download/v1.8.0/cn-v1.8.0-bb92a8e-linux-amd64"
+  cn_link="https://github.com/ceph/cn/releases/download/${CN_RELEASE}/cn-${CN_RELEASE}-linux-amd64"
   if [[ $(arch) == "aarch64" ]]; then
-    cn_link="https://github.com/ceph/cn/releases/download/v1.8.0/cn-v1.8.0-bb92a8e-linux-arm64"
+    cn_link="https://github.com/ceph/cn/releases/download/${CN_RELEASE}/cn-${CN_RELEASE}-linux-arm64"
   fi
   curl -L "$cn_link" -o cn
   chmod +x cn


### PR DESCRIPTION
The ceph nano (cn) release was pretty old (1.8.0) so updating it to the
latest one.
Also adding the cn release as a variable.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>