### PR TITLE
labels: add label to inform this is a ceph container

### DIFF
--- a/src/__DOCKERFILE_TRACEABILITY_LABELS__
+++ b/src/__DOCKERFILE_TRACEABILITY_LABELS__
@@ -1,6 +1,9 @@
 # Who is the maintainer ?
 LABEL maintainer="__DOCKERFILE_MAINTAINER__"
 
+# Is a ceph container ?
+LABEL ceph="True"
+
 # What is the actual release ? If not defined, this equals the git branch name
 LABEL RELEASE="__ENV_[RELEASE]__"
 


### PR DESCRIPTION
While implementing https://tracker.ceph.com/issues/44440 we had the need of being able to identify images that are "ceph images".

The idea behind this PR is to have an easy way to filter ceph images, e.g.:

```
docker images --filter label=ceph=True
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
