### PR TITLE
centos/8: add python3-saml package (bp #1756)

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,0 +1,7 @@
+ceph-mgr__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-cephadm__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-dashboard__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-diskprediction-local__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-k8sevents__ENV_[CEPH_POINT_RELEASE]__ \
+ceph-mgr-rook__ENV_[CEPH_POINT_RELEASE]__ \
+python3-saml


### PR DESCRIPTION
The python3-saml package is now available in EPEL 8 so we can include
it for the mgr dashboard sso module dependency.

Backport: #1756

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit b682658663b616b89b39a9ca47531211813a550f)