### PR TITLE
ubi8: add python3-saml package for mgr SSO module

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
 yum update -y && \
-yum install -y wget unzip util-linux python3-setuptools udev device-mapper && \
+yum install -y wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
 yum install -y __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
The sso mgr module requires the saml python library to be installed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1820217

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>