### PR TITLE
centos: disable python3 update for CentOS 8

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -27,7 +27,7 @@ bash -c ' \
       curl -s -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     fi ; \
   fi' && \
-yum update -y && \
+yum update -y --exclude=platform-python --exclude=python3-libs && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
 bash -c ' \
   if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \


### PR DESCRIPTION
On some GNU/Linux distribution, when updating the CentOS 8 packages in
the container base image then the platform-python package is updated.
After the update the python interpreter is broken so we can run yum/dnf
commands anymore

yum: /usr/libexec/platform-python: bad interpreter: Permission denied

As a temporary solution we can disable the platform-python and
python3-libs package update.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>