### PR TITLE
daemon/common_functions.sh: remove NBSP (bp #1431)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 
 
 before_install:
+  - if [[ -n $(grep --exclude-dir=.git -I -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - docker --version
   - sudo apt-get install -y --force-yes xfsprogs
   - sudo ./travis-builds/purge_cluster.sh


### PR DESCRIPTION
A NBSP has been introduced in ce6b4f0 causing the function
get_dmcrypt_bluestore_uuid to fail.

bin/common_functions.sh: line 376: $'[\302\240-n': command not found

Backport: #1431

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit ba4e71d7e1a1b68d0db8c8d35ecab78d30e9fe5c)