### PR TITLE
ubi8: use quotes for LABEL version

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -8,7 +8,7 @@ RUN echo "Red Hat Ceph Storage Server 4 (Container)" > /etc/redhat-storage-relea
 EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 
 # Atomic specific labels
-LABEL version=4
+LABEL version="4"
 
 # Build specific labels
 LABEL com.redhat.component="rhceph-container"


### PR DESCRIPTION
This was done downstream and to avoid conflict during sync between
upstream and downstream we should use the same syntax.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 0788747e09d28fac14503d2fb20fe39dd0b3a1ac)