### PR TITLE
travis: remove secure variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ after_failure:
   - docker exec ceph-demo ceph --cluster test -s
 
 env:
-  global:
-    secure: Q7ilx50Ch5DPNiSfTpEwrlrzGOXTFaKVoaGdKWHoxj5zf2+G3/pggCtW3ZTeuof0AtHjsnfG0f20Y+S+pwo9q+ksTa52UdUIBOXZZVeovGfQAaH23E+gxJwxHYdWwhSJAzpRzFKgr7XoZO+lwMFYun0sBCTk8lLG/nEMw37t3ks=
   matrix:
     - CEPH_FLAVOR=master RGW_FRONTEND_TYPE=beast CENTOS_RELEASE=8
     - CEPH_FLAVOR=octopus RGW_FRONTEND_TYPE=beast CENTOS_RELEASE=8


### PR DESCRIPTION
This is not used anymore so we can remove it.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>