### PR TITLE
contrib: Aggressively clean up leftover podman artifacts

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -64,6 +64,13 @@ function _centos_release {
 
 function cleanup_previous_run {
   make clean.all || true
+  # https://github.com/containers/libpod/issues/5306#issuecomment-591661572
+  # https://github.com/containers/libpod/issues/5306#issuecomment-595737952
+  if ${CI_CONTAINER}; then
+    docker system migrate || true
+    rm -rf ~/.config/containers || true
+    rm -rf ~/.local/share/containers || true
+  fi
 }
 
 declare -F install_docker ||


### PR DESCRIPTION
In our CI, we're occasionally seeing https://github.com/containers/libpod/issues/5306

This PR is an attempt to fix those issues based on the suggestions in the comments.

Signed-off-by: David Galloway <dgallowa@redhat.com>

Description of your changes:
- Cleanup leftover artifacts from previous builds
