### PR TITLE
[skip ci] contrib: registry login earlier

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -17,6 +17,7 @@ source "${SCRIPT_DIR}/ceph-build-config.sh"
 flavors_to_build="$(get_flavors_to_build "${ARCH}")"
 
 install_docker
+do_login
 do_clean
 
 echo ''

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -437,12 +437,18 @@ function image_base_changed () {
 # Image operations
 #===================================================================================================
 
+# Login on the registry
+function do_login () {
+  if [ -z "${DRY_RUN:-}" ]; then
+    docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
+  fi
+}
+
 # For an image on the local host, given the full tag (lib/repo:tag) of an image, push it
 function do_push () {
   local image_library_repo_tag="${1}"
   local push_cmd="docker push ${image_library_repo_tag}"
   if [ -z "${DRY_RUN:-}" ]; then
-    docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
     ${push_cmd}
   else
     # just echo what we would've executed if this is a dry run


### PR DESCRIPTION
Currently the registry login is only done just before the push operation
so any pull operations are done anonymously.
With the latest docker hub limitation, we should do any operation with
an authenticate user like we already do in the build-push-ceph scripts.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>