### PR TITLE
contrib: Use sudo to cleanup podman cache

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -68,8 +68,8 @@ function cleanup_previous_run {
   # https://github.com/containers/libpod/issues/5306#issuecomment-595737952
   if ${CI_CONTAINER}; then
     docker system migrate || true
-    rm -rf ~/.config/containers || true
-    rm -rf ~/.local/share/containers || true
+    sudo rm -rf ~/.config/containers || true
+    sudo rm -rf ~/.local/share/containers || true
   fi
 }
 


### PR DESCRIPTION
Fixes:
```
+ rm -rf /home/jenkins-build/.config/containers
+ rm -rf /home/jenkins-build/.local/share/containers
rm: cannot remove '/home/jenkins-build/.local/share/containers/storage/overlay/aff9833d464191900b4a3b6e68aad912f930de639b411124e433aeb3757001cd/diff/root/.wh..wh..opq': Permission denied
rm: cannot remove '/home/jenkins-build/.local/share/containers/storage/overlay/aff9833d464191900b4a3b6e68aad912f930de639b411124e433aeb3757001cd/diff/root/.bash_logout': Permission denied
```

Signed-off-by: David Galloway <dgallowa@redhat.com>