### PR TITLE
common_functions: fix lockbox partition number (bp #1587)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -528,7 +528,11 @@ function dmcrypt_data_map() {
     fi
     DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
     DATA_UUID=$(get_part_uuid "${DATA_PART}")
-    LOCKBOX_PART=$(dev_part "${OSD_DEVICE}" 5)
+    if [[ -b "$(dev_part "${OSD_DEVICE}" 3)" ]]; then
+      LOCKBOX_PART=$(dev_part "${OSD_DEVICE}" 3)
+    else
+      LOCKBOX_PART=$(dev_part "${OSD_DEVICE}" 5)
+    fi
     LOCKBOX_UUID=$(get_part_uuid "${LOCKBOX_PART}")
     mount_lockbox "${DATA_UUID}" "${LOCKBOX_UUID}"
     ceph-disk --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon ${DATA_PART} || true


### PR DESCRIPTION
In Jewel the lockbox partition is using the partition number 3 compared
to 5 for Luminous.
The dmcrypt_data_map function doesn't handle this situation causing issue
when upgrading from Jewel to Luminous with ceph-disk dmcrypt OSDs.

Backport: #1587
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1803755

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 3fda10ce4608dec5469353bbe06eccf31295ae7f)