### PR TITLE
Makefile: add docker pull parameter on build (bp #1501)

### DIFF
--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -22,7 +22,7 @@
 
 build:
 	@echo === docker build $(DAEMON_BASE_IMAGE)
-	@docker build $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
+	@docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
 
 push: ; @docker push $(DAEMON_BASE_IMAGE)
 clean:


### PR DESCRIPTION
If there's already base image present on the system then the new build
won't try to pull the latest version of that image.
When the base image isn't present on the system then the image will be
downloaded to the latest version.

That's why we could have:

$ docker images
centos  7  5f65840122d0  18 months ago  234MB

instead of:

$ docker images
centos  7  67fa590cfc1c   2 months ago  202MB

By using the --pull parameter with the docker build command we ensure
that the latest base image is pulled.

Backport: #1501 

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit e247e24a182352b3bab94ba444c779678031fa07)