### PR TITLE
backports stable-3.2

### DIFF
--- a/src/daemon/docker_exec.sh
+++ b/src/daemon/docker_exec.sh
@@ -68,7 +68,7 @@ function teardown {
   echo
   echo "teardown: Process $child_for_exec is terminated"
 
-  if [ "$signal_name" = "SIGTERM" ]; then
+  if [[ "$signal_name" =~ SIGTERM|SIGCHLD ]]; then
     # Execute the cleanup post-script if any is declared
     declare -F sigterm_cleanup_post && sigterm_cleanup_post
   else
@@ -114,7 +114,7 @@ function _bus {
 }
 
 function _chld {
-  teardown "SIGCHLD" -1
+  teardown "SIGCHLD" 0
 }
 
 function _err {

--- a/src/daemon/osd_scenarios/osd_disks.sh
+++ b/src/daemon/osd_scenarios/osd_disks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-${OSD_DISKS:-none}
+OSD_DISKS=${OSD_DISKS:-none}
 
 function osd_disks {
   if [[ ! -d /var/lib/ceph/osd ]]; then

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -41,7 +41,7 @@ function osd_volume_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | grep '^/')
+    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/"${CLUSTER}-${OSD_ID}" | grep '^/')
     for mnt in $ceph_mnt; do
       log "osd_volume_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof "$mnt")


### PR DESCRIPTION
This is a the list of the commits backported to stable-3.2. It's mainly about osd_volume_activate and disk_list.sh changes.

de54772 fix: delete temporary mount point
3454e80 docker_exec: execute sigterm_cleanup_post() when signal is SIGCHLD
ae8387c osd_volume_activate: fix a bug in findmnt cmd call
e3d1299 fix: assign properly OSD_DISKS variable