### PR TITLE
el8: add target-restore package

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__ISCSI_PACKAGES__
@@ -1,1 +1,1 @@
-tcmu-runner ceph-iscsi python3-rtslib
+tcmu-runner ceph-iscsi python3-rtslib target-restore

--- a/ceph-releases/ALL/ubi8/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__ISCSI_PACKAGES__
@@ -1,1 +1,1 @@
-tcmu-runner ceph-iscsi
+tcmu-runner ceph-iscsi python3-rtslib target-restore


### PR DESCRIPTION
This is a workaround for the python3-rtslib package that doesn't create
the /etc/target and /var/target directories compared to python-rtslib.
Installing target-restore package will create those without pulling a
lot a directories

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>