### PR TITLE
Add two entrypoints for ceph-disk OSD ids (bp #1434)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -517,3 +517,15 @@ function ami_privileged {
   # lsblk is not able to get device mappers path and is complaining.
   # That's why stderr is suppressed in /dev/null
 }
+
+# Map dmcrypt data device
+function dmcrypt_data_map() {
+  for lockbox in $(blkid -t PARTLABEL="ceph lockbox" -o device | tr '\n' ' '); do
+    OSD_DEVICE=${lockbox:0:-1}
+    DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
+    DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
+    LOCKBOX_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")
+    mount_lockbox "${DATA_UUID}" "${LOCKBOX_UUID}"
+    ceph-disk --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon ${DATA_PART} || true
+  done
+}

--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -93,6 +93,12 @@ case "$CEPH_DAEMON" in
     OSD_TYPE="activate"
     start_osd
     ;;
+  osd_ceph_disk_activate_only)
+    # TAG: osd_ceph_disk_activate_only
+    source start_osd.sh
+    OSD_TYPE="activate_only"
+    start_osd
+    ;;
   osd_ceph_activate_journal)
     # TAG: osd_ceph_activate_journal
     source start_osd.sh

--- a/src/daemon/entrypoint.sh.in
+++ b/src/daemon/entrypoint.sh.in
@@ -112,6 +112,10 @@ case "$CEPH_DAEMON" in
     source osd_volume_activate.sh
     osd_volume_activate
     ;;
+  osd_ceph_disk_dmcrypt_data_map)
+    # TAG: osd_ceph_disk_dmcrypt_data_map
+    dmcrypt_data_map
+    ;;
   mds)
     # TAG: mds
     source start_mds.sh

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -4,6 +4,8 @@ set -e
 source disk_list.sh
 
 function osd_activate {
+  local action=${1}
+
   if [[ -z "${OSD_DEVICE}" ]] || [[ ! -b "${OSD_DEVICE}" ]]; then
     log "ERROR: you either provided a non-existing device or no device at all."
     log "You must provide a device to build your OSD ie: /dev/sdb"
@@ -85,5 +87,7 @@ function osd_activate {
     log "osd_disk_activate: Unmounting $osd_mnt"
     umount "$osd_mnt" || (log "osd_disk_activate: Failed to umount $osd_mnt"; lsof "$osd_mnt")
   }
-  exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  if [ "${action}" != "no_start" ]; then
+    exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk
+  fi
 }

--- a/src/daemon/start_osd.sh
+++ b/src/daemon/start_osd.sh
@@ -38,6 +38,10 @@ function start_osd {
       source osd_disk_activate.sh
       osd_activate
       ;;
+    activate_only)
+      source osd_disk_activate.sh
+      osd_activate no_start
+      ;;
     devices)
       source osd_disks.sh
       source osd_common.sh

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal osd_ceph_disk_dmcrypt_data_map mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_disk_activate_only osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list tcmu_runner rbd_target_api rbd_target_gw"
 
 
 #########################


### PR DESCRIPTION
In some case, we don't want to activate and start the OSD process in
the same entrypoint.
In order to allocate an OSD id on prepared OSD, we need to activate it
without start it.
That way, we're able to get the OSD id for systemd unit script.

In order to get the OSD ids with ceph-disk list command, we need first
to map the dmcrypt data partitions (mount the lockbox partition and
then open the encrypted partition).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1670734
Backport: #1434 

Signed-off-by: Dimitri Savineau dsavinea@redhat.com