### PR TITLE
ceph: fix remoto hack

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -33,6 +33,7 @@ bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
+    rpm -e python-remoto --nodeps ; \
     yum install -y python-pip ; \
     pip install -U remoto ; \
     yum remove -y python-pip ; \


### PR DESCRIPTION
We need to (force) remove the packaged version before the pip install or
else we they conflict and we get the old version instead of the new.

Signed-off-by: Sage Weil <sage@redhat.com>