### PR TITLE
ubi8: add container.yaml

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon/container.yaml
+++ b/ceph-releases/ALL/ubi8/daemon/container.yaml
@@ -1,0 +1,6 @@
+# https://osbs.readthedocs.io/en/latest/users.html#compose
+---
+
+compose:
+  packages: []
+  pulp_repos: true


### PR DESCRIPTION
This allows us to build the RHEL 8-based container image using packages
from ODCS.

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.