### PR TITLE
contrib/build-push-ceph-container-imgs.sh: solve aarch64 pkg conflict

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -103,7 +103,11 @@ function install_podman {
     # We used to provide fuse-overlayfs-0.7.6-2.0 in lab-extras but a newer version is available in the kubic repo so we'll install/update from there
     sudo dnf install -y fuse-overlayfs
   fi
-  sudo dnf install -y podman podman-docker
+  ALLOWERASING=""
+  if [[ "$HOST_ARCH" == "aarch64" ]] ; then 
+    ALLOWERASING="--allowerasing"
+  fi
+  sudo dnf install ${ALLOWERASING} -y podman podman-docker
 }
 
 function login_docker_hub {


### PR DESCRIPTION
installing podman-docker leads to:

 Problem: cannot install both podman-2.2.1-1.el8.aarch64 and podman-2.0.5-5.module_el8.3.0+512+b3b58dca.aarch64
  - package podman-catatonit-2.0.5-5.module_el8.3.0+512+b3b58dca.aarch64 requires podman = 2.0.5-5.module_el8.3.0+512+b3b58dca, but none of the providers can be installed

Adding --allowerasing as dnf suggests allows the dnf install to complete.

Signed-off-by: Dan Mick <dmick@redhat.com>

