### PR TITLE
demo: move OSD data path in dedicated section

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -93,11 +93,17 @@ function bootstrap_osd {
   fi
 
   if [ ! -e "$OSD_PATH"/keyring ]; then
-    if ! grep -qE "osd data = $OSD_PATH" /etc/ceph/"${CLUSTER}".conf; then
-      echo "osd data = $OSD_PATH" >> /etc/ceph/"${CLUSTER}".conf
+    if ! grep -qE "osd objectstore = bluestore" /etc/ceph/"${CLUSTER}".conf; then
       echo "osd objectstore = bluestore" >> /etc/ceph/"${CLUSTER}".conf
     fi
+    if ! grep -qE "osd data = $OSD_PATH" /etc/ceph/"${CLUSTER}".conf; then
+      cat <<ENDHERE >>/etc/ceph/"${CLUSTER}".conf
 
+[osd.${OSD_ID}]
+osd data = ${OSD_PATH}
+
+ENDHERE
+    fi
     # bootstrap OSD
     mkdir -p "$OSD_PATH"
     chown --verbose -R ceph. "$OSD_PATH"


### PR DESCRIPTION
We don't need to set the osd data path in the global section. If someone
wants to add more OSDs then it won't be possible because the OSD 0 data
path is set globally.
Instead we should set this in the osd.0 section.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>