### PR TITLE
config.kv.etcd: Remove set-uid flag for nautilus+ (bp #1440)

### DIFF
--- a/src/daemon/config.kv.etcd.sh
+++ b/src/daemon/config.kv.etcd.sh
@@ -55,6 +55,10 @@ function get_mon_config {
       sleep 1
     done
 
+    if [[ "$CEPH_VERSION" == "luminous" ]] || [[ "$CEPH_VERSION" == "mimic" ]]; then
+      CLI+=("--set-uid=0")
+    fi
+
     log "Creating Keyrings."
     if [ -z "$ADMIN_SECRET" ]; then
       # Automatically generate administrator key
@@ -63,7 +67,7 @@ function get_mon_config {
       # Generate custom provided administrator key
       CLI+=("--add-key=$ADMIN_SECRET")
     fi
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw ${RBD_MIRROR_BOOTSTRAP_KEYRING}:Rbd; do


### PR DESCRIPTION
8dfe9da removed the set-uid option in config.static file but not in the
one for etcd configuration.

Backport: #1440

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 8c292f087031e268b8d13815c4836a60a7362c9c)