### PR TITLE
start_mon: fix DAEMON_OPTS

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -193,10 +193,9 @@ function start_mon {
     # enable cluster/audit/mon logs on the same stream
     # Mind the extra space after 'debug'
     # DO NOT TOUCH IT, IT MUST BE PRESENT
+    DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
     if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
-      DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--default-mon-cluster-log-to-file=false " "--log-stderr-prefix=debug ")
-    else
-      DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
+      DAEMON_OPTS+=("--default-mon-cluster-log-to-file=false")
     fi
     log "SUCCESS"
     exec /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"


### PR DESCRIPTION
Typical error:
```
Jan 21 16:15:20 mon0 docker[19458]: parse error setting 'mon_cluster_log_to_file' to 'false ' (Expected option value to be integer, got 'false ')
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1793608

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
