### PR TITLE
osd_volume_activate: don't force c-v simple scan

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -11,7 +11,7 @@ function osd_volume_simple {
       if [[ "${device}" =~ ^/dev/(cciss|nvme|loop) ]]; then
         device+="p"
       fi
-      ceph-volume simple scan ${device}1 --force || true
+      ceph-volume simple scan ${device}1 || true
     fi
   done
 


### PR DESCRIPTION
After a reboot, the encrypted partitions aren't opened so the ceph-volume
simple scan command won't find the block partition (not mapped, broken
symlink) and the simple activate will fail.
```console
$ ceph-volume simple scan /dev/sdb1 --force
(...)
--> broken symlink found /tmp/tmpept0ox2j/block -> /dev/mapper/457d7196-4015-40fe-aa83-a160477450f7
```
```console
$ ceph-volume.log
(...)
[ceph_volume.util.system][INFO  ] /dev/sdb1 was not found as mounted
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.devices.simple.scan][WARNING] broken symlink found /tmp/tmpept0ox2j/block -> /dev/mapper/457d7196-4015-40fe-aa83-a160477450f7
[ceph_volume.devices.simple.scan][ERROR ] skipping due to IOError on file: /tmp/tmpept0ox2j/block
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/simple/scan.py", line 118, in scan_directory
    if system.is_binary(file_path):
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/system.py", line 116, in is_binary
    with open(path, 'rb') as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpept0ox2j/block'
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.devices.simple.scan][INFO  ] skipping binary file: /tmp/tmpept0ox2j/block_dmcrypt
```
If the OSD has already been scanned then we shouldn't update the
associated json file on each start.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792122

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>