### PR TITLE
daemon: handle special devices in dmcrypt data (bp #1538)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -521,7 +521,11 @@ function ami_privileged {
 # Map dmcrypt data device
 function dmcrypt_data_map() {
   for lockbox in $(blkid -t PARTLABEL="ceph lockbox" -o device | tr '\n' ' '); do
-    OSD_DEVICE=${lockbox:0:-1}
+    if [[ "${lockbox}" =~ ^/dev/(cciss|nvme|loop) ]]; then
+      OSD_DEVICE=${lockbox:0:-2}
+    else
+      OSD_DEVICE=${lockbox:0:-1}
+    fi
     DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
     DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
     LOCKBOX_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")

--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -527,8 +527,9 @@ function dmcrypt_data_map() {
       OSD_DEVICE=${lockbox:0:-1}
     fi
     DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
-    DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
-    LOCKBOX_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")
+    DATA_UUID=$(get_part_uuid "${DATA_PART}")
+    LOCKBOX_PART=$(dev_part "${OSD_DEVICE}" 5)
+    LOCKBOX_UUID=$(get_part_uuid "${LOCKBOX_PART}")
     mount_lockbox "${DATA_UUID}" "${LOCKBOX_UUID}"
     ceph-disk --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon ${DATA_PART} || true
   done


### PR DESCRIPTION
Some devices use an extra 'p' character before the partition number.

Backport: #1538

Signed-off-by: Dimitri Savineau dsavinea@redhat.com