### PR TITLE
disk_list.sh: Don't use wildcard on OSD device

### DIFF
--- a/src/daemon/disk_list.sh
+++ b/src/daemon/disk_list.sh
@@ -29,7 +29,8 @@ function mount_ceph_data () {
   if is_dmcrypt; then
     mount /dev/mapper/"${data_uuid}" "$tmp_dir"
   else
-    mount /dev/disk/by-partuuid/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value "${OSD_DEVICE}"*)" "$tmp_dir"
+    data_part=$(dev_part "${OSD_DEVICE}" 1)
+    mount /dev/disk/by-partuuid/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value ${data_part})" "$tmp_dir"
   fi
 }
 


### PR DESCRIPTION
Using a wildcard after the OSD device name with the blkid command could
return more than one result when having a lot of disks.

With /dev/sda, /dev/sdaa, /dev/sdab, etc... the command will return
multiple PARTUUID values.

$ blkid -t PARTLABEL="ceph data" -s PARTUUID -o value /dev/sda*
867ef9c4-2ae1-4c61-b99f-786646807fba
d7c2aff0-9fe6-4dba-8e9d-03c0b2e95a61
5ad89aa8-0dcf-42b6-8e12-3aa916dee91c
129df299-0142-4091-9a54-01411450df3a
fbe6babc-1164-40bc-86b4-0422c18d9b90

We know that the ceph data partition will always be the partition 1 on
the device so we can replace the wildcard by the right partition number.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1628652

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 610c5d91738969c38a963cd10599f375afa5e134)