### PR TITLE
osd_volume_activate: open encrypted legacy parts (bp #1572)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -373,13 +373,17 @@ function get_dmcrypt_bluestore_uuid {
   start_disk_list
   BLOCK_DB_PART=$(start_disk_list)
   unset DISK_LIST_SEARCH
-  BLOCK_DB_UUID=$(get_part_uuid "${BLOCK_DB_PART}")
+  if [ -n "${BLOCK_DB_PART}" ]; then
+    BLOCK_DB_UUID=$(get_part_uuid "${BLOCK_DB_PART}")
+  fi
 
   export DISK_LIST_SEARCH=block.wal_dmcrypt
   start_disk_list
   BLOCK_WAL_PART=$(start_disk_list)
   unset DISK_LIST_SEARCH
-  BLOCK_WAL_UUID=$(get_part_uuid "${BLOCK_WAL_PART}")
+  if [ -n "${BLOCK_WAL_PART}" ]; then
+    BLOCK_WAL_UUID=$(get_part_uuid "${BLOCK_WAL_PART}")
+  fi
 }
 
 # This function gets the uuid of filestore partitions
@@ -409,10 +413,10 @@ function open_encrypted_parts_bluestore {
   if [[ ! -e /dev/mapper/"${BLOCK_UUID}" ]]; then
     open_encrypted_part "${BLOCK_UUID}" "${BLOCK_PART}" "${DATA_UUID}"
   fi
-  if [[ ! -e /dev/mapper/"${BLOCK_DB_UUID}" ]]; then
+  if [[ -n "${BLOCK_DB_UUID}" && ! -e /dev/mapper/"${BLOCK_DB_UUID}" ]]; then
     open_encrypted_part "${BLOCK_DB_UUID}" "${BLOCK_DB_PART}" "${DATA_UUID}"
   fi
-  if [[ ! -e /dev/mapper/"${BLOCK_WAL_UUID}" ]]; then
+  if [[ -n "${BLOCK_WAL_UUID}" && ! -e /dev/mapper/"${BLOCK_WAL_UUID}" ]]; then
     open_encrypted_part "${BLOCK_WAL_UUID}" "${BLOCK_WAL_PART}" "${DATA_UUID}"
   fi
 }
@@ -437,10 +441,10 @@ function close_encrypted_parts_bluestore {
   if [[ -e /dev/mapper/"${BLOCK_UUID}" ]]; then
     close_encrypted_part "${BLOCK_UUID}" "${BLOCK_PART}" "${DATA_UUID}"
   fi
-  if [[ -e /dev/mapper/"${BLOCK_DB_UUID}" ]]; then
+  if [[ -n "${BLOCK_DB_UUID}" && -e /dev/mapper/"${BLOCK_DB_UUID}" ]]; then
     close_encrypted_part "${BLOCK_DB_UUID}" "${BLOCK_DB_PART}" "${DATA_UUID}"
   fi
-  if [[ -e /dev/mapper/"${BLOCK_WAL_UUID}" ]]; then
+  if [[ -n "${BLOCK_WAL_UUID}" && -e /dev/mapper/"${BLOCK_WAL_UUID}" ]]; then
     close_encrypted_part "${BLOCK_WAL_UUID}" "${BLOCK_WAL_PART}" "${DATA_UUID}"
   fi
 }


### PR DESCRIPTION
When managing legacy ceph-disk based OSD with ceph-volume then we need
to open the encrypted partitions before running the ceph-volume simple
scan command otherwise the scan will fail.
This situation happens after a reboot because all encrypted partitions
are closed.

$ ceph-volume simple scan /dev/sdb1 --force
(...)
--> broken symlink found /tmp/tmpept0ox2j/block -> /dev/mapper/457d7196-4015-40fe-aa83-a160477450f7

$ ceph-volume.log
(...)
[ceph_volume.util.system][INFO  ] /dev/sdb1 was not found as mounted
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.devices.simple.scan][WARNING] broken symlink found /tmp/tmpept0ox2j/block -> /dev/mapper/457d7196-4015-40fe-aa83-a160477450f7
[ceph_volume.devices.simple.scan][ERROR ] skipping due to IOError on file: /tmp/tmpept0ox2j/block
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/simple/scan.py", line 118, in scan_directory
    if system.is_binary(file_path):
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/system.py", line 116, in is_binary
    with open(path, 'rb') as fp: 
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpept0ox2j/block'
[ceph_volume.util.encryption][WARNING] failed to detect device mapper information
[ceph_volume.devices.simple.scan][INFO  ] skipping binary file: /tmp/tmpept0ox2j/block_dmcrypt

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792122
Backport: #1572 

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit d07436a353f499f11b2ce65c50686702083f8881)