### PR TITLE
osd_volume_activate: fix osd_volume_lvm function

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -99,7 +99,7 @@ function osd_volume_activate {
       else
         DATA=$(echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])")
       fi
-      if grep -qo "${uuid}" "${DATA}"; then
+      if echo "${DATA}" | grep -qo "${uuid}"; then
         log "osd_volume_activate: Closing dmcrypt $uuid"
         cryptsetup close "${uuid}" || log "osd_volume_activate: Failed to close dmcrypt ${uuid}"
       fi


### PR DESCRIPTION
90511a4e0231d42d98171ac456e714406605de15 introduced a bug in
osd_volume_lvm function.
OSDs couldn't start because `$CEPH_VOLUME_LIST_JSON` is seen as an empty
variable when consumed in this function.
Since there's no need to have a separate function for detecting the
volume type, let's refact this part of the code so we can fix this
issue.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>