### PR TITLE
travis: remove branch limitation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: minimal
 
-branches:
-  only:
-    - master
-
 sudo: required
 
 dist: xenial


### PR DESCRIPTION
We don't need the branch limitation on stable branch.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>