### PR TITLE
daemon-base: Add ceph-iscsi for octopus on CentOS8

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -16,9 +16,7 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi ; \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    for repo in tcmu-runner python-rtslib; do \
-      curl -s -L https://shaman.ceph.com/api/repos/$repo/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/$repo.repo ; \
-    done ; \
+    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/tcmu-runner.repo ; \
     if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
       curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/ceph-iscsi.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -3,4 +3,4 @@ echo 'Postinstall cleanup' && \
    yum clean all && \
    rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   yum-config-manager --disable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source python-rtslib-source python-rtslib-noarch python-rtslib)
+   yum-config-manager --disable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source)

--- a/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,0 +1,1 @@
+tcmu-runner ceph-iscsi python3-rtslib


### PR DESCRIPTION
There's now build available for ceph-iscsi and tcmu-runner on CentOS 8.
The rtslib python library is available in both CentOS 7 and 8 by default
so we don't need this shaman repository anymore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>