### PR TITLE
daemon-base: add support for cephfs-mirror package

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__CEPHFS_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__CEPHFS_PACKAGES__
@@ -1,0 +1,1 @@
+ceph-mds__ENV_[CEPH_POINT_RELEASE]__

--- a/ceph-releases/nautilus/daemon-base/__CEPHFS_PACKAGES__
+++ b/ceph-releases/nautilus/daemon-base/__CEPHFS_PACKAGES__
@@ -1,0 +1,1 @@
+ceph-mds__ENV_[CEPH_POINT_RELEASE]__

--- a/ceph-releases/octopus/daemon-base/__CEPHFS_PACKAGES__
+++ b/ceph-releases/octopus/daemon-base/__CEPHFS_PACKAGES__
@@ -1,0 +1,1 @@
+ceph-mds__ENV_[CEPH_POINT_RELEASE]__

--- a/src/daemon-base/__CEPHFS_PACKAGES__
+++ b/src/daemon-base/__CEPHFS_PACKAGES__
@@ -1,0 +1,2 @@
+ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
+cephfs-mirror__ENV_[CEPH_POINT_RELEASE]__

--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -4,7 +4,7 @@
         ceph-common__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-mon__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
-        ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
+        __CEPHFS_PACKAGES__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
         __CEPH_MGR_PACKAGES__\
         __CEPH_GRAFANA_PACKAGES__ \


### PR DESCRIPTION
On master/devel for Pacific we would like to have the cephfs-mirror
package to start the implementation in Rook.
This package isn't installed for RHCS 5 even if it's based on Pacific.

Signed-off-by: Sébastien Han <seb@redhat.com>
