### PR TITLE
[skip ci] ubi8: disable weak dependencies

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
 yum update -y && \
 yum install -y wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
By default, dnf tries to install weak dependencies which leads to install
packages like podman or chrony in the container image.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1921807

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>