### PR TITLE
Revert "ceph: need openssh-clients for remoto to work"

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -41,7 +41,7 @@ bash -c ' \
 yum install -y __CEPH_BASE_PACKAGES__ && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
-    yum install -y python-pip openssh-clients ; \
+    yum install -y python-pip ; \
     pip install -U remoto ; \
     yum remove -y python-pip ; \
   fi '


### PR DESCRIPTION
Reverts ceph/ceph-container#1507

Replaced by https://github.com/ceph/ceph/pull/31806