### PR TITLE
contrib: fix BRANCH variable name

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -153,7 +153,7 @@ function create_head_or_point_release {
     git checkout refs/tags/"${tag_to_build[*]}"
 
     # find branch associated to that tag
-    BRANCH=$(git branch -r --contains tags/"${tag_to_build[*]}" | grep -Eo 'stable-[0-9].[0-9]')
+    CONTAINER_BRANCH=$(git branch -r --contains tags/"${tag_to_build[*]}" | grep -Eo 'stable-[0-9].[0-9]')
     echo "Building a release Ceph container image based on branch $CONTAINER_BRANCH and tag ${tag_to_build[*]}"
     RELEASE="${tag_to_build[*]}-$CONTAINER_BRANCH"
     # (todo): remove this when we have a better solution like running


### PR DESCRIPTION
d4eedeb introduced a regression by omitting a variable renaming.
This breaks the current stable (tagged) container image build.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>