### PR TITLE
Revert "centos/8: add ktdreyer copr repository back" (bp #1770)

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 echo 'Install packages' && \
       yum install -y wget unzip util-linux python3-setuptools udev device-mapper && \
-      yum install -y --enablerepo=PowerTools __DAEMON_PACKAGES__ && \
+      yum install -y --enablerepo=powertools __DAEMON_PACKAGES__ && \
     # Centos 8 doesn't have confd/forego/etcdctl/kubectl packages, so install them from web
     __WEB_INSTALL_CONFD__ && \
     __WEB_INSTALL_ETCDCTL__ && \

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -48,10 +48,6 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
-    yum install -y dnf-plugins-core ;\
-    yum copr enable -y ktdreyer/ceph-el8 ;\
-  fi && \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=default&ref=${CEPH_VERSION}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\


### PR DESCRIPTION
This reverts commit aa644a5.

CentOS 8.3 has been released so we don't need the extra copr repository.

Backport: #1770

Signed-off-by: Dimitri Savineau dsavinea@redhat.com