### PR TITLE
ubi8: add ceph-mgr-k8sevents package (bp #1524)

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,0 +1,6 @@
+ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-ssh__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
This adds the ceph-mgr-k8sevents rpm package to the RHEL 8 container
image for OCS/rook-ceph usage.

Backport: #1524
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1763918

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 3b4056dc12bd8a4d02e563cfc6e428e3c8af8166)