### PR TITLE
daemon-base: add cephadm mgr package for octopus

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -41,7 +41,6 @@ bash -c ' \
 yum install -y __CEPH_BASE_PACKAGES__ && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
-    yum install -y ceph-mgr-cephadm ; \
     yum install -y python-pip ; \
     pip install -U remoto ; \
     yum remove -y python-pip ; \

--- a/ceph-releases/nautilus/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/nautilus/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,5 +1,4 @@
 ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-cephadm__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \


### PR DESCRIPTION
This is a follow up on #1534.
Because ceph-mgr-cephadm is only available on octopus then we need a
dedicated copy of the ceph mgr packages for nautilus.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>