### PR TITLE
centos: use https for ganesha repository (bp #1686)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -12,16 +12,16 @@ bash -c ' \
       echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "baseurl=https://download.nfs-ganesha.org/3/LATEST/CentOS/el-\$releasever/noarch" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == octopus ]]; then \
-      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
       echo "[ganesha-noarch]" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha-noarch" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/noarch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.ceph.com/nfs-ganesha/rpm-V3.2-stable/$CEPH_VERSION/el\$releasever/noarch/" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
-      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.ceph.com/nfs-ganesha/rpm-V2.8-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     else \
-      echo "baseurl=http://download.ceph.com/nfs-ganesha/rpm-V2.7-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://download.ceph.com/nfs-ganesha/rpm-V2.7-stable/$CEPH_VERSION/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
     fi ; \
     echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \


### PR DESCRIPTION
This allows to use https instead of http for the nfs ganesha repository
hosted on download.ceph.com

Backport: #1686

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit abf38c046df4ce1ff5fac3957259d528999a1eb4)