### PR TITLE
cleanup: disable repos pointing to chacra

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -2,4 +2,5 @@ echo 'Postinstall cleanup' && \
  (rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
    yum clean all && \
    rpmdb --rebuilddb && \
-   rpm -q __CEPH_BASE_PACKAGES__)
+   rpm -q __CEPH_BASE_PACKAGES__ && \
+   yum-config-manager --disable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source python-rtslib-source python-rtslib-noarch python-rtslib)


### PR DESCRIPTION
Description of your changes:

Repos on chacra are quite ephemeral, they last for 2 weeks only. If
someone is using an image that is 3 weeks old, the repos will be gone
and they won't be able to install any packages.
So disabling these repos is easy and less confusing for users.

They can always be re-enabled with:

yum-config-manager --enable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source python-rtslib-source python-rtslib-noarch python-rtslib

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Which issue is resolved by this Pull Request:
Resolves https://github.com/rook/rook/issues/3662

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
