### PR TITLE
ceph-releases: add centos-arm64/8 directory

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/__DOCKERFILE_CLEAN_COMMON__
+++ b/ceph-releases/ALL/centos-arm64/8/__DOCKERFILE_CLEAN_COMMON__
@@ -1,0 +1,1 @@
+../../centos/8/__DOCKERFILE_CLEAN_COMMON__

--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__

--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__GANESHA_PACKAGES__
@@ -1,0 +1,1 @@
+../../daemon-base/__GANESHA_PACKAGES__

--- a/ceph-releases/ALL/centos-arm64/8/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon/__DOCKERFILE_INSTALL__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon/__DOCKERFILE_INSTALL__

--- a/ceph-releases/ALL/centos-arm64/8/daemon/__ETCD_PACKAGE__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon/__ETCD_PACKAGE__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon/__ETCD_PACKAGE__

--- a/ceph-releases/ALL/centos-arm64/8/daemon/__KUBECTL_PACKAGE__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon/__KUBECTL_PACKAGE__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon/__KUBECTL_PACKAGE__


### PR DESCRIPTION
There was no CentOS 8 configuration for the arm64 architecture so the
Octopus on that arch currently fails.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>