### PR TITLE
tox: update ansible release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,7 @@ setenv=
   VAGRANT_PROVIDER = {env:VAGRANT_PROVIDER:libvirt}
   CEPH_ANSIBLE_VAGRANT_BOX = centos/8
 deps=
-  ceph_ansible: ansible==2.4.1
-  ceph_ansible2.3: ansible==2.3.1
+  ceph_ansible: ansible>=2.8.8,<2.9
 commands=
   bash {toxinidir}/tests/tox.sh
 


### PR DESCRIPTION
This is to match the ceph-ansible ansible requirement.
We don't need the ceph_ansible2.3 env because it doesn't exist anymore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>