### PR TITLE
Revert "daemon-base/Makefile: chown $(USER) $(DAEMON_BASE_IMAGE)"

### DIFF
--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -24,11 +24,8 @@ build:
 	@echo === docker build $(DAEMON_BASE_IMAGE)
 # use root to workaround https://bugzilla.redhat.com/show_bug.cgi?id=1802907
 	@sudo docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
-# chown the image, so it's visible to $(USER)
-	@sudo docker save $(DAEMON_BASE_IMAGE) | sudo -u $(USER) docker load
-	@sudo docker rmi $(DAEMON_BASE_IMAGE)
 
-push: ; docker push $(DAEMON_BASE_IMAGE)
+push: ; @sudo docker push $(DAEMON_BASE_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	docker rmi $(DAEMON_BASE_IMAGE) || true
+	@sudo docker rmi $(DAEMON_BASE_IMAGE) || true

--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -22,10 +22,9 @@
 
 build:
 	@echo === docker build $(DAEMON_BASE_IMAGE)
-# use root to workaround https://bugzilla.redhat.com/show_bug.cgi?id=1802907
-	@sudo docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
+	@docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
 
-push: ; @sudo docker push $(DAEMON_BASE_IMAGE)
+push: ; @docker push $(DAEMON_BASE_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@sudo docker rmi $(DAEMON_BASE_IMAGE) || true
+	@docker rmi $(DAEMON_BASE_IMAGE) || true


### PR DESCRIPTION
This reverts commit 4564c28b25b3a20c9fa1ad19340e083086b7ba1b and f307829

This is breaking the upstream ci build system.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>