### PR TITLE
support crimson packages for wip branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ BASEOS_TAG ?= ""
 
 # Use Ceph development build packages from shaman/chacra repositories.
 CEPH_DEVEL ?= false
+OSD_FLAVOR ?= "default"
 
 
 # ==============================================================================

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -58,7 +58,7 @@ bash -c ' \
     echo "gpgcheck=0" >> /etc/yum.repos.d/lab-extras.repo ;\
   fi && \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
-    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
   else \
     RELEASE_VER=1 ;\

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -34,11 +34,18 @@ fi
 CONTAINER_REPO_USERNAME=${CONTAINER_REPO_USERNAME:-$DOCKER_HUB_USERNAME}
 CONTAINER_REPO_PASSWORD=${CONTAINER_REPO_PASSWORD:-$DOCKER_HUB_PASSWORD}
 
+OUTFILE=../src/daemon-base/__CRIMSON_PACKAGES__
+if [[ "$FLAVOR" == "crimson" ]] && ! grep -q "crimson" $OUTFILE ; then
+  echo "        ceph-crimson-osd__ENV_[CEPH_POINT_RELEASE]__" >> $OUTFILE
+fi
+
 # GIT_BRANCH is typically 'origin/master', we strip the variable to only get 'master'
 CONTAINER_BRANCH="${GIT_BRANCH#*/}"
 CONTAINER_SHA=$(git rev-parse --short HEAD)
 TAGGED_HEAD=false # does HEAD is on a tag ?
 DEVEL=${DEVEL:=false}
+OSD_FLAVOR=${FLAVOR:="default"}
+
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'master' position in the array, this will break the 'latest' tag
   CEPH_RELEASES=(master luminous mimic nautilus octopus)
@@ -202,6 +209,7 @@ function build_ceph_imgs {
   if ${CI_CONTAINER}; then
     make FLAVORS="${CEPH_BRANCH},centos,$(_centos_release ${CEPH_BRANCH})" \
          CEPH_DEVEL="true" \
+         OSD_FLAVOR=${OSD_FLAVOR} \
          RELEASE=${RELEASE} \
          TAG_REGISTRY=${CONTAINER_REPO_ORGANIZATION} \
          IMAGES_TO_BUILD=daemon-base \

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -20,6 +20,7 @@ $(shell bash -c 'set -eu ; \
 	set_var CEPH_VERSION       "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_VERSION)" ; \
 	set_var CEPH_POINT_RELEASE "$$(bash maint-lib/ceph_version.sh "$$ceph_version_spec" CEPH_POINT_RELEASE)" ; \
 	set_var CEPH_DEVEL         "$(CEPH_DEVEL)" ; \
+	set_var	OSD_FLAVOR         "$(OSD_FLAVOR)" ; \
 	set_var DISTRO             "$(word 3, $(subst $(comma), , $(1)))" ; \
 	set_var DISTRO_VERSION     "$(word 4, $(subst $(comma), , $(1)))" ; \
 	\

--- a/maint-lib/stagelib/envglobals.py
+++ b/maint-lib/stagelib/envglobals.py
@@ -18,6 +18,7 @@ REQUIRED_ENV_VARS = OrderedDict([
                             ALIGNED_NEWLINE + '(e.g., luminous, mimic)'),  # noqa: E241
     ('CEPH_POINT_RELEASE', 'Points to specific version of Ceph (e.g -12.2.0) or empty'),  # noqa: E241,E501
     ('CEPH_DEVEL',         'Flag to enable ceph development packages (default false)'), # noqa: E241,E501
+    ('OSD_FLAVOR',         'Choose to build between default and crimson osd (default flavor: default)'), # noqa: E241,E501
     ('DISTRO',             'Distro part of the ceph-releases source path (e.g., opensuse, centos)'),  # noqa: E241,E501
     ('DISTRO_VERSION',     'Distro version part of the ceph-releases source path' +  # noqa: E241,E501
                             ALIGNED_NEWLINE + '(e.g. in quotes, opensuse/"42.3", centos/"7")'),

--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -7,6 +7,7 @@ __DOCKERFILE_TRACEABILITY_LABELS__
 ENV CEPH_VERSION __ENV_[CEPH_VERSION]__
 ENV CEPH_POINT_RELEASE "__ENV_[CEPH_POINT_RELEASE]__"
 ENV CEPH_DEVEL __ENV_[CEPH_DEVEL]__
+ENV OSD_FLAVOR __ENV_[OSD_FLAVOR]__
 
 #======================================================
 # Install ceph and dependencies, and clean up

--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -17,4 +17,5 @@
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \
-        __CSI_PACKAGES__
+        __CSI_PACKAGES__ \
+        __CRIMSON_PACKAGES__ 


### PR DESCRIPTION
For testing crimson in container environment for wip branches, introduce
a centos 8 container with crimson if OSD_FLAVOR is set to crimson.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
