### PR TITLE
Dockerfile: update maintainer name (bp #1426)

### DIFF
--- a/ceph-releases/ALL/centos/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/centos/__DOCKERFILE_MAINTAINER__
@@ -1,1 +1,1 @@
-Erwan Velu <evelu@redhat.com>
+Dimitri Savineau <dsavinea@redhat.com>

--- a/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/rhel7/__DOCKERFILE_MAINTAINER__
@@ -1,1 +1,1 @@
-Erwan Velu <evelu@redhat.com>
+Dimitri Savineau <dsavinea@redhat.com>

--- a/ceph-releases/ALL/ubi8/__DOCKERFILE_MAINTAINER__
+++ b/ceph-releases/ALL/ubi8/__DOCKERFILE_MAINTAINER__
@@ -1,1 +1,1 @@
-Sebastien Han <seb@redhat.com>
+Dimitri Savineau <dsavinea@redhat.com>

--- a/src/__DOCKERFILE_MAINTAINER__
+++ b/src/__DOCKERFILE_MAINTAINER__
@@ -1,1 +1,1 @@
-Sébastien Han "seb@redhat.com"
+Dimitri Savineau <dsavinea@redhat.com>


### PR DESCRIPTION
Since the maintainer for the base image and all rhel based ceph-container
images has changed, let's update this label.

Backport: #1426

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 64b1c5f554895053deeb368eba827ae4cb135512)