### PR TITLE
src/daemon-base: add smartmontools and nvme-cli packages (bp #1489)

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -11,6 +11,8 @@
         kmod \
         lvm2 \
         gdisk \
+	smartmontools \
+	nvme-cli \
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__


### PR DESCRIPTION
The mon and osd need smartctl and nvme to scrape metrics from HDDs/SSDs.

Closes: #1396
Backport: #1489

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 854cf34296706337a59e95124ee80b6afe1cea36)