### PR TITLE
centos: run pip after rpm package installation

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -33,13 +33,15 @@ bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
-    yum install -y python-pip ; \
-    pip install -U remoto ; \
-    yum remove -y python-pip ; \
   else \
     RELEASE_VER=1 ;\
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
-yum install -y __CEPH_BASE_PACKAGES__
-
+yum install -y __CEPH_BASE_PACKAGES__ && \
+bash -c ' \
+  if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
+    yum install -y python-pip ; \
+    pip install -U remoto ; \
+    yum remove -y python-pip ; \
+  fi '


### PR DESCRIPTION
To update remoto via pip we need to run the upgrade process after the
package installation otherwise we will still have the old remoto version
from the rpm package.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>