### PR TITLE
ceph-build-config: fix infinite loop on registry

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -343,7 +343,11 @@ function get_tags_matching () {
     if [ -n "${matching_tags}" ]; then
       all_matching_tags="$(printf '%s\n%s' "${all_matching_tags}" "${matching_tags}")"
     fi
-    page=$((page + 1))
+    if [ "$(echo "${response}" | jq -r .next)" == "null" ]; then
+      break
+    else
+      page=$((page + 1))
+    fi
   done
   local full_tags=''
   for tag in $all_matching_tags; do


### PR DESCRIPTION
Now the curl command against the docker hub registry to list the
tags per page doesn't fail on non existing page.
Because there's only a condition on the curl command then there's an
infinite loop with the page number incrementing.
We can break the loop when the next attribute is null.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>