### PR TITLE
centos/8: remove copr and sepia repositories (bp #1694)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -48,15 +48,6 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
-    yum install -y dnf-plugins-core ;\
-    yum copr enable -y ktdreyer/ceph-el8 ;\
-    echo "[lab-extras]" > /etc/yum.repos.d/lab-extras.repo ;\
-    echo "name=labextras" >> /etc/yum.repos.d/lab-extras.repo ;\
-    echo "baseurl=http://apt-mirror.front.sepia.ceph.com/lab-extras/8/" >> /etc/yum.repos.d/lab-extras.repo ;\
-    echo "enabled=1" >> /etc/yum.repos.d/lab-extras.repo ;\
-    echo "gpgcheck=0" >> /etc/yum.repos.d/lab-extras.repo ;\
-  fi && \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\


### PR DESCRIPTION
All EL8 dependencies are now present on EPEL 8 so we don't need the
additional repositories that were only a temporary solution.

Backport: #1694

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 541cc031acbb5325aef06cd7eacabe6809e87657)