### PR TITLE
tcmu-runner: set log dir to /var/log/tcmu-runner (bp #1726)

### DIFF
--- a/src/daemon/start_tcmu_runner.sh
+++ b/src/daemon/start_tcmu_runner.sh
@@ -16,7 +16,10 @@ function start_tcmu_runner {
   # mount configfs at /sys/kernel/config
   mount -t configfs none /sys/kernel/config
 
+  # create the log directory
+  mkdir -p "${TCMU_RUNNER_LOG_DIR}"
+
   log "SUCCESS"
   # start tcmu-runner
-  exec tcmu-runner
+  exec tcmu-runner --tcmu-log-dir "${TCMU_RUNNER_LOG_DIR}"
 }

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -123,3 +123,4 @@ MONMAP=/etc/ceph/monmap-${CLUSTER}
 MGR_KEYRING=/var/lib/ceph/mgr/${CLUSTER}-${MGR_NAME}/keyring
 RBD_MIRROR_KEYRING=/etc/ceph/${CLUSTER}.client.rbd-mirror.${HOSTNAME}.keyring
 STAYALIVE=
+TCMU_RUNNER_LOG_DIR=/var/log/tcmu-runner

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -105,7 +105,7 @@ export ANSIBLE_SSH_ARGS="-F $CEPH_ANSIBLE_SCENARIO_PATH/vagrant_ssh_config -o Co
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/tests/setup.yml --extra-vars="ceph_docker_registry=$REGISTRY_ADDRESS"
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/lvm_setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
-ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-nautilus ceph_docker_registry=$REGISTRY_ADDRESS fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
+ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-nautilus ceph_docker_registry=$REGISTRY_ADDRESS ceph_docker_image=ceph/daemon fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
 
 py.test --reruns 5 --reruns-delay 1 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
 


### PR DESCRIPTION
This commit changes the log directory for tcmu-runner to
/var/log/tcmu-runner. This way we can bindmount this directory in
order to make logrotate access it from the host.

ceph-ansible related PR: ceph/ceph-ansible#5780

Backport: #1726
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1873915

Signed-off-by: Guillaume Abrioux gabrioux@redhat.com
(cherry picked from commit 94c4ece920d4ef03bd004e0fc4aa9019c8ae37ac)