### PR TITLE
ubi8: add gating.yaml

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon/gating.yaml
+++ b/ceph-releases/ALL/ubi8/daemon/gating.yaml
@@ -1,0 +1,7 @@
+--- !Policy
+id: "cvp-external"
+product_versions:
+ - cvp
+decision_context: cvp_default
+rules:
+ - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}


### PR DESCRIPTION
Our internal Greenwave instance will use these settings to determine overall pass/fail test results.