### PR TITLE
contrib: add octopus to ceph/ceph repository

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,7 +13,7 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
+X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7 octopus,centos,8"
 AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
@@ -236,7 +236,7 @@ function get_ceph_versions_on_server () {
   # <a href="ceph-12.2.7-0.el7.x86_64.rpm">ceph-12.2.7-0.el7.x86_64.rpm</a>  17-Jul-2018 14:11  3024
   # The ceph base package can be id'ed uniquely by the text ">ceph-" followed by a version string
   # Only match stable releases which are identified by the minor number '2'
-  local pkg_regex=">ceph-[0-9]+.[2].[0-9]-[0-9]+"
+  local pkg_regex=">ceph-[0-9]+.[12].[0-9]-[0-9]+"
   # pkg_list is returned in the form ">ceph-12.2.0 >ceph-12.2.1 >ceph-12.2.2 ..."
   local pkg_list
   # Make sure the versions are sorted. This should always be the case, but it's better to be safe.


### PR DESCRIPTION
This commit adds the Ceph Octopus release to the ceph/ceph repository
but only for x86_64 architecture.
When the arm64 build will be available we will add it to the mix.
This also allows using RC build (X.1.Z) in addition of stable build
(X.2.Z).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>