### PR TITLE
centos8: don't remove /usr/lib/systemd

### DIFF
--- a/ceph-releases/ALL/centos/8/__DOCKERFILE_CLEAN_COMMON__
+++ b/ceph-releases/ALL/centos/8/__DOCKERFILE_CLEAN_COMMON__
@@ -1,0 +1,29 @@
+rm -rf \
+        /etc/{selinux,systemd,udev} \
+        /lib/{lsb,udev} \
+        /tmp/* \
+        /usr/lib{,64}/{locale,udev,dracut} \
+        /usr/share/{doc,info,locale,man} \
+        /usr/share/{bash-completion,pkgconfig/bash-completion.pc} \
+        /var/log/* \
+        /var/tmp/* && \
+    find  / -xdev -name "*.pyc" -o -name "*.pyo" -exec rm -f {} \; && \
+    # ceph-dencoder is only used for debugging, compressing it saves 10MB
+    # If needed it will be decompressed
+    # TODO: Is ceph-dencoder safe to remove as rook was trying to do?
+    # rm -f /usr/bin/ceph-dencoder && \
+    if [ -f /usr/bin/ceph-dencoder ]; then gzip -9 /usr/bin/ceph-dencoder; fi && \
+    # TODO: What other ceph stuff needs removed/stripped/zipped here?
+    # TODO: There was some overlap between this and the ceph clean? Where does it belong?
+    #       If it's idempotent, it can *always* live here, even if it doesn't always apply
+    # TODO: Should we even strip ceph libs at all?
+    bash -c ' \
+      function ifstrip () { if compgen -g "$1"; then strip -s "$1"; fi } && \
+      ifstrip /usr/lib{,64}/ceph/erasure-code/* && \
+      ifstrip /usr/lib{,64}/rados-classes/* && \
+      ifstrip /usr/lib{,64}/python*/{dist,site}-packages/{rados,rbd,rgw}.*.so && \
+      ifstrip /usr/bin/{crushtool,monmaptool,osdmaptool}' && \
+    # Photoshop files inside a container ?
+    rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* && \
+    # Some logfiles are not empty, there is no need to keep them
+    find /var/log/ -type f -exec truncate -s 0 {} \;


### PR DESCRIPTION
The libsystemd-shared file is located in the /usr/lib/systemd directory
on CentOS 8.
Because we are removing the content of that directory during the
container clean then commands like udevadm that are linked to the
systemd library generete errors like:

error while loading shared libraries: libsystemd-shared-239.so: cannot
open shared object file: No such file or directory

```console
$ ldd /usr/bin/udevadm | grep systemd
        libsystemd-shared-239.so => not found
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
