### PR TITLE
tox: update ansible release to 2.9 (bp #1652)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv=
   VAGRANT_PROVIDER = {env:VAGRANT_PROVIDER:libvirt}
   CEPH_ANSIBLE_VAGRANT_BOX = centos/8
 deps=
-  ceph_ansible: ansible>=2.8.8,<2.9
+  ceph_ansible: ansible>=2.9,<2.10
 commands=
   bash {toxinidir}/tests/tox.sh
 


### PR DESCRIPTION
This is to match the ceph-ansible ansible requirement. ceph-ansible now
uses ansible 2.9.

Backport: #1652

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit c050085bc30e7a88f276ac165898c3327f9875e4)