### PR TITLE
daemon: set root owner/group on etcdctl binary

### DIFF
--- a/ceph-releases/ALL/daemon/__WEB_INSTALL_ETCDCTL__
+++ b/ceph-releases/ALL/daemon/__WEB_INSTALL_ETCDCTL__
@@ -4,5 +4,5 @@ echo 'Web install etcdctl' && \
     ETCDCTL_ARCH=linux-__ENV_[GO_ARCH]__ && \
     wget -q -O- \
       "https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz" | \
-      tar xfz - -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl && \
+      tar xfz - --no-same-owner -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl && \
     mv /tmp/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl /usr/local/bin/etcdctl


### PR DESCRIPTION
When installing etcdctl binary via the upstream tarball the owner/group
is set to 478493:89939 which could lead to failure when using podman and
rootless containers.
There's no need to have such uid/gid on the etcdctl binary. When the
installation is done by package then the owner/group is root.

Closes: #1725

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>