### PR TITLE
ceph: temporarily use remoto from pip

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -33,9 +33,13 @@ bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
+    yum install -y python-pip ; \
+    pip install -U remoto ; \
+    yum remove -y python-pip ; \
   else \
     RELEASE_VER=1 ;\
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
 yum install -y __CEPH_BASE_PACKAGES__
+


### PR DESCRIPTION
Ceph is in the process of moving to python 3 only but in the meantime we need a higher version of remoto which has a better support of python 2.

This can get reverted in a few weeks when that transition is finished.