### PR TITLE
nautilus: parametrize k8sevents package name

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -31,6 +31,15 @@ bash -c ' \
   fi' && \
 yum update -y --exclude=platform-python --exclude=python3-libs && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
+if [[ "${CEPH_VERSION}" == nautilus ]]; then \
+  CEPH_MGR_K8SEVENTS="ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__"; \
+  if [[ -n "__ENV_[CEPH_POINT_RELEASE]__" ]]; then \
+    CPR=__ENV_[CEPH_POINT_RELEASE]__ ; \
+    if [[ ${CPR:1:2} -eq 14 ]] && [[ ${CPR:4:1} -eq 2 ]] && [[ ${CPR:6} -lt 5 ]]; then \
+      CEPH_MGR_K8SEVENTS="" ; \
+    fi ; \
+  fi ; \
+fi && \
 bash -c ' \
   if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
     yum install -y dnf-plugins-core ;\

--- a/ceph-releases/nautilus/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/nautilus/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,5 +1,5 @@
 ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
 ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
-ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
+${CEPH_MGR_K8SEVENTS} \
 ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
The ceph-mgr-k8sevents package isn't present in all Nautilus release
but only since 14.2.5.
If we try to build an older release then this package will be installed
and veriried which ultimately fails.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>