### PR TITLE
src/daemon-base: add libstoragemgmt

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -13,6 +13,7 @@
         gdisk \
 	smartmontools \
 	nvme-cli \
+	libstoragemgmt \
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \


### PR DESCRIPTION
This is needed to turn device LEDs on and off.

Signed-off-by: Sage Weil <sage@redhat.com>