### PR TITLE
Fix osd-volume sigterm-cleanup

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -99,7 +99,7 @@ function osd_volume_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/"${CLUSTER}-${OSD_ID}" | grep '^/')
+    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/"${CLUSTER}-${OSD_ID}" | grep '^/' || true)
     for mnt in $ceph_mnt; do
       log "osd_volume_activate: Unmounting $mnt"
       umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof "$mnt")


### PR DESCRIPTION
Description of your changes:
Made sure that `findmnt ... | grep`-construction always returns 0

Which issue is resolved by this Pull Request:
`findmnt ... | grep` would return 1 when there's no mounts to be found, terminiating the sigterm_cleanup_post-function immediately, skipping the cryptsetup-close.