### PR TITLE
src/daemon: enforce ceph-osd ulimit values (bp #1497)

### DIFF
--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -47,5 +47,9 @@ function osd_activate {
       umount "$mnt" || (log "osd_disk_activate: Failed to umount $mnt"; lsof "$mnt")
     done
   }
+  # /usr/lib/systemd/system/ceph-osd@.service
+  # LimitNOFILE=1048576
+  # LimitNPROC=1048576
+  ulimit -n 1048576 -u 1048576
   exec /usr/bin/ceph-osd "${DAEMON_OPTS[@]}" -i "${OSD_ID}"
 }

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -8,6 +8,9 @@ function osd_activate {
     exit 1
   fi
 
+  ulimit -Sn 1024
+  ulimit -Hn 4096
+
   if [ -L "${OSD_DEVICE}" ]; then
     OSD_DEVICE=$(readlink -f ${OSD_DEVICE})
   fi

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -105,5 +105,9 @@ function osd_volume_activate {
       fi
     done
   }
+  # /usr/lib/systemd/system/ceph-osd@.service
+  # LimitNOFILE=1048576
+  # LimitNPROC=1048576
+  ulimit -n 1048576 -u 1048576
   exec /usr/bin/ceph-osd "${DAEMON_OPTS[@]}" -i "${OSD_ID}"
 }

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -63,6 +63,9 @@ function osd_volume_lvm {
 function osd_volume_activate {
   : "${OSD_ID:?Give me an OSD ID to activate, eg: -e OSD_ID=0}"
 
+  ulimit -Sn 1024
+  ulimit -Hn 4096
+
   CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
 
   #shellcheck disable=SC2153


### PR DESCRIPTION
The ceph-osd systemd unit script set LimitNOFILE=1048576 and
LimitNPROC=1048576.
We should enforce this value before executing the ceph-osd process.
This is especially true when the container is started with custom ulimit
nofile values but smaller than the expected (like ceph-ansible does)

Backport: #1497 
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1766079
    
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 881b66da06871e4b8f7fb1064d14d7ab1b9fd4ac)