### PR TITLE
manifest: add variant attribute to arm64 build

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -312,6 +312,9 @@ function create_registry_manifest {
 
       #shellcheck disable=SC2086
       docker manifest create $DOCKER_IMAGES
+      if [ -n "$BUILD_ARM" ]; then
+        docker manifest annotate --variant v8 "${TARGET_RELEASE}" "${TARGET_RELEASE}-aarch64"
+      fi
       docker manifest push "$TARGET_RELEASE"
     done
   done

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -530,6 +530,7 @@ manifests:
     platform:
       architecture: arm64
       os: linux
+      variant: v8
 EOF
   info "manifest file:
 $(cat "${manifest_spec_file}")


### PR DESCRIPTION
The arm64 container image needs to be referenced with the variant
attribute.
At the moment, the arm64 is only referring to arm64v8 which could change
in the futur.
This doesn't seem to be an issue on docker platform but only for podman.

Closes: #1673

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>