### PR TITLE
contrib: add vX.Y.Z container tag on ceph/ceph

### DIFF
--- a/contrib/make-ceph-base-manifests.sh
+++ b/contrib/make-ceph-base-manifests.sh
@@ -77,7 +77,7 @@ done"  # add 'done' to end of next_versions list so for loop will continue one p
                                        "${PUSH_REPOSITORY}" "${newest_build_number}")"
 
     # Apply tags for the minor versions (and major version)
-    additional_tags=()
+    additional_tags=("${version_tag}")
     minor_number="$(extract_minor_version "${version_tag}")"
     next_minor_number=''
     if [ "${next_version}" == "done" ]; then


### PR DESCRIPTION
Only vX and vX.Y were created on ceph/ceph.
The full vX.Y.Z tag was present but with a date suffix.
Let's add it by default.

Closes: #1528

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>