### PR TITLE
Makefile: allow building using Podman

### DIFF
--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -21,10 +21,10 @@
 .PHONY: build push clean
 
 build:
-	@echo === docker build $(DAEMON_BASE_IMAGE)
-	@docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
+	@echo === container build $(DAEMON_BASE_IMAGE)
+	$(IMAGE_BUILD_CMD) build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
 
-push: ; @docker push $(DAEMON_BASE_IMAGE)
+push: ; $(IMAGE_BUILD_CMD) push $(DAEMON_BASE_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@docker rmi $(DAEMON_BASE_IMAGE) || true
+	$(IMAGE_BUILD_CMD) rmi $(DAEMON_BASE_IMAGE) || true

--- a/src/daemon/Makefile
+++ b/src/daemon/Makefile
@@ -21,10 +21,10 @@
 .PHONY: build push clean
 
 build:
-	@echo === docker build $(DAEMON_IMAGE)
-	@docker build $(BUILD_ARGS) -t $(DAEMON_IMAGE) .
+	@echo === container build $(DAEMON_IMAGE)
+	$(IMAGE_BUILD_CMD) build $(BUILD_ARGS) -t $(DAEMON_IMAGE) .
 
-push: ; @docker push $(DAEMON_IMAGE)
+push: ; $(IMAGE_BUILD_CMD) push $(DAEMON_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@docker rmi $(DAEMON_IMAGE) || true
+	$(IMAGE_BUILD_CMD) rmi $(DAEMON_IMAGE) || true


### PR DESCRIPTION
These patches to the Makefile files allow building with Podman as an
alternative to Docker.

Signed-off-by:  Yaniv Kaul <ykaul@redhat.com>