### PR TITLE
ubi8: update for RHCS 5 (bp #1649)

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -3,17 +3,17 @@ RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager
 RUN rm -f /etc/yum.repos.d/ubi.repo
 
 # Editing /etc/redhat-storage-server release file
-RUN echo "Red Hat Ceph Storage Server 4 (Container)" > /etc/redhat-storage-release
+RUN echo "Red Hat Ceph Storage Server 5 (Container)" > /etc/redhat-storage-release
 
 EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 
 # Atomic specific labels
-LABEL version="4"
+LABEL version="5"
 
 # Build specific labels
 LABEL com.redhat.component="rhceph-container"
 LABEL name="rhceph"
-LABEL description="Red Hat Ceph Storage 4"
-LABEL summary="Provides the latest Red Hat Ceph Storage 4 on RHEL 8 in a fully featured and supported base image."
-LABEL io.k8s.display-name="Red Hat Ceph Storage 4 on RHEL 8"
+LABEL description="Red Hat Ceph Storage 5"
+LABEL summary="Provides the latest Red Hat Ceph Storage 5 on RHEL 8 in a fully featured and supported base image."
+LABEL io.k8s.display-name="Red Hat Ceph Storage 5 on RHEL 8"
 LABEL io.openshift.tags="rhceph ceph"

--- a/ceph-releases/ALL/ubi8/daemon/content_sets.yml
+++ b/ceph-releases/ALL/ubi8/daemon/content_sets.yml
@@ -14,12 +14,12 @@
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
-  - rhceph-4-tools-for-rhel-8-x86_64-rpms
-  - rhceph-4-mon-for-rhel-8-x86_64-rpms
-  - rhceph-4-osd-for-rhel-8-x86_64-rpms
+  - rhceph-5-tools-for-rhel-8-x86_64-rpms
+  - rhceph-5-mon-for-rhel-8-x86_64-rpms
+  - rhceph-5-osd-for-rhel-8-x86_64-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
-  - rhceph-4-tools-for-rhel-8-ppc64le-rpms
-  - rhceph-4-mon-for-rhel-8-ppc64le-rpms
-  - rhceph-4-osd-for-rhel-8-ppc64le-rpms
+  - rhceph-5-tools-for-rhel-8-ppc64le-rpms
+  - rhceph-5-mon-for-rhel-8-ppc64le-rpms
+  - rhceph-5-osd-for-rhel-8-ppc64le-rpms


### PR DESCRIPTION
RHCS 5 will be based on Ceph Octopus release.

Backport: #1649

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 2b6244e372fa2fbcf9e6f354686346eb1e41cd6e)