### PR TITLE
tests/tox.sh: increase pytest thread (bp #1653)

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -107,7 +107,7 @@ ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-an
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-nautilus ceph_docker_registry=$REGISTRY_ADDRESS fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
 
-py.test --reruns 5 --reruns-delay 1 -n 4 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
+py.test --reruns 5 --reruns-delay 1 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
 
 # teardown
 #################################################################################

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -95,7 +95,7 @@ sleep 1
 sudo docker --debug push localhost:5000/ceph/daemon:latest-nautilus
 
 cd "$CEPH_ANSIBLE_SCENARIO_PATH"
-vagrant up --no-provision --provider="$VAGRANT_PROVIDER"
+bash "$TOXINIDIR"/ceph-ansible/tests/scripts/vagrant_up.sh --no-provision --provider="$VAGRANT_PROVIDER"
 
 bash "$TOXINIDIR"/ceph-ansible/tests/scripts/generate_ssh_config.sh "$CEPH_ANSIBLE_SCENARIO_PATH"
 


### PR DESCRIPTION
This is to reflect the ceph-ansible configuration.

Backport: #1653

Signed-off-by: Dimitri Savineau dsavinea@redhat.com
(cherry picked from commit 0a73e117f338773ea1f902f026093aa00dbaeb13)