### PR TITLE
daemon-base: Tweaks to get CentOS8 containers built

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -42,7 +42,7 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
 fi && \
 bash -c ' \
   if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
-    yum install -y dnf-plugins-core ;\
+    yum install -y dnf-plugins-core yum-utils ;\
     yum copr enable -y ktdreyer/ceph-el8 ;\
     echo "[lab-extras]" > /etc/yum.repos.d/lab-extras.repo ;\
     echo "name=labextras" >> /etc/yum.repos.d/lab-extras.repo ;\

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -2,4 +2,4 @@ echo 'Postinstall cleanup' && \
  (rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
    yum clean all && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   yum-config-manager --disable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source)
+   for repo in ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source; do yum-config-manager --disable $repo || true; done)

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,6 +1,5 @@
 echo 'Postinstall cleanup' && \
  (rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
    yum clean all && \
-   rpmdb --rebuilddb && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
    yum-config-manager --disable ceph-iscsi ceph-iscsi-source ceph-iscsi-noarch tcmu-runner tcmu-runner-noarch tcmu-runner-source)

--- a/ceph-releases/ALL/centos/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon/__DOCKERFILE_INSTALL__
@@ -1,5 +1,11 @@
 echo 'Install packages' && \
-      yum install -y wget unzip util-linux python-setuptools udev device-mapper && \
+    bash -c ' \
+    if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
+      yum install -y python3-setuptools; \
+    else \
+      yum install -y python-setuptools; \
+    fi' && \
+      yum install -y wget unzip util-linux udev device-mapper && \
       yum install -y __DAEMON_PACKAGES__ && \
     # Centos 7 doesn't have confd/forego packages, so install them from web
     __WEB_INSTALL_CONFD__ && \


### PR DESCRIPTION
**Changes:**
* This is unnecessary and doesn't work in CentOS8 anyway.
  See https://bugzilla.redhat.com/show_bug.cgi?id=1680124
* Install yum-utils to provide `yum-config-manager` command in CentOS8 container.

Signed-off-by: David Galloway <dgallowa@redhat.com>