### PR TITLE
contrib: add octopus to arm64 list

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -50,7 +50,7 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/lab-extras.repo ;\
     echo "gpgcheck=0" >> /etc/yum.repos.d/lab-extras.repo ;\
   fi && \
-  if [[ "${CEPH_VERSION}" =~ master|octopus|^wip* ]] || ${CEPH_DEVEL}; then \
+  if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
   else \

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -5,7 +5,7 @@ set -ex
 # VARIABLES #
 #############
 
-CEPH_RELEASES=(luminous mimic nautilus)
+CEPH_RELEASES=(luminous mimic nautilus octopus)
 
 
 #############

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -14,7 +14,7 @@ trap 'exit $?' ERR
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
 X86_64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7 octopus,centos,8"
-AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7"
+AARCH64_FLAVORS_TO_BUILD="luminous,centos,7 mimic,centos,7 nautilus,centos,7 octopus,centos,8"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
We now have arm64 build available on download.ceph.com so we can add the
octopus release to the list.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>