### PR TITLE
centos/8: add ktdreyer copr repository back (bp #1745)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -48,6 +48,10 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
+  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
+    yum install -y dnf-plugins-core ;\
+    yum copr enable -y ktdreyer/ceph-el8 ;\
+  fi && \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\


### PR DESCRIPTION
Since smarmontools 7 won't be present in CentOS 8 until 8.3 then we will
be stuck with 6.6 which isn't compatible with the device health status.
This re-adds ktdreyer copr repository that contains a smartmontools 7
build.
This is a temporary solution until CentOS 8.3 release.

Fixes: https://tracker.ceph.com/issues/47107
Backport: #1745

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit aa644a5fd03aecb9eda8b95002d25ded9c57b25e)