### PR TITLE
DNM: release: Bump ceph-release RPM version

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -45,7 +45,7 @@ fi && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
-    RELEASE_VER=0 ;\
+    RELEASE_VER=1 ;\
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then \
      CRIMSON_PACKAGES="ceph-crimson-osd__ENV_[CEPH_POINT_RELEASE]__";\
     fi ;\


### PR DESCRIPTION
Backstory: chacra.ceph.com got erased inadvertently (https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/YQMAHTB7MUHL25QP7V5ZUJQSTOGY4GHX/).

The packages on download.ceph.com come from chacra.ceph.com, get signed, then pushed to download.ceph.com.

Since chacra.ceph.com got erased, I've had to rebuild the ceph-release RPM for each Ceph version.

The new ceph-release RPM version is 1-1.  See https://github.com/ceph/ceph-build/blob/master/ceph-release-rpm/build/build#L117-L125

container builds are currently failing because ceph-release-1-0.elX.noarch.rpm is missing.  e.g.,
```
[91merror: open of null/noarch/ceph-release-1-0.el8.noarch.rpm failed: No such file or directory
```

Signed-off-by: David Galloway <dgallowa@redhat.com>