### PR TITLE
contrib: rhcs is based on master

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -43,7 +43,7 @@ git reset --hard "origin/$CURRENT_GIT_BRANCH" || fatal "Cannot reset the local d
 DOWNSTREAM_BRANCH_VERSION=$(echo "$CURRENT_GIT_BRANCH" | sed 's/ceph-\(.*\)-rhel.*/\1/g')
 
 step "Cloning ceph-container $DOWNSTREAM_BRANCH_VERSION"
-git clone https://github.com/ceph/ceph-container.git -b "stable-$DOWNSTREAM_BRANCH_VERSION" $CEPH_CONTAINER_DIR
+git clone https://github.com/ceph/ceph-container.git -b "stable-$DOWNSTREAM_BRANCH_VERSION" "$CEPH_CONTAINER_DIR"
 
 step "Composing RHCS"
 pushd "$CEPH_CONTAINER_DIR"
@@ -78,6 +78,6 @@ This is not related to the bz but needed to keep the resync in coherency with up
 
 EOF
 COMMITS=$(git diff --staged | grep GIT_COMMIT |cut -d '"' -f 2 | sed -e ':a;N;$!ba;s/\n/../g')
-git -C  $CEPH_CONTAINER_DIR log "$COMMITS" --oneline --no-decorate >> "$COMMIT_TEMPLATE"
+git -C  "$CEPH_CONTAINER_DIR" log "$COMMITS" --oneline --no-decorate >> "$COMMIT_TEMPLATE"
 
 git commit -st "$COMMIT_TEMPLATE"

--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -50,7 +50,7 @@ pushd "$CEPH_CONTAINER_DIR"
   contrib/compose-rhcs.sh
 popd > /dev/null
 
-COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/octopus-ubi8-latest-x86_64/composed
+COMPOSED_DIR=$CEPH_CONTAINER_DIR/staging/master-ubi8-latest-x86_64/composed
 
 if [ ! -d "$COMPOSED_DIR" ]; then
   fatal "There is no composed directory. Looks like the build failed !"

--- a/contrib/compose-rhcs.sh
+++ b/contrib/compose-rhcs.sh
@@ -6,7 +6,7 @@ set -e
 # VARIABLES #
 #############
 
-STAGING_DIR=staging/octopus-ubi8-latest-x86_64/
+STAGING_DIR=staging/master-ubi8-latest-x86_64/
 DAEMON_DIR=$STAGING_DIR/daemon
 DAEMON_BASE_DIR=${DAEMON_DIR}-base/
 DOCKERFILE_DAEMON=$DAEMON_DIR/Dockerfile
@@ -57,7 +57,7 @@ clean_staging() {
 }
 
 make_staging() {
-  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi8/ubi FLAVORS=octopus,ubi8,latest || fatal "Cannot build rhel8"
+  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi8/ubi FLAVORS=master,ubi8,latest || fatal "Cannot build rhel8"
 }
 
 success() {


### PR DESCRIPTION
RHCS 5 tracks master at the moment. Remove the octopus references and update the contrib scripts for master.

We'll update to pacific when that branches.