### PR TITLE
centos: add nfs-ganesha on CentOS 8

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -5,8 +5,12 @@ bash -c ' \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
     if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
-      REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=nfs-ganesha&distros=centos/__ENV_[BASEOS_TAG]__&flavor=ceph_master&ref=next&sha1=latest" | jq -a ".[0] | .url"); \
-      echo "baseurl=$REPO_URL/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
+      echo "[ganesha-noarch]" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/noarch" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
       echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -410,9 +410,7 @@ function build_bootstrap {
         fi
         ;;
       nfs)
-        if [[ "${CEPH_VERSION}" != "master" ]]; then
-          bootstrap_nfs
-        fi
+        bootstrap_nfs
         ;;
       rbd_mirror)
         bootstrap_rbd_mirror

--- a/travis-builds/validate_demo_cluster.sh
+++ b/travis-builds/validate_demo_cluster.sh
@@ -11,7 +11,7 @@ function get_cluster_name {
 }
 
 function wait_for_daemon () {
-  timeout=20
+  timeout=90
   daemon_to_test=$1
   while [ $timeout -ne 0 ]; do
     if eval $daemon_to_test; then
@@ -90,9 +90,7 @@ test_demo_mon
 test_demo_osd
 test_demo_rgw
 test_demo_mds
-if [[ $(echo $ceph_version '<' 15.0 | bc -l) == 1 ]] ; then
-  test_demo_nfs
-fi
+test_demo_nfs
 test_demo_rbd_mirror
 test_demo_mgr
 test_demo_rest_api


### PR DESCRIPTION
There nfs-ganesha builds available on https://download.nfs-ganesha.org/
instead of shaman.
Until we have someting available on shaman we can use the other source.

This also re-enable the nfs test in demo/travis.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>