### PR TITLE
centos 8: add s3cmd package

### DIFF
--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -233,9 +233,7 @@ function bootstrap_demo_user {
       log "Creating bucket..."
 
       # Trying to create a s3cmd within 5 seconds
-      if [[ "${CEPH_VERSION}" != "master" ]]; then
-        timeout 5 bash -c "until s3cmd mb s3://$CEPH_DEMO_BUCKET; do sleep .1; done"
-      fi
+      timeout 5 bash -c "until s3cmd mb s3://$CEPH_DEMO_BUCKET; do sleep .1; done"
     fi
   fi
 }
@@ -404,9 +402,7 @@ function build_bootstrap {
         bootstrap_demo_user
         bootstrap_sree
         if [[ -n "$DATA_TO_SYNC" ]] && [[ -n "$DATA_TO_SYNC_BUCKET" ]]; then
-          if [[ "${CEPH_VERSION}" != "master" ]]; then
-            import_in_s3
-          fi
+          import_in_s3
         fi
         ;;
       nfs)


### PR DESCRIPTION
The s3cmd isn't yet present on epel 8 repository but in epel 8 testing
so enabling the EPEL testing repository only during the s3cmd package
installation until it is promoted.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>