### PR TITLE
ubi8: remove ceph-mgr-ssh package

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
@@ -2,5 +2,4 @@ ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-ssh__ENV_[CEPH_POINT_RELEASE]__
+ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
The ceph-mgr-ssh isn't present in RHCS 4.0

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>