### PR TITLE
README: update ceph uid/gid value for ceph osd

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -305,9 +305,9 @@ To create your OSDs simply run the following command:
 
 `docker exec <mon-container-id> ceph osd create`.
 
-Note that we now default to dropping root privileges, so it is important to set the proper ownership for your OSD directories. The Ceph OSD runs as UID:64045, GID:64045, so:
+Note that we now default to dropping root privileges, so it is important to set the proper ownership for your OSD directories. The Ceph OSD runs as UID:167, GID:167, so:
 
-`chown -R 64045:64045 /var/lib/ceph/osd/`
+`chown -R 167:167 /var/lib/ceph/osd/`
 
 #### Multiple OSDs
 


### PR DESCRIPTION
The ceph container image are based on CentOS which use the ceph user
mapped on the uid/gid 167.

Closes: #1520

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>