### PR TITLE
demo: Fix ceph health with no redundancy

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -36,7 +36,7 @@ MGR_IP=$MON_IP
 # MON #
 #######
 function bootstrap_mon {
-  if [[ "$CEPH_VERSION" != "luminous" ]] && [[ "$CEPH_VERSION" != "mimic" ]] ; then
+  if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
     MON_PORT=3300
   fi
   # shellcheck disable=SC1091
@@ -74,7 +74,7 @@ function parse_size {
 
 function bootstrap_osd {
   # Apply the tuning on Nautilus and above only since the values applied are causing the ceph-osd to crash on earlier versions
-  if [[ ${OSD_BLUESTORE} -eq 1 ]] && [[ "$CEPH_VERSION" != "luminous" ]] && [[ "$CEPH_VERSION" != "mimic" ]]; then
+  if [[ ${OSD_BLUESTORE} -eq 1 ]] && [[ "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
     tune_memory $(get_available_ram)
   fi
 

--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -181,6 +181,9 @@ function start_mon {
 
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then
+    if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic|nautilus)$ ]]; then
+      echo "mon warn on pool no redundancy = false" >> /etc/ceph/"${CLUSTER}".conf
+    fi
     /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"
 
     if [ -n "$NEW_USER_KEYRING" ]; then


### PR DESCRIPTION
Since [1] the ceph status will show a health warning when the pool size
is set the 1.
On the demo scenario we can disable this warning.
This is only for ceph release >= octopus.

[1] https://github.com/ceph/ceph/commit/33c647e

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>