### PR TITLE
Revert "ceph: unblock master images"

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -5,10 +5,8 @@ bash -c ' \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
     if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
-      # Currently nfs-ganesha is broken on master so let's pin on 2.8 to build latest-master images
-      #REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
-      #echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/nautilus/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
+      echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
       echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \


### PR DESCRIPTION
This reverts commit a61f2e2d7345f3f3d7b29d478adeebfb07cd8a3e.

Because nfs-ganesha@master (2.9-dev) build has been fixed by [1] then
we can reuse that version on container image build for master/octopus.

[1] https://github.com/ceph/ceph-build/pull/1346