### PR TITLE
centos/8: add ktdreyer copr repository back

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -43,6 +43,10 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
+  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
+    yum install -y dnf-plugins-core ;\
+    yum copr enable -y ktdreyer/ceph-el8 ;\
+  fi && \
   if [[ "${CEPH_VERSION}" =~ master ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\


### PR DESCRIPTION
Since smarmontools 7 won't be present in CentOS 8 until 8.3 then we will
be stuck with 6.6 which isn't compatible with the device health status.
This re-adds ktdreyer copr repository that contains a smartmontools 7
build.
This is a temporary solution until CentOS 8.3 release.

Fixes: https://tracker.ceph.com/issues/47107

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>