### PR TITLE
[skip ci] contrib/rhcs: update ubi8 container image (bp #1721)

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -50,7 +50,7 @@ pushd "$CEPH_CONTAINER_DIR"
   contrib/compose-rhcs.sh
 popd > /dev/null
 
-COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/octopus-ubi8-8-released-x86_64/composed
+COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/octopus-ubi8-latest-x86_64/composed
 
 if [ ! -d "$COMPOSED_DIR" ]; then
   fatal "There is no composed directory. Looks like the build failed !"

--- a/contrib/compose-rhcs.sh
+++ b/contrib/compose-rhcs.sh
@@ -6,7 +6,7 @@ set -e
 # VARIABLES #
 #############
 
-STAGING_DIR=staging/octopus-ubi8-8-released-x86_64/
+STAGING_DIR=staging/octopus-ubi8-latest-x86_64/
 DAEMON_DIR=$STAGING_DIR/daemon
 DAEMON_BASE_DIR=${DAEMON_DIR}-base/
 DOCKERFILE_DAEMON=$DAEMON_DIR/Dockerfile
@@ -57,7 +57,7 @@ clean_staging() {
 }
 
 make_staging() {
-  make FLAVORS=octopus,ubi8,8-released || fatal "Cannot build rhel8"
+  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi8/ubi FLAVORS=octopus,ubi8,latest || fatal "Cannot build rhel8"
 }
 
 success() {


### PR DESCRIPTION
We now need to inherit from registry.redhat.io when using the ubi8
container image.
The ubi8 taag also changed from 8-released to latest.

Backport: #1721

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 97db9ff4e8004d31e9db249e29917faff0c6e4aa)