### PR TITLE
[skip ci] contrib: add back luminous on centos 7

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -60,6 +60,9 @@ CN_RELEASE="v2.3.1"
 function _centos_release {
   local release=$1
   case  "${release}" in
+    *luminous*)
+      echo 7
+      ;;
     *mimic*)
       echo 7
       ;;


### PR DESCRIPTION
This was removed in ef48a80b so let's add it back.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>