### PR TITLE
daemon-base: drop ceph-mgr-ssh, except for the master/wip-* special case

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -41,6 +41,7 @@ bash -c ' \
 yum install -y __CEPH_BASE_PACKAGES__ && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
+    yum install -y ceph-mgr-cephadm ; \
     yum install -y python-pip ; \
     pip install -U remoto ; \
     yum remove -y python-pip ; \

--- a/src/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/src/daemon-base/__CEPH_MGR_PACKAGES__
@@ -2,5 +2,4 @@ ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-ssh__ENV_[CEPH_POINT_RELEASE]__
+ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
This is an ugly kludge but it will work for the time being until something
more elegant is sorted out.

Signed-off-by: Sage Weil <sage@redhat.com>