### PR TITLE
[skip ci] daemon/demo: avoid duplicate option on restart (bp #1780)

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -183,7 +183,9 @@ function start_mon {
   # start MON
   if [[ "$CEPH_DAEMON" == demo ]]; then
     if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
-      echo "mon warn on pool no redundancy = false" >> /etc/ceph/"${CLUSTER}".conf
+      if ! grep -qE "mon warn on pool no redundancy = false" /etc/ceph/"${CLUSTER}".conf; then
+          echo "mon warn on pool no redundancy = false" >> /etc/ceph/"${CLUSTER}".conf
+      fi
     fi
     /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"
 


### PR DESCRIPTION
If the demo container is restarted then the warning option in the ceph
configuration file about the pool without redundancy will be set again
even if it is already present.

Backport: #1780

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 2bb051a8e19c7fa9015280fa36ff3afb64438e5c)