### PR TITLE
Fix activating legacy osd-disk partitioned nvme device (bp #1582)

### DIFF
--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -20,12 +20,14 @@ function osd_activate {
     exit 1
   fi
 
-  if ! test -d /etc/ceph/osd || ! grep -q ${OSD_DEVICE}1 /etc/ceph/osd/*.json; then
-    log "INFO: Scanning ${OSD_DEVICE}"
-    ceph-volume simple scan ${OSD_DEVICE}1
+  data_part=$(dev_part "${OSD_DEVICE}" 1)
+
+  if ! test -d /etc/ceph/osd || ! grep -q ${data_part} /etc/ceph/osd/*.json; then
+    log "INFO: Scanning ${data_part}"
+    ceph-volume simple scan ${data_part}
   fi
 
-  CEPH_VOLUME_SCAN_FILE=$(grep -l ${OSD_DEVICE}1 /etc/ceph/osd/*.json)
+  CEPH_VOLUME_SCAN_FILE=$(grep -l ${data_part} /etc/ceph/osd/*.json)
 
   # Find the OSD ID
   OSD_ID="$(cat ${CEPH_VOLUME_SCAN_FILE} | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"whoami\"])")"


### PR DESCRIPTION
When the daemon tries to mount an nvme device which was prepared by ceph-disk, the partition path should be /dev/nvme0n1p1, the current osd_disk_activate.sh will use the hdd rule and try to find the partition as /dev/nvme0n11, which missed a 'p'.

As "dev_part" already been widly used, we can use it here to avoid un-reliable text concatenation.

Backport: #1582

Signed-off-by: Tang Jianyu <jianyu@jianyu.net>
(cherry picked from commit 1dfeba5a7fb018311c4a67862efa74a773931894)