### PR TITLE
build-push-ceph-container-imgs.sh: do not overwrite images created fo…

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -251,16 +251,17 @@ function push_ceph_imgs_latest {
     full_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${RELEASE}-centos-${CENTOS_RELEASE}-${HOST_ARCH}-devel
     branch_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${BRANCH}
     sha1_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}
-    docker tag $local_tag $full_repo_tag
-    docker tag $local_tag $branch_repo_tag
-    docker tag $local_tag $sha1_repo_tag
-    docker push $full_repo_tag
-    docker push $branch_repo_tag
-    docker push $sha1_repo_tag
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then
       sha1_flavor_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}-${OSD_FLAVOR}
       docker tag $local_tag $sha1_flavor_repo_tag
       docker push $sha1_flavor_repo_tag
+    else
+      docker tag $local_tag $full_repo_tag
+      docker tag $local_tag $branch_repo_tag
+      docker tag $local_tag $sha1_repo_tag
+      docker push $full_repo_tag
+      docker push $branch_repo_tag
+      docker push $sha1_repo_tag
     fi
     return
   fi


### PR DESCRIPTION
…r default flavor

otherwise cephadm and other consumers pulling using $full_repo_tag,
$branch_repo_tag and $sha1_repo_tag will be testing crimson-osd, if
crimson-osd flavored image is pushed after the default one.

Signed-off-by: Kefu Chai <kchai@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
