### PR TITLE
Add two entrypoints for ceph-disk OSD ids

### DIFF
--- a/ceph-releases/luminous/daemon/entrypoint.sh.in
+++ b/ceph-releases/luminous/daemon/entrypoint.sh.in
@@ -112,6 +112,10 @@ case "$CEPH_DAEMON" in
     source /opt/ceph-container/bin/osd_volume_activate.sh
     osd_volume_activate
     ;;
+  osd_ceph_disk_dmcrypt_data_map)
+    # TAG: osd_ceph_disk_dmcrypt_data_map
+    dmcrypt_data_map
+    ;;
   mds)
     # TAG: mds
     source /opt/ceph-container/bin/start_mds.sh

--- a/ceph-releases/luminous/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/daemon/osd_scenarios/osd_disk_activate.sh
@@ -4,6 +4,8 @@ set -e
 source /opt/ceph-container/bin/disk_list.sh
 
 function osd_activate {
+  local action=${1}
+
   if [[ -z "${OSD_DEVICE}" ]] || [[ ! -b "${OSD_DEVICE}" ]]; then
     log "ERROR: you either provided a non-existing device or no device at all."
     log "You must provide a device to build your OSD ie: /dev/sdb"
@@ -85,5 +87,7 @@ function osd_activate {
     log "osd_disk_activate: Unmounting $osd_mnt"
     umount "$osd_mnt" || (log "osd_disk_activate: Failed to umount $osd_mnt"; lsof "$osd_mnt")
   }
-  exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  if [ "${action}" != "no_start" ]; then
+    exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  fi
 }

--- a/ceph-releases/luminous/daemon/start_osd.sh
+++ b/ceph-releases/luminous/daemon/start_osd.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+if is_redhat; then
+  if [[ -n "${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}" ]]; then
+    sed -i -e "s/^\(TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES\)=.*/\1=${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}/" /etc/sysconfig/ceph
+  fi
+  source /etc/sysconfig/ceph
+fi
+
+function start_osd {
+  get_config
+  check_config
+
+  if [ "${CEPH_GET_ADMIN_KEY}" -eq 1 ]; then
+    get_admin_key
+    check_admin_key
+  fi
+
+  case "$OSD_TYPE" in
+    directory)
+      source /opt/ceph-container/bin/osd_directory.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_directory
+      ;;
+    directory_single)
+      source /opt/ceph-container/bin/osd_directory_single.sh
+      osd_directory_single
+      ;;
+    disk)
+      osd_disk
+      ;;
+    prepare)
+      source /opt/ceph-container/bin/osd_disk_prepare.sh
+      osd_disk_prepare
+      ;;
+    activate)
+      source /opt/ceph-container/bin/osd_disk_activate.sh
+      osd_activate
+      ;;
+    activate_only)
+      source /opt/ceph-container/bin/osd_disk_activate.sh
+      osd_activate no_start
+      ;;
+    devices)
+      source /opt/ceph-container/bin/osd_disks.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_disks
+      ;;
+    activate_journal)
+      source /opt/ceph-container/bin/osd_activate_journal.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_activate_journal
+      ;;
+    *)
+      osd_trying_to_determine_scenario
+      ;;
+  esac
+}
+
+function osd_disk {
+  source /opt/ceph-container/bin/osd_disk_prepare.sh
+  source /opt/ceph-container/bin/osd_disk_activate.sh
+  osd_disk_prepare
+  osd_activate
+}

--- a/ceph-releases/luminous/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal osd_ceph_disk_dmcrypt_data_map mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################

--- a/ceph-releases/luminous/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################

--- a/ceph-releases/mimic/daemon/entrypoint.sh.in
+++ b/ceph-releases/mimic/daemon/entrypoint.sh.in
@@ -105,6 +105,10 @@ case "$CEPH_DAEMON" in
     OSD_TYPE="activate_journal"
     start_osd
     ;;
+  osd_ceph_disk_dmcrypt_data_map)
+    # TAG: osd_ceph_disk_dmcrypt_data_map
+    dmcrypt_data_map
+    ;;
   osd_ceph_volume_activate)
     ami_privileged
     # shellcheck disable=SC1091

--- a/ceph-releases/mimic/daemon/entrypoint.sh.in
+++ b/ceph-releases/mimic/daemon/entrypoint.sh.in
@@ -127,11 +127,6 @@ case "$CEPH_DAEMON" in
     source /opt/ceph-container/bin/start_rgw.sh
     create_rgw_user
     ;;
-  restapi)
-    # TAG: restapi
-    source /opt/ceph-container/bin/start_restapi.sh
-    start_restapi
-    ;;
   rbd_mirror)
     # TAG: rbd_mirror
     source /opt/ceph-container/bin/start_rbd_mirror.sh

--- a/ceph-releases/mimic/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/mimic/daemon/osd_scenarios/osd_disk_activate.sh
@@ -4,6 +4,8 @@ set -e
 source /opt/ceph-container/bin/disk_list.sh
 
 function osd_activate {
+  local action=${1}
+
   if [[ -z "${OSD_DEVICE}" ]] || [[ ! -b "${OSD_DEVICE}" ]]; then
     log "ERROR: you either provided a non-existing device or no device at all."
     log "You must provide a device to build your OSD ie: /dev/sdb"
@@ -85,5 +87,7 @@ function osd_activate {
     log "osd_disk_activate: Unmounting $osd_mnt"
     umount "$osd_mnt" || (log "osd_disk_activate: Failed to umount $osd_mnt"; lsof "$osd_mnt")
   }
-  exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  if [ "${action}" != "no_start" ]; then
+    exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  fi
 }

--- a/ceph-releases/mimic/daemon/start_osd.sh
+++ b/ceph-releases/mimic/daemon/start_osd.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+if is_redhat; then
+  if [[ -n "${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}" ]]; then
+    sed -i -e "s/^\(TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES\)=.*/\1=${TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES}/" /etc/sysconfig/ceph
+  fi
+  source /etc/sysconfig/ceph
+fi
+
+function start_osd {
+  get_config
+  check_config
+
+  if [ "${CEPH_GET_ADMIN_KEY}" -eq 1 ]; then
+    get_admin_key
+    check_admin_key
+  fi
+
+  case "$OSD_TYPE" in
+    directory)
+      source /opt/ceph-container/bin/osd_directory.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_directory
+      ;;
+    directory_single)
+      source /opt/ceph-container/bin/osd_directory_single.sh
+      osd_directory_single
+      ;;
+    disk)
+      osd_disk
+      ;;
+    prepare)
+      source /opt/ceph-container/bin/osd_disk_prepare.sh
+      osd_disk_prepare
+      ;;
+    activate)
+      source /opt/ceph-container/bin/osd_disk_activate.sh
+      osd_activate
+      ;;
+    activate_only)
+      source /opt/ceph-container/bin/osd_disk_activate.sh
+      osd_activate no_start
+      ;;
+    devices)
+      source /opt/ceph-container/bin/osd_disks.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_disks
+      ;;
+    activate_journal)
+      source /opt/ceph-container/bin/osd_activate_journal.sh
+      source /opt/ceph-container/bin/osd_common.sh
+      osd_activate_journal
+      ;;
+    *)
+      osd_trying_to_determine_scenario
+      ;;
+  esac
+}
+
+function osd_disk {
+  source /opt/ceph-container/bin/osd_disk_prepare.sh
+  source /opt/ceph-container/bin/osd_disk_activate.sh
+  osd_disk_prepare
+  osd_activate
+}

--- a/ceph-releases/mimic/daemon/variables_entrypoint.sh
+++ b/ceph-releases/mimic/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal osd_ceph_disk_dmcrypt_data_map mds rgw rgw_user nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################

--- a/ceph-releases/mimic/daemon/variables_entrypoint.sh
+++ b/ceph-releases/mimic/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################

--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -542,3 +542,15 @@ function MB_to_bytes() {
 function bytes_to_MB() {
   echo $(($1 / 1024 / 1024))
 }
+
+# Map dmcrypt data device
+function dmcrypt_data_map() {
+  for lockbox in $(blkid -t PARTLABEL="ceph lockbox" -o device | tr '\n' ' '); do
+    OSD_DEVICE=${lockbox:0:-1}
+    DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
+    DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
+    LOCKBOX_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")
+    mount_lockbox "${DATA_UUID}" "${LOCKBOX_UUID}"
+    ceph-disk --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon ${DATA_PART} || true
+  done
+}


### PR DESCRIPTION
In some case, we don't want to activate and start the OSD process in
the same entrypoint.
In order to allocate an OSD id on prepared OSD, we need to activate it
without start it.
That way, we're able to get the OSD id for systemd unit script.

In order to get the OSD ids with ceph-disk list command, we need first
to map the dmcrypt data partitions (mount the lockbox partition and
then open the encrypted partition).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1670734

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>