### PR TITLE
tweaks: disable obtain_device_list_from_udev lvm (bp #1466)

### DIFF
--- a/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
+++ b/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
@@ -1,5 +1,6 @@
 # disable sync with udev since the container can not contact udev
-sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/' /etc/lvm/lvm.conf && \
+sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/' -e 's/obtain_device_list_from_udev = 1/obtain_device_list_from_udev = 0/' /etc/lvm/lvm.conf && \
 # validate the sed command worked as expected
 grep -sqo "udev_sync = 0" /etc/lvm/lvm.conf && \
-grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf
+grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf && \
+grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf


### PR DESCRIPTION
Because we're using lvm commands from the container but udev isn't
running then we also need to disable obtain_device_list_from_udev.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1676612
Backport: #1466

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 75b23017cb673e419fa2ee3f9dcb0bb2a71b456d)