### PR TITLE
ubi8: update to octopus

### DIFF
--- a/contrib/compose-rhcs.sh
+++ b/contrib/compose-rhcs.sh
@@ -6,7 +6,7 @@ set -e
 # VARIABLES #
 #############
 
-STAGING_DIR=staging/nautilus-ubi8-8-released-x86_64/
+STAGING_DIR=staging/octopus-ubi8-8-released-x86_64/
 DAEMON_DIR=$STAGING_DIR/daemon
 DAEMON_BASE_DIR=${DAEMON_DIR}-base/
 DOCKERFILE_DAEMON=$DAEMON_DIR/Dockerfile
@@ -57,7 +57,7 @@ clean_staging() {
 }
 
 make_staging() {
-  make FLAVORS=nautilus,ubi8,8-released || fatal "Cannot build rhel8"
+  make FLAVORS=octopus,ubi8,8-released || fatal "Cannot build rhel8"
 }
 
 success() {


### PR DESCRIPTION
This updates the ceph release for ubi8 to octopus and also disable the
ceph csi packages.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>