### PR TITLE
[skip ci] contrib: force installing containerd on ubuntu

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -578,7 +578,7 @@ function install_docker {
   if [ -n "${DRY_RUN:-}" ]; then
     return
   fi
-  sudo apt-get install -y --force-yes docker.io
+  sudo apt-get install -y --force-yes docker.io containerd
   sudo systemctl start docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock


### PR DESCRIPTION
To avoid unmet dependencies.

```console
The following packages have unmet dependencies:
 docker.io : Depends: containerd (>= 1.2.6-0ubuntu1~)
E: Unable to correct problems, you have held broken packages.
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>