### PR TITLE
daemon: speed up create_mandatory_directories (bp #1537)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -87,7 +87,7 @@ function create_mandatory_directories {
 
   # Adjust the owner of all those directories
   chown "${CHOWN_OPT[@]}" -R ceph. /var/run/ceph/
-  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown "${CHOWN_OPT[@]}" ceph. {} \;
+  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -not \( -user ceph -or -group ceph \) -exec chown "${CHOWN_OPT[@]}" ceph. {} \;
 }
 
 # Print resolved symbolic links of a device


### PR DESCRIPTION
Makes find skip files already owned by 'ceph' user when launching
chown command; chown will unconditionally re-apply the ownership
causing a lot of writes.

It looks like we use this function not only when it is necessary
to create the directories but also when there is existing data into
those, as a safety measure.

Backport: #1537
Resolves: #1536
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1784047
Signed-off-by: Giulio Fidente <gfidente@redhat.com>
(cherry picked from commit 625630cc4a9722ad1130612c63871e75d6e9c26c)
