### PR TITLE
ubi8: daemon-base: install without docs

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
-yum update -y && \
-yum install -y wget unzip util-linux python3-setuptools udev device-mapper && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum update --setopt=tstflags=nodocs -y && \
+yum install --setopt=tstflags=nodocs -y wget unzip util-linux python3-setuptools udev device-mapper && \
+yum install --setopt=tstflags=nodocs -y __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
In a container, there's no need to install documentation.
Pass the relevant option for yum to skip documentation installation

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>