### PR TITLE
daemon-base: add ceph-mgr-k8sevents package (bp #1531)

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,5 +1,0 @@
-ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__

--- a/src/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/src/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,4 +1,5 @@
 ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
Ceph nautilus 14.2.5 is now out and includes the k8sevents mgr package.

Backport: #1531

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 21c2ff9ec2d4470bf31dfebb7929874f340799d2)