### PR TITLE
contrib: add stable-5.0 branch for octopus

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -184,6 +184,8 @@ function create_head_or_point_release {
       CEPH_RELEASES=(luminous mimic)
     elif [ "${CONTAINER_BRANCH}" == "stable-4.0" ]; then
       CEPH_RELEASES=(nautilus)
+    elif [ "${CONTAINER_BRANCH}" == "stable-5.0" ]; then
+      CEPH_RELEASES=(octopus)
     fi
   else
     set -e


### PR DESCRIPTION
Override the ceph releases list for stable-5.0 branch (octopus).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>