### PR TITLE
tests/tox: don't use sudo with make (bp #1730)

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -105,7 +105,7 @@ export ANSIBLE_SSH_ARGS="-F $CEPH_ANSIBLE_SCENARIO_PATH/vagrant_ssh_config -o Co
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/tests/setup.yml --extra-vars="ceph_docker_registry=$REGISTRY_ADDRESS"
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/lvm_setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
-ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-docker.yml.sample --extra-vars="ceph_docker_image_tag=latest-luminous ceph_docker_registry=$REGISTRY_ADDRESS fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
+ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-docker.yml.sample --extra-vars="ceph_docker_image_tag=latest-luminous ceph_docker_registry=$REGISTRY_ADDRESS ceph_docker_image=ceph/daemon fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
 
 py.test -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
 


### PR DESCRIPTION
If we use sudo with make then we will generate some files with root:root
owner/group which can't be deleted by jenkins during the workspace clean
up.
Because we already allow the current user to use the docker socket then
there's no need to use sudo with docker commands too.

Backport: #1730

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit c945b6c3d040f8a2a4e032840edd362d69fc1dd9)