### PR TITLE
contrib: fix centos release for ceph-ci build

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -22,7 +22,8 @@ function install_docker {
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,7" BASEOS_REPO=centos build
+    CENTOS_RELEASE=$(_centos_release ${ceph_release})
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos build
   done
   docker images
 }
@@ -30,7 +31,8 @@ function build_ceph_imgs {
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-7-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,7" BASEOS_REPO=centos push
+    CENTOS_RELEASE=$(_centos_release ${ceph_release})
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos push
   done
 }
 


### PR DESCRIPTION
This also add a new function to get the centos release from a ceph
release/branch

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>