### PR TITLE
contrib: do not overwrite images created for el8

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -281,6 +281,9 @@ function push_ceph_imgs_latest {
       sha1_flavor_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}-${OSD_FLAVOR}
       docker tag "$local_tag" "$sha1_flavor_repo_tag"
       docker push "$sha1_flavor_repo_tag"
+    elif [[ "${distro_release}" == "7" ]]; then
+      docker tag "$local_tag" "$full_repo_tag"
+      docker push "$full_repo_tag"
     else
       docker tag "$local_tag" "$full_repo_tag"
       docker tag "$local_tag" "$branch_repo_tag"


### PR DESCRIPTION
before this change, we build octopus container images for both el7 and
el8, and tag them using the same set of tag names. so the last build
wins in the racing. the consumers of these images still expect the el8
builds by asking the images by names encoded using sha1.

after this change, the el7 container images are not tagged with names
without distro_release encoded, so the el7 images does not overwrite
the el8 ones even if they are built and pushed after el8 ones with
the same sha1 and branch names.

Fixes: https://tracker.ceph.com/issues/48162
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
