### PR TITLE
backports stable-4.0

### DIFF
--- a/src/daemon/disk_list.sh
+++ b/src/daemon/disk_list.sh
@@ -29,7 +29,8 @@ function mount_ceph_data () {
   if is_dmcrypt; then
     mount /dev/mapper/"${data_uuid}" "$tmp_dir"
   else
-    mount /dev/disk/by-partuuid/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value "${OSD_DEVICE}"*)" "$tmp_dir"
+    data_part=$(dev_part "${OSD_DEVICE}" 1)
+    mount /dev/disk/by-partuuid/"$(blkid -t PARTLABEL="ceph data" -s PARTUUID -o value ${data_part})" "$tmp_dir"
   fi
 }
 

--- a/src/daemon/docker_exec.sh
+++ b/src/daemon/docker_exec.sh
@@ -68,7 +68,7 @@ function teardown {
   echo
   echo "teardown: Process $child_for_exec is terminated"
 
-  if [ "$signal_name" = "SIGTERM" ]; then
+  if [[ "$signal_name" =~ SIGTERM|SIGCHLD ]]; then
     # Execute the cleanup post-script if any is declared
     declare -F sigterm_cleanup_post && sigterm_cleanup_post
   else
@@ -114,7 +114,7 @@ function _bus {
 }
 
 function _chld {
-  teardown "SIGCHLD" -1
+  teardown "SIGCHLD" 0
 }
 
 function _err {

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -8,6 +8,10 @@ function osd_activate {
     exit 1
   fi
 
+  if [ -L "${OSD_DEVICE}" ]; then
+    OSD_DEVICE=$(readlink -f ${OSD_DEVICE})
+  fi
+
   if ! parted --script "${OSD_DEVICE}" print | grep -qE '^ 1.*ceph data'; then
     log "ERROR: ${OSD_DEVICE} doesn't have a ceph metadata partition"
     exit 1

--- a/src/daemon/osd_scenarios/osd_disks.sh
+++ b/src/daemon/osd_scenarios/osd_disks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-${OSD_DISKS:-none}
+OSD_DISKS=${OSD_DISKS:-none}
 
 function osd_disks {
   if [[ ! -d /var/lib/ceph/osd ]]; then

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -99,7 +99,7 @@ function osd_volume_activate {
       else
         DATA=$(echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])")
       fi
-      if grep -qo "${uuid}" "${DATA}"; then
+      if echo "${DATA}" | grep -qo "${uuid}"; then
         log "osd_volume_activate: Closing dmcrypt $uuid"
         cryptsetup close "${uuid}" || log "osd_volume_activate: Failed to close dmcrypt ${uuid}"
       fi

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -8,7 +8,7 @@ function osd_volume_simple {
   # Scan devices with ceph data partition
   for device in ${DEVICES}; do
     if parted --script "${device}" print | grep -qE '^ 1.*ceph data'; then
-      if [[ "${device}" =~ ^/dev/(cciss|nvme) ]]; then
+      if [[ "${device}" =~ ^/dev/(cciss|nvme|loop) ]]; then
         device+="p"
       fi
       ceph-volume simple scan ${device}1 --force || true

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -73,7 +73,7 @@ function osd_volume_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | grep '^/')
+    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/"${CLUSTER}-${OSD_ID}" | grep '^/')
     for mnt in $ceph_mnt; do
       log "osd_volume_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof "$mnt")

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+function get_osd_volume_type {
+  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
+  #shellcheck disable=SC2153
+  if echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])" &> /dev/null; then
+    echo "lvm"
+  else
+    echo "simple"
+  fi
+}
+
 function osd_volume_simple {
   # Find the devices used by ceph-disk
   DEVICES=$(ceph-volume inventory --format json | $PYTHON -c 'import sys, json; print(" ".join([d.get("path") for d in json.load(sys.stdin) if "Used by ceph-disk" in d.get("rejected_reasons")]))')
@@ -24,10 +34,14 @@ function osd_volume_simple {
 
   # Activate the OSD
   # The command can fail so if it does, let's output the ceph-volume logs
-  if ! ceph-volume simple activate --file ${OSD_JSON} --no-systemd; then
+  if ! ceph-volume simple activate --file "${OSD_JSON}" --no-systemd; then
     cat /var/log/ceph
     exit 1
   fi
+}
+
+function get_dmcrypt_uuids {
+  dmsetup ls --target=crypt | cut -d$'\t' -f 1
 }
 
 function osd_volume_lvm {
@@ -58,9 +72,9 @@ function osd_volume_lvm {
 function osd_volume_activate {
   : "${OSD_ID:?Give me an OSD ID to activate, eg: -e OSD_ID=0}"
 
-  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
+  OSD_VOLUME_TYPE=$(get_osd_volume_type)
 
-  if echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
+  if [[ "$OSD_VOLUME_TYPE" == "lvm" ]]; then
     osd_volume_lvm
   else
     osd_volume_simple
@@ -77,6 +91,20 @@ function osd_volume_activate {
     for mnt in $ceph_mnt; do
       log "osd_volume_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof "$mnt")
+    done
+
+    UUIDS=$(get_dmcrypt_uuids)
+
+    for uuid in ${UUIDS}; do
+      if [[ "$OSD_VOLUME_TYPE" == "simple" ]]; then
+        DATA="${OSD_JSON}"
+      else
+        DATA=$(echo "$CEPH_VOLUME_LIST_JSON" | $PYTHON -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])")
+      fi
+      if grep -qo "${uuid}" "${DATA}"; then
+        log "osd_volume_activate: Closing dmcrypt $uuid"
+        cryptsetup close "${uuid}" || log "osd_volume_activate: Failed to close dmcrypt ${uuid}"
+      fi
     done
   }
   exec /usr/bin/ceph-osd "${DAEMON_OPTS[@]}" -i "${OSD_ID}"


### PR DESCRIPTION
This is a the list of the commits backported to stable-4.0. It's mainly about osd_volume_activate and disk_list.sh changes.

f96aaa8 fix: delete temporary mount point
9fa8986 osd_disk_activate: resolve device symlink
0625c25 osd_volume_activate: handle loop device
cfce9fe osd_volume_activate: fix bug in teardown
4b0360a osd_volume_activate: fix osd_volume_lvm function
f5d8ba2 osd_volume_activate: cleanup dmcrypt when osd is stopped
4da6ca2 docker_exec: execute sigterm_cleanup_post() when signal is SIGCHLD
206ee85 osd_volume_activate: fix a bug in findmnt cmd call
3df9a91 fix: assign properly OSD_DISKS variable
c56e627 disk_list.sh: Don't use wildcard on OSD device