### PR TITLE
octopus: nfs-ganesha bits from download.ceph.com (bp #1620)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -4,13 +4,20 @@ bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-    if [[ "${CEPH_VERSION}" =~ master|octopus|^wip* ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
       echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
       echo "[ganesha-noarch]" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/noarch" >> /etc/yum.repos.d/ganesha.repo ; \
+    elif [[ "${CEPH_VERSION}" == octopus ]]; then \
+      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
+      echo "[ganesha-noarch]" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/noarch/" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
       echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \


### PR DESCRIPTION
We now have nfs-ganesha 3.2 builds available on download.ceph.com so we
should use this source for the Ceph Octopus release.

Backport: #1620

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 116b7191954657223328711361a61cab98e7859e)