### PR TITLE
osd_volume_activate: umount lockbox after scanning (bp #1592)

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -23,6 +23,9 @@ function osd_volume_simple {
         open_encrypted_parts_bluestore
       fi
       ceph-volume simple scan ${DATA_PART} --force || true
+      if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+        umount_lockbox
+      fi
     fi
   done
 


### PR DESCRIPTION
To find the correct OSD id in all the OSD devices we need to scan them.
This requires to mount the lockbox partitions and open the encrypted
partitions when using dmcrypt.
After the ceph-volume simple scan command we should umount the lockbox
partitions otherwise each OSD containers will mount all lockbox
partitions.

Backport: #1592
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1806033

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 82a1ee7d9fcbda64b21365a70c10af5a02634469)