### PR TITLE
Revert "centos/8: add ktdreyer copr repository back"

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 echo 'Install packages' && \
       yum install -y wget unzip util-linux python3-setuptools udev device-mapper && \
-      yum install -y --enablerepo=PowerTools __DAEMON_PACKAGES__ && \
+      yum install -y --enablerepo=powertools __DAEMON_PACKAGES__ && \
     # Centos 8 doesn't have confd/forego/etcdctl/kubectl packages, so install them from web
     __WEB_INSTALL_CONFD__ && \
     __WEB_INSTALL_ETCDCTL__ && \

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -43,10 +43,6 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
-    yum install -y dnf-plugins-core ;\
-    yum copr enable -y ktdreyer/ceph-el8 ;\
-  fi && \
   if [[ "${CEPH_VERSION}" =~ master ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\


### PR DESCRIPTION
This reverts commit aa644a5fd03aecb9eda8b95002d25ded9c57b25e.

CentOS 8.3 has been released so we don't need the extra copr repository.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>