### PR TITLE
ubi8: ignore absent pulp repositories (bp #1669)

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon/container.yaml
+++ b/ceph-releases/ALL/ubi8/daemon/container.yaml
@@ -4,3 +4,4 @@
 compose:
   packages: []
   pulp_repos: true
+  ignore_absent_pulp_repos: true


### PR DESCRIPTION
OSBS introduced a new "ignore_absent_pulp_repos" setting. This setting
tells ODCS to proceed when it cannot find some of the expected
repositories in pulp.

The reason we must enable this setting is that Red Hat release
engineering has not created all the pulp repositories in
content_sets.yml yet. We can revert this commit when all of those pulp
repositories are ready.

Backport: #1669

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 59450b60137b2e9daaedac95ca750946fbeefc6e)