### PR TITLE
osd_volume_activate: handle loop device

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -8,7 +8,7 @@ function osd_volume_simple {
   # Scan devices with ceph data partition
   for device in ${DEVICES}; do
     if parted --script "${device}" print | grep -qE '^ 1.*ceph data'; then
-      if [[ "${device}" =~ ^/dev/(cciss|nvme) ]]; then
+      if [[ "${device}" =~ ^/dev/(cciss|nvme|loop) ]]; then
         device+="p"
       fi
       ceph-volume simple scan ${device}1 --force || true


### PR DESCRIPTION
Loop devices are like nvme or cciss devices because the partitions are
referenced with an extra 'p' before the partition number.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>