### PR TITLE
tests/tox: update ius centos repository (bp #1690)

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -30,7 +30,7 @@ else
   sudo yum install -y docker xfsprogs
   if ! command -v python3.6 &>/dev/null; then
     sudo yum -y groupinstall development
-    sudo yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+    sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
     sudo yum -y install python36u
   fi
   sudo ln -sf "$(command -v python3.6)" /usr/bin/python3


### PR DESCRIPTION
The IUS CentOS repository URL has been updated to https://repo.ius.io

Backport: #1690

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 292e32f343d1d5b97d78020d4f71b68cadf46511)