### PR TITLE
octopus: use ceph bits from shaman

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -50,7 +50,7 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/lab-extras.repo ;\
     echo "gpgcheck=0" >> /etc/yum.repos.d/lab-extras.repo ;\
   fi && \
-  if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
+  if [[ "${CEPH_VERSION}" =~ master|octopus|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
   else \


### PR DESCRIPTION
Because octopus is still in development then we should still use shaman
as the source and only switch to download.ceph.com when the release
become stable (15.2.x).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>