### PR TITLE
start_mon.sh: fix mon bootstrap bug

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -144,7 +144,8 @@ function start_mon {
     done
 
     # Prepare the monitor daemon's directory with the map and keyring
-    ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" --mkfs -i "${MON_NAME}" --inject-monmap "$MONMAP" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
+    ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" --mkfs -i "${MON_NAME}" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
+    ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" --inject-monmap "${MONMAP}" -i "${MON_NAME}" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
 
     # Never re-use that monmap again, otherwise we end up with partitioned Ceph monitor
     # The initial mon **only** contains the current monitor, so this is useful for initial bootstrap


### PR DESCRIPTION
The current code combines `--mkfs` and `--inject-monmap` when bootstrapping the mon which is not supported. 
We end up with a default monmap containing the mons from `mon_host` with names `noname-<x>`.This is problematic when using CNI with k8s because the ceph-mon service is resolvable only after the Pod is ready so the mons won't form a quorum.
This injects the monmap after running mkfs.

I'm thinking that this will break a few things down the line when multiple mons are bootstrapped since it's been there forever. I'll do more tests over the weekend, please don't merge yet.

I'm working in an environment without rook, but I believe this could fix https://github.com/rook/rook/issues/5065 

