### PR TITLE
ubi8: add nfs-ganesha-rados-urls package

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__GANESHA_PACKAGES__
@@ -1,0 +1,1 @@
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls


### PR DESCRIPTION
Since nfs-ganesha 2.8.3, there's a new subpackage for using RADOS URLS
which is called nfs-ganesha-rados-urls

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797075

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>