### PR TITLE
workflow: add NBSP validation

### DIFF
--- a/.github/workflows/nbsp.yml
+++ b/.github/workflows/nbsp.yml
@@ -1,0 +1,11 @@
+name: nbsp
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: check NBSP characters
+        run: if [[ -n $(grep --exclude-dir=.git -I -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi


### PR DESCRIPTION
This removes the NBSP test from Travis CI.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 41985804e2dbe63025d180149788bc73815d7977)