### PR TITLE
daemon/common_functions.sh: remove NBSP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
 
 
 before_install:
+  - if [[ -n $(grep --exclude-dir=.git -I -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - docker --version
   - sudo apt-get install -y --force-yes xfsprogs
   - sudo ./travis-builds/purge_cluster.sh

--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -373,7 +373,7 @@ function get_dmcrypt_bluestore_uuid {
   start_disk_list
   BLOCK_DB_PART=$(start_disk_list)
   unset DISK_LIST_SEARCH
-  if [ -n "${BLOCK_DB_PART}" ]; then
+  if [ -n "${BLOCK_DB_PART}" ]; then
     BLOCK_DB_UUID=$(get_part_uuid "${BLOCK_DB_PART}")
   fi
 


### PR DESCRIPTION
A NBSP has been introduced in ce6b4f0 causing the function
get_dmcrypt_bluestore_uuid to fail.

bin/common_functions.sh: line 376: $'[\302\240-n': command not found

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>