### PR TITLE
contrib: update commit-rhcs.sh for octopus

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -50,7 +50,7 @@ pushd "$CEPH_CONTAINER_DIR"
   contrib/compose-rhcs.sh
 popd > /dev/null
 
-COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/nautilus-ubi8-8-released-x86_64/composed
+COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/octopus-ubi8-8-released-x86_64/composed
 
 if [ ! -d "$COMPOSED_DIR" ]; then
   fatal "There is no composed directory. Looks like the build failed !"


### PR DESCRIPTION
The `contrib/commit-rhcs.sh` script needs to look in the "octopus" directory for RHCS 5.