### PR TITLE
contrib: update commit-rhcs for octopus (bp #1664)

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -50,7 +50,7 @@ pushd "$CEPH_CONTAINER_DIR"
   contrib/compose-rhcs.sh
 popd > /dev/null
 
-COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/nautilus-ubi8-8-released-x86_64/composed
+COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/octopus-ubi8-8-released-x86_64/composed
 
 if [ ! -d "$COMPOSED_DIR" ]; then
   fatal "There is no composed directory. Looks like the build failed !"


### PR DESCRIPTION
The contrib/commit-rhcs.sh script needs to look in the "octopus"
directory for RHCS 5.

Backport: #1664

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit c14464c0e94b8146d89a341596d2cfc6a8daa97f)