### PR TITLE
nautilus: pin ganesha version to 2.8 (bp #1435)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -4,9 +4,11 @@ bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-    if [[ "${CEPH_VERSION}" =~ master|nautilus|^wip* ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
       REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
       echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+    elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
+      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \
       echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.7-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     fi ; \


### PR DESCRIPTION
On Nautilus release, let's use the stable 2.8 packages for Ganesha.

Backport: #1435 

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 5938be9f2df87b3acdca2c94712a58d5b7527a6e)