### PR TITLE
centos/rhel: remove vim-minimal package

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,6 @@
 echo 'Postinstall cleanup' && \
  (rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
+   rpm --nodeps -e vim-minimal && \
    yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__)

--- a/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/rhel7/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,6 @@
 echo 'Postinstall cleanup' && \
- ( yum clean all && \
+ ( rpm --nodeps -e vim-minimal && \
+   yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
    sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \

--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,6 @@
 echo 'Postinstall cleanup' && \
- ( yum clean all && \
+ ( rpm --nodeps -e vim-minimal && \
+   yum clean all && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
    sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \
    rm -f /etc/profile.d/lang.sh )


### PR DESCRIPTION
The vim package isn't required on the ceph container image and could
shows a bad mark on security scanner reports when CVE are discovered.

Resolves: #1413

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>