### PR TITLE
osd_volume_activate: support ceph-disk based OSDs via ceph-volume

### DIFF
--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -102,7 +102,7 @@ function osd_volume_activate {
       else
         DATA=$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])")
       fi
-      if grep -qo "${uuid}" "${DATA}"; then
+      if echo "${DATA}" | grep -qo "${uuid}"; then
         log "osd_volume_activate: Closing dmcrypt $uuid"
         cryptsetup close "${uuid}" || log "osd_volume_activate: Failed to close dmcrypt ${uuid}"
       fi

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -8,7 +8,7 @@ function osd_volume_simple {
   # Scan devices with ceph data partition
   for device in ${DEVICES}; do
     if parted --script "${device}" print | grep -qE '^ 1.*ceph data'; then
-      if [[ "${device}" =~ ^/dev/(cciss|nvme) ]]; then
+      if [[ "${device}" =~ ^/dev/(cciss|nvme|loop) ]]; then
         device+="p"
       fi
       ceph-volume simple scan ${device}1 --force || true

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -e
 
-function get_osd_volume_type {
-  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
-  #shellcheck disable=SC2153
-  if echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])" &> /dev/null; then
-    echo "lvm"
-  else
-    echo "simple"
-  fi
-}
-
 function osd_volume_simple {
   # Find the devices used by ceph-disk
   DEVICES=$(ceph-volume inventory --format json | python -c 'import sys, json; print(" ".join([d.get("path") for d in json.load(sys.stdin) if "Used by ceph-disk" in d.get("rejected_reasons")]))')
@@ -26,6 +16,7 @@ function osd_volume_simple {
   done
 
   # Find the OSD json file associated to the ID
+  #shellcheck disable=SC2153
   OSD_JSON=$(grep -l "whoami\": ${OSD_ID}$" /etc/ceph/osd/*.json)
   if [ -z "${OSD_JSON}" ]; then
     log "OSD id ${OSD_ID} does not exist"
@@ -46,10 +37,10 @@ function get_dmcrypt_uuids {
 
 function osd_volume_lvm {
   # Find the OSD FSID from the OSD ID
-  OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
+  OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'][0]['tags']['ceph.osd_fsid'])")"
 
   # Find the OSD type
-  OSD_TYPE="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"type\"])")"
+  OSD_TYPE="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'][0]['type'])")"
 
   # Discover the objectstore
   if [[ "data journal" =~ $OSD_TYPE ]]; then
@@ -75,7 +66,14 @@ function osd_volume_activate {
   ulimit -Sn 1024
   ulimit -Hn 4096
 
-  OSD_VOLUME_TYPE=$(get_osd_volume_type)
+  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
+
+  #shellcheck disable=SC2153
+  if echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)['$OSD_ID'])" &> /dev/null; then
+    OSD_VOLUME_TYPE=lvm
+  else
+    OSD_VOLUME_TYPE=simple
+  fi
 
   if [[ "$OSD_VOLUME_TYPE" == "lvm" ]]; then
     osd_volume_lvm

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -1,19 +1,36 @@
 #!/bin/bash
 set -e
 
-function osd_volume_activate {
-  : "${OSD_ID:?Give me an OSD ID to activate, eg: -e OSD_ID=0}"
+function osd_volume_simple {
+  # Find the devices used by ceph-disk
+  DEVICES=$(ceph-volume inventory --format json | python -c 'import sys, json; print(" ".join([d.get("path") for d in json.load(sys.stdin) if "Used by ceph-disk" in d.get("rejected_reasons")]))')
 
-  ulimit -Sn 1024
-  ulimit -Hn 4096
+  # Scan devices with ceph data partition
+  for device in ${DEVICES}; do
+    if parted --script "${device}" print | grep -qE '^ 1.*ceph data'; then
+      if [[ "${device}" =~ ^/dev/(cciss|nvme) ]]; then
+        device+="p"
+      fi
+      ceph-volume simple scan ${device}1 --force || true
+    fi
+  done
 
-  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
-
-  if ! echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
-    log "OSD id $OSD_ID does not exist"
+  # Find the OSD json file associated to the ID
+  OSD_JSON=$(grep -l "whoami\": ${OSD_ID}$" /etc/ceph/osd/*.json)
+  if [ -z "${OSD_JSON}" ]; then
+    log "OSD id ${OSD_ID} does not exist"
     exit 1
   fi
 
+  # Activate the OSD
+  # The command can fail so if it does, let's output the ceph-volume logs
+  if ! ceph-volume simple activate --file ${OSD_JSON} --no-systemd; then
+    cat /var/log/ceph
+    exit 1
+  fi
+}
+
+function osd_volume_lvm {
   # Find the OSD FSID from the OSD ID
   OSD_FSID="$(echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"][0][\"tags\"][\"ceph.osd_fsid\"])")"
 
@@ -35,6 +52,21 @@ function osd_volume_activate {
   if ! ceph-volume lvm activate --no-systemd "${OSD_OBJECTSTORE[@]}" "${OSD_ID}" "${OSD_FSID}"; then
     cat /var/log/ceph
     exit 1
+  fi
+}
+
+function osd_volume_activate {
+  : "${OSD_ID:?Give me an OSD ID to activate, eg: -e OSD_ID=0}"
+
+  ulimit -Sn 1024
+  ulimit -Hn 4096
+
+  CEPH_VOLUME_LIST_JSON="$(ceph-volume lvm list --format json)"
+
+  if echo "$CEPH_VOLUME_LIST_JSON" | python -c "import sys, json; print(json.load(sys.stdin)[\"$OSD_ID\"])" &> /dev/null; then
+    osd_volume_lvm
+  else
+    osd_volume_simple
   fi
 
   log "SUCCESS"

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -23,6 +23,9 @@ function osd_volume_simple {
         open_encrypted_parts_bluestore
       fi
       ceph-volume simple scan ${DATA_PART} --force || true
+      if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+        umount_lockbox
+      fi
     fi
   done
 


### PR DESCRIPTION
This adds support for managing ceph-disk based OSDs via ceph-volume simple commands when using the `OSD_CEPH_VOLUME_ACTIVATE` entrypoint.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1844591

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>