### PR TITLE
Revert "centos: disable python3 update for CentOS 8"

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -29,7 +29,7 @@ bash -c ' \
       curl -s -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     fi ; \
   fi' && \
-yum update -y --exclude=platform-python --exclude=python3-libs && \
+yum update -y && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
 bash -c ' \
   if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \


### PR DESCRIPTION
This reverts commit c7500c027aca679e0f8696f5e6dd5a9038783e06.

We don't need this anymore since CentOS 8.1 container image.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>