### PR TITLE
rhel7: add gating.yaml (bp #1600)

### DIFF
--- a/ceph-releases/ALL/rhel7/daemon/gating.yaml
+++ b/ceph-releases/ALL/rhel7/daemon/gating.yaml
@@ -1,0 +1,7 @@
+--- !Policy
+id: "cvp-external"
+product_versions:
+ - cvp
+decision_context: cvp_default
+rules:
+ - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}


### PR DESCRIPTION
Our internal Greenwave instance will use these settings to determine
overall pass/fail test results.

Backport: #1600

Co-authored-by: subhash <vpoliset@redhat.com>
Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 3916d7b77c7c2877c1b5ea533c76471d5c0cb852)