### PR TITLE
demo: fix no redundancy for nautilus (bp #1700)

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -182,7 +182,7 @@ function start_mon {
 
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then
-    if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic|nautilus)$ ]]; then
+    if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
       echo "mon warn on pool no redundancy = false" >> /etc/ceph/"${CLUSTER}".conf
     fi
     /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"


### PR DESCRIPTION
mon_warn_on_pool_no_redundancy has been backported to nautilus.

Backport: #1700

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 61f415697a7197e122c166faedc010e9eea6ae28)