### PR TITLE
add logging on the fly support (bp #1574)

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -190,7 +190,11 @@ function start_mon {
     # enable cluster/audit/mon logs on the same stream
     # Mind the extra space after 'debug'
     # DO NOT TOUCH IT, IT MUST BE PRESENT
-    DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
+    if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
+      DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--default-mon-cluster-log-to-file=false " "--log-stderr-prefix=debug ")
+    else
+      DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
+    fi
     log "SUCCESS"
     exec /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"
   fi

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -80,7 +80,12 @@ CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
 CLI_OPTS=(--cluster ${CLUSTER})
 
 # This is ONLY used for the daemon's startup, e.g: ceph-osd $DAEMON_OPTS
-DAEMON_OPTS=(--cluster ${CLUSTER} --default-log-to-file=false --default-mon-cluster-log-to-file=false --setuser ceph --setgroup ceph -d)
+DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph --log-to-stderr=true --err-to-stderr=true --default-log-to-file=false)
+if [[ "$CEPH_DAEMON" == demo ]]; then
+  DAEMON_OPTS+=(--daemon)
+else
+  DAEMON_OPTS+=(--foreground)
+fi
 
 MOUNT_OPTS=(-t xfs -o noatime,inode64)
 


### PR DESCRIPTION
as of nautilus, we can use these options so we can log to file 'on the fly'.

eg:

```
$ sudo podman exec ceph-mon-mon0 ceph config set mon.mon0 log_to_file true
$ sudo podman exec ceph-mon-mon0 ceph config set mon.mon0 mon_cluster_log_to_file true
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1710548
Closes: ceph/ceph-container#1479
Backport: #1574

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit a63bcf48c7e69c3abe7288e77c85c14554188247)