### PR TITLE
osd_activate: fix osd umount on container stop

### DIFF
--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -12,7 +12,7 @@ function osd_activate {
   ulimit -Hn 4096
 
   if [ -L "${OSD_DEVICE}" ]; then
-    OSD_DEVICE=$(readlink -f ${OSD_DEVICE})
+    OSD_DEVICE=$(readlink -f "${OSD_DEVICE}")
   fi
 
   if ! parted --script "${OSD_DEVICE}" print | grep -qE '^ 1.*ceph data'; then
@@ -22,19 +22,19 @@ function osd_activate {
 
   data_part=$(dev_part "${OSD_DEVICE}" 1)
 
-  if ! test -d /etc/ceph/osd || ! grep -q ${data_part} /etc/ceph/osd/*.json; then
+  if ! test -d /etc/ceph/osd || ! grep -q "${data_part}" /etc/ceph/osd/*.json; then
     log "INFO: Scanning ${data_part}"
-    ceph-volume simple scan ${data_part}
+    ceph-volume simple scan "${data_part}"
   fi
 
-  CEPH_VOLUME_SCAN_FILE=$(grep -l ${data_part} /etc/ceph/osd/*.json)
+  CEPH_VOLUME_SCAN_FILE=$(grep -l "${data_part}" /etc/ceph/osd/*.json)
 
   # Find the OSD ID
-  OSD_ID="$(cat ${CEPH_VOLUME_SCAN_FILE} | $PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"whoami\"])")"
+  OSD_ID="$($PYTHON -c "import sys, json; print(json.load(sys.stdin)[\"whoami\"])" < "${CEPH_VOLUME_SCAN_FILE}")"
 
   # Activate the OSD
   # The command can fail so if it does, let's output the ceph-volume logs
-  if ! ceph-volume simple activate --file ${CEPH_VOLUME_SCAN_FILE} --no-systemd; then
+  if ! ceph-volume simple activate --file "${CEPH_VOLUME_SCAN_FILE}" --no-systemd; then
     cat /var/log/ceph
     exit 1
   fi

--- a/src/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/src/daemon/osd_scenarios/osd_disk_activate.sh
@@ -39,6 +39,10 @@ function osd_activate {
     exit 1
   fi
 
+  if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+    umount_lockbox
+  fi
+
   log "SUCCESS"
   # This ensures all resources have been unmounted after the OSD has exited
   # We define `sigterm_cleanup_post` here because:
@@ -46,11 +50,9 @@ function osd_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/ | grep '^/')
-    for mnt in $ceph_mnt; do
-      log "osd_disk_activate: Unmounting $mnt"
-      umount "$mnt" || (log "osd_disk_activate: Failed to umount $mnt"; lsof "$mnt")
-    done
+    ceph_mnt="/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}"
+    log "osd_disk_activate: Unmounting $ceph_mnt"
+    umount "$ceph_mnt" || (log "osd_disk_activate: Failed to umount $ceph_mnt"; lsof "$ceph_mnt")
   }
   # /usr/lib/systemd/system/ceph-osd@.service
   # LimitNOFILE=1048576

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -19,10 +19,11 @@ function osd_volume_simple {
       elif [[ ${OSD_DMCRYPT} -eq 1 ]] && [[ ${OSD_BLUESTORE} -eq 1 ]]; then
         get_dmcrypt_bluestore_uuid  || true
         mount_lockbox "$DATA_UUID" "$LOCKBOX_UUID"
+        # shellcheck disable=SC2034
         MOUNTED_PART="/dev/mapper/${DATA_UUID}"
         open_encrypted_parts_bluestore
       fi
-      ceph-volume simple scan ${DATA_PART} --force || true
+      ceph-volume simple scan "${DATA_PART}" --force || true
       if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
         umount_lockbox
       fi

--- a/src/daemon/osd_scenarios/osd_volume_activate.sh
+++ b/src/daemon/osd_scenarios/osd_volume_activate.sh
@@ -102,11 +102,9 @@ function osd_volume_activate {
   # - having the cleaning code just next to the concerned function in the same file is nice.
   function sigterm_cleanup_post {
     local ceph_mnt
-    ceph_mnt=$(findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/"${CLUSTER}-${OSD_ID}" | grep '^/')
-    for mnt in $ceph_mnt; do
-      log "osd_volume_activate: Unmounting $mnt"
-      umount "$mnt" || (log "osd_volume_activate: Failed to umount $mnt"; lsof "$mnt")
-    done
+    ceph_mnt="/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}"
+    log "osd_volume_activate: Unmounting $ceph_mnt"
+    umount "$ceph_mnt" || (log "osd_volume_activate: Failed to umount $ceph_mnt"; lsof "$ceph_mnt")
 
     UUIDS=$(get_dmcrypt_uuids)
 


### PR DESCRIPTION
There's no need to have complexity to get the path of the current OSD.

By the way, at the moment this complexity leads to incorrect behavior:

```
-bash-4.2# docker exec ceph-osd-2 findmnt --nofsroot --noheadings --output SOURCE --submounts --target /var/lib/ceph/osd/
/dev/mapper/atomicos-root
/dev/sdb1
/dev/sda1
-bash-4.2# docker exec ceph-osd-2 df --output=target | grep '/var/lib/ceph/osd/'
/var/lib/ceph/osd/ceph-0
/var/lib/ceph/osd/ceph-2
-bash-4.2#
```

In the first method used in recent branches, it means we might try to umount
the root partition.
In the second method used in older branches we try to umount something
messed up:
```
2021-01-14 00:17:08  /opt/ceph-container/bin/entrypoint.sh: osd_disk_activate: Unmounting /var/lib/ceph/osd/ceph-0
/var/lib/ceph/osd/ceph-2

...

umount: /var/lib/ceph/osd/ceph-0
/var/lib/ceph/osd/ceph-2: mountpoint not found
++/opt/ceph-container/bin/osd_disk_activate.sh:92: sigterm_cleanup_post(): log 'osd_disk_activate: Failed to umount /var/lib/ceph/osd/ceph-0
/var/lib/ceph/osd/ceph-2'

...

++/opt/ceph-container/bin/common_functions.sh:13: log(): echo '2021-01-14 00:17:08  /opt/ceph-container/bin/entrypoint.sh: osd_disk_activate: Failed to umount /var/lib/ceph/osd/ceph-0
/var/lib/ceph/osd/ceph-2'

```
We can easily build and predict the path to umount since we have
`$CLUSTER` and `$OSD_ID` variables in the code of `osd_disk_activate.sh`

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1921750

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>