### PR TITLE
common_function: use dev_real_path as array (bp #1667)

### DIFF
--- a/src/daemon/common_functions.sh
+++ b/src/daemon/common_functions.sh
@@ -275,8 +275,8 @@ function apply_ceph_ownership_to_disks {
     fi
   fi
   if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
-    dev_real_path=$(resolve_symlink "$OSD_BLUESTORE_BLOCK_WAL" "$OSD_BLUESTORE_BLOCK_DB")
-    for partition in $(list_dev_partitions "$OSD_DEVICE" "$dev_real_path"); do
+    dev_real_path=($(resolve_symlink "$OSD_BLUESTORE_BLOCK_WAL" "$OSD_BLUESTORE_BLOCK_DB"))
+    for partition in $(list_dev_partitions "$OSD_DEVICE" "${dev_real_path[@]}"); do
       part_code=$(get_part_typecode "$partition")
       if [[ "$part_code" == "5ce17fce-4087-4169-b7ff-056cc58472be" ||
             "$part_code" == "5ce17fce-4087-4169-b7ff-056cc58473f9" ||

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -68,6 +68,7 @@ function osd_activate {
   OSD_ID=$(grep "${actual_part}" /proc/mounts | awk '{print $2}' | sed -r 's/^.*-([0-9]+)$/\1/')
 
   if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
+    OSD_PATH=$(get_osd_path "${OSD_ID}")
     # Get the device used for block db and wal otherwise apply_ceph_ownership_to_disks will fail
     OSD_BLUESTORE_BLOCK_DB_TMP=$(resolve_symlink "${OSD_PATH}block.db")
 # shellcheck disable=SC2034


### PR DESCRIPTION
When applying ceph owner/group for Bluestore OSD with dedicated DB
and/or WAL partitions then the blank spaces in the dev_real_path
variable will be preserve. The result will be a single string which
won't be evaluated correctly with the for loop.

Backport: #1667
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1831273
Closes: #1579

Signed-off-by: Dimitri Savineau dsavinea@redhat.com
(cherry picked from commit dc262d14421f3964eea70e0cb0f4d6832120e081)