### PR TITLE
daemon/start_mon.sh: fix failure handling in ceph-conf 'mon host'

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -170,13 +170,14 @@ function start_mon {
       ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" -i "${MON_NAME}" --inject-monmap "$MONMAP" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
     fi
     if [[ "$CEPH_DAEMON" != demo ]]; then
-      v2v1=$(ceph-conf -c /etc/ceph/${CLUSTER}.conf 'mon host' | tr ',' '\n' | grep -c ${MON_IP})
-      # in case of v2+v1 configuration : [v2:xxxx:3300,v1:xxxx:6789]
-      if [ ${v2v1} -eq 2 ]; then
-        timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}" || true
+      v2v1=$(ceph-conf -c /etc/ceph/${CLUSTER}.conf 'mon host' | tr ',' '\n' | grep -c ${MON_IP} || true)
       # with v2 only : [v2:xxxx:3300]
-      else
+      if [ ${v2v1} -eq 1 ]; then
         timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}":"${MON_PORT}" || true
+      # in case of explicit v2+v1 configuration : [v2:xxxx:3300,v1:xxxx:6789]
+      # or implicit v2+v1 configuration : xxxx
+      else
+        timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}" || true
       fi
     fi
   fi


### PR DESCRIPTION
In commit 'daemon/start_mon.sh: add mon without port value' the
following code was added:
  v2v1=$(ceph-conf -c /etc/ceph/${CLUSTER}.conf 'mon host' | tr ',' '\n' | grep -c ${MON_IP})

If that command fails, the process stops because of set -e, while it is
expected that we would reach the 'else' case.

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
