### PR TITLE
osd_disk_activate: resolve device symlink

### DIFF
--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -8,6 +8,10 @@ function osd_activate {
     exit 1
   fi
 
+  if [ -L "${OSD_DEVICE}" ]; then
+    OSD_DEVICE=$(readlink -f ${OSD_DEVICE})
+  fi
+
   if ! parted --script "${OSD_DEVICE}" print | grep -qE '^ 1.*ceph data'; then
     log "ERROR: ${OSD_DEVICE} doesn't have a ceph metadata partition"
     exit 1


### PR DESCRIPTION
When using OSD_DEVICE variable with /dev/disk/by-[id|path] then the
partition name is different for the ceph data partition. There's an
additional '-part' prefix before the partition number.
Instead of managing this prefix and considering that files located in
the /dev/disk/by-[id|path] directories are symlinks then we can resolve
the symlink to get the actual device /dev/xxxx.

Closes: #1480

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>