### PR TITLE
src/daemon-base: add smartmontools and nvme-cli packages

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -11,6 +11,8 @@
         kmod \
         lvm2 \
         gdisk \
+	smartmontools \
+	nvme-cli \
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \


### PR DESCRIPTION
The mon and osd need smartctl and nvme to scrape metrics from HDDs/SSDs.
