### PR TITLE
centos: use repo at buildlogs.centos.org for nfs-ganesha

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -5,12 +5,7 @@ bash -c ' \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
     if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
-      echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
-      echo "[ganesha-noarch]" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/noarch" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever/storage/\$basearch/nfsganesha-3/" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == octopus ]]; then \
       echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
see https://download.nfs-ganesha.org/3/LATEST/RHEL/

also, the noarch packages are now offered by arch-specific repo, see
https://buildlogs.centos.org/centos/8/storage/x86_64/nfsganesha-3/Packages/n/
where nfs-ganesha-selinux-* packages can also be found.

Signed-off-by: Kefu Chai <kchai@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
