### PR TITLE
daemon-base: include less

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -17,4 +17,5 @@
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \
-        __CSI_PACKAGES__
+        __CSI_PACKAGES__ \
+	less


### PR DESCRIPTION
This is purely for human users of the container.  AFAICS the other staples
are there (grep, jq, watch), but not less... and more suuuuucks.

Signed-off-by: Sage Weil <sage@redhat.com>