### PR TITLE
release: add pacific target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 FLAVORS ?= \
 	nautilus,centos,7 \
 	octopus,centos,8 \
+	pacific,centos,8 \
 	master,centos,8
 
 TAG_REGISTRY ?= ceph
@@ -55,6 +56,7 @@ ALL_BUILDABLE_FLAVORS := \
 	nautilus,centos,8 \
 	octopus,centos,7 \
 	octopus,centos,8 \
+	pacific,centos,8 \
 	master,centos,8
 
 # ==============================================================================

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -4,7 +4,7 @@ bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
     echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-    if [[ "${CEPH_VERSION}" =~ master ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|pacific ]]; then \
       echo "baseurl=https://buildlogs.centos.org/centos/\$releasever/storage/\$basearch/nfsganesha-3/" >> /etc/yum.repos.d/ganesha.repo ; \
     elif [[ "${CEPH_VERSION}" == octopus ]]; then \
       echo "baseurl=https://download.ceph.com/nfs-ganesha/rpm-V3.3-stable/$CEPH_VERSION/el\$releasever/\$basearch/" >> /etc/yum.repos.d/ganesha.repo ; \
@@ -25,7 +25,7 @@ bash -c ' \
     curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/tcmu-runner.repo ; \
     if [[ "${CEPH_VERSION}" =~ master ]]; then \
       curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/ceph-iscsi.repo ; \
-    elif [[ "${CEPH_VERSION}" =~ nautilus|octopus ]]; then \
+    elif [[ "${CEPH_VERSION}" =~ nautilus|octopus|pacific ]]; then \
       curl -s -L https://download.ceph.com/ceph-iscsi/3/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     else \
       curl -s -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
@@ -43,7 +43,7 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ "${CEPH_VERSION}" =~ master ]] || ${CEPH_DEVEL}; then \
+  if [[ "${CEPH_VERSION}" =~ master|pacific ]] || ${CEPH_DEVEL}; then \
     REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -a ".[0] | .url"); \
     RELEASE_VER=0 ;\
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then \


### PR DESCRIPTION
Since pacific branch has been created then we can split pacific and
master.
There's still no pacific build on download.ceph.com so this target is
still using shaman/chacra bits for now. Same thing for nfs-ganesha.
However we can use the stable ceph-iscsi 3 repository instead of
shaman/chacra.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>