### PR TITLE
tests/tox: increase pytest rerun delay

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -111,7 +111,7 @@ ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-an
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-master ceph_docker_registry=$REGISTRY_ADDRESS ceph_docker_image=ceph/daemon fetch_directory=$CEPH_ANSIBLE_SCENARIO_PATH/fetch"
 
-py.test --reruns 5 --reruns-delay 1 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
+py.test --reruns 5 --reruns-delay 10 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
 
 # teardown
 #################################################################################


### PR DESCRIPTION
When running pytest after the deployment then the cluster status could
be in WARNING due to global recovery event.

```console
STDOUT:

  cluster:
    id:     212ac54d-bc36-44de-a483-1f33b1b70b2d
    health: HEALTH_WARN
            1 osds down

  services:
    mon: 1 daemons, quorum mon0 (age 2m)
    mgr: mon0(active, since 2m)
    osd: 8 osds: 7 up (since 2s), 8 in (since 66s)

  data:
    pools:   3 pools, 289 pgs
    objects: 0 objects, 0 B
    usage:   26 GiB used, 199 GiB / 225 GiB avail
    pgs:     26.644% pgs unknown
             58.131% pgs not active
             147 peering
             77  unknown
             38  active+clean
             21  activating
             6   stale+active+clean

  progress:
    Global Recovery Event (25s)
      [=...........................] (remaining: 6m)
```

Increasing the pytest rerun delay to let more time to the cluster to
be fully recovered.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
