### PR TITLE
ubi8: add s390x entry to content_sets.yml

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon/content_sets.yml
+++ b/ceph-releases/ALL/ubi8/daemon/content_sets.yml
@@ -23,3 +23,9 @@ ppc64le:
   - rhceph-5-tools-for-rhel-8-ppc64le-rpms
   - rhceph-5-mon-for-rhel-8-ppc64le-rpms
   - rhceph-5-osd-for-rhel-8-ppc64le-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
+  - rhceph-5-tools-for-rhel-8-s390x-rpms
+  - rhceph-5-mon-for-rhel-8-s390x-rpms
+  - rhceph-5-osd-for-rhel-8-s390x-rpms


### PR DESCRIPTION
We're building the RHCS 5 container for s390x. Add the relevant repositories to the `content_sets.yml` file that the [OSBS](https://osbs.readthedocs.io/) and [Freshmaker](https://pagure.io/freshmaker) systems read.