### PR TITLE
contrib: add missing octopus condition

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -55,7 +55,7 @@ CN_RELEASE="v2.3.1"
 
 function _centos_release {
   local release=$1
-  if [[ "${release}" =~ master|^wip* ]]; then
+  if [[ "${release}" =~ master|octopus|^wip* ]]; then
     echo 8
   else
     echo 7


### PR DESCRIPTION
The _ceph_release function which returns the CentOS release used as
the base container image was missing the octopus release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>