### PR TITLE
Add ability to execute from Ceph build and build containers for CI/testing

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -38,7 +38,7 @@ function build_and_push_latest_bis {
   return
 }
 
-function push_ceph_imgs_latests {
+function push_ceph_imgs_latest {
   return
 }
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -68,7 +68,7 @@ function install_docker {
     sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
   fi
   sudo systemctl start docker
-  sudo systemctl status docker
+  sudo systemctl status --no-pager docker
   sudo chgrp "$(whoami)" /var/run/docker.sock
 }
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -59,10 +59,14 @@ function cleanup_previous_run {
 
 declare -F install_docker ||
 function install_docker {
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  sudo apt-get update
-  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
+  if [[ -x /usr/bin/yum ]] ; then
+    sudo yum install -y docker
+  else
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get update
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
+  fi
   sudo systemctl start docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-set -ex
+# vim: set expandtab ts=2 sw=2 :
 
+set -ex
 
 #############
 # VARIABLES #

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -168,8 +168,8 @@ function build_and_push_latest_bis {
   docker push ceph/daemon:latest-bis
 }
 
-declare -F push_ceph_imgs_latests ||
-function push_ceph_imgs_latests {
+declare -F push_ceph_imgs_latest ||
+function push_ceph_imgs_latest {
   local latest_name
   for release in "${CEPH_RELEASES[@]}" latest; do
     if [[ "$release" == "latest" ]]; then
@@ -256,7 +256,7 @@ if $TAGGED_HEAD; then
   echo "Don't push latest as we run on a tagged head"
   exit 0
 fi
-push_ceph_imgs_latests
+push_ceph_imgs_latest
 # We don't need latest bis tags with ceph devel
 if ! ${DEVEL}; then
   build_and_push_latest_bis


### PR DESCRIPTION
This branch modifies contrib/build-push-ceph-container-imgs.sh to allow use from a Ceph build to push a centos7 daemon-base container to a repo of choice.  There are also some cleanups and refactors for clarity, which I've tried to isolate in separate commits.

I expect this not to change the behavior of this script in other contexts.