### PR TITLE
travis: remove secure variable (bp #1612)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,5 @@ after_failure:
   - docker exec ceph-demo ceph --cluster test -s
 
 env:
-  global:
-    secure: Q7ilx50Ch5DPNiSfTpEwrlrzGOXTFaKVoaGdKWHoxj5zf2+G3/pggCtW3ZTeuof0AtHjsnfG0f20Y+S+pwo9q+ksTa52UdUIBOXZZVeovGfQAaH23E+gxJwxHYdWwhSJAzpRzFKgr7XoZO+lwMFYun0sBCTk8lLG/nEMw37t3ks=
   matrix:
     - CEPH_FLAVOR=nautilus RGW_FRONTEND_TYPE=beast


### PR DESCRIPTION
This is not used anymore so we can remove it.

Backport: #1612

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit e5702444dc9e99571214a03c02311a50cc8d0378)