### PR TITLE
daemon-base/Makefile: use root for groupadd in podman

### DIFF
--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -22,9 +22,10 @@
 
 build:
 	@echo === docker build $(DAEMON_BASE_IMAGE)
-	@docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
+# use root to workaround https://bugzilla.redhat.com/show_bug.cgi?id=1802907
+	@sudo docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
 
-push: ; @docker push $(DAEMON_BASE_IMAGE)
+push: ; @sudo docker push $(DAEMON_BASE_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@docker rmi $(DAEMON_BASE_IMAGE) || true
+	@sudo docker rmi $(DAEMON_BASE_IMAGE) || true


### PR DESCRIPTION
it's a workaround of https://bugzilla.redhat.com/show_bug.cgi?id=1802907

Fixes: https://tracker.ceph.com/issues/44242
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
