### PR TITLE
DAEMON_OPTS: use --default-* for logging opts

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -194,7 +194,7 @@ function start_mon {
     # enable cluster/audit/mon logs on the same stream
     # Mind the extra space after 'debug'
     # DO NOT TOUCH IT, IT MUST BE PRESENT
-    DAEMON_OPTS+=(--mon-cluster-log-to-stderr "--log-stderr-prefix=debug ")
+    DAEMON_OPTS+=("--default-mon-cluster-log-to-stderr=true" "--default-log-stderr-prefix=debug ")
     if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
       DAEMON_OPTS+=("--default-mon-cluster-log-to-file=false")
     fi

--- a/src/daemon/variables_entrypoint.sh
+++ b/src/daemon/variables_entrypoint.sh
@@ -80,7 +80,7 @@ CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
 CLI_OPTS=(--cluster ${CLUSTER})
 
 # This is ONLY used for the daemon's startup, e.g: ceph-osd $DAEMON_OPTS
-DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph --log-to-stderr=true --err-to-stderr=true --default-log-to-file=false)
+DAEMON_OPTS=(--cluster ${CLUSTER} --setuser ceph --setgroup ceph --default-log-to-stderr=true --err-to-stderr=true --default-log-to-file=false)
 if [[ "$CEPH_DAEMON" == demo ]]; then
   DAEMON_OPTS+=(--daemon)
 else


### PR DESCRIPTION
Description of your changes:
Using --default-* in DAEMON_OPTS to allow ceph.conf to override this value.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
