### PR TITLE
daemon-base/centos: specify arch on shaman url

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -11,7 +11,7 @@ jobs:
         run: make RELEASE="demo" FLAVORS="master,centos,8" build
 
       - name: run the ceph demo container
-        run: docker run -d --privileged --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -v /mnt/ceph:/var/lib/ceph -e RGW_FRONTEND_TYPE=beast -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=test -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_PORT=5001 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=github ceph/daemon:demo-master-centos-8-x86_64 demo
+        run: docker run -d --privileged --name ceph-demo -v /etc/modprobe.d:/etc/modprobe.d -v /mnt/ceph:/var/lib/ceph -e RGW_FRONTEND_TYPE=beast -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=test -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_PORT=5001 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=github -e OSD_COUNT=2 ceph/daemon:demo-master-centos-8-x86_64 demo
 
       - name: run the demo validation
         run: |

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -44,7 +44,11 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
 fi && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|pacific ]] || ${CEPH_DEVEL}; then \
-    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -a ".[0] | .url"); \
+    ARCH=$(arch); \
+    if [[ "${ARCH}" == "aarch64" ]]; then \
+      ARCH="arm64"; \
+    fi ; \
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/__ENV_[BASEOS_TAG]__/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url); \
     RELEASE_VER=0 ;\
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then \
      CRIMSON_PACKAGES="ceph-crimson-osd__ENV_[CEPH_POINT_RELEASE]__";\

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -21,8 +21,8 @@ function install_docker {
 function build_ceph_imgs {
   echo "Build Ceph container image(s)"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
-    CENTOS_RELEASE=$(_centos_release ${ceph_release})
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos build
+    CENTOS_RELEASE=$(_centos_release "${ceph_release}")
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos build
   done
   docker images
 }
@@ -30,8 +30,8 @@ function build_ceph_imgs {
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
-    CENTOS_RELEASE=$(_centos_release ${ceph_release})
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-${CENTOS_RELEASE}-aarch64 RELEASE="$RELEASE" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos push
+    CENTOS_RELEASE=$(_centos_release "${ceph_release}")
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos push
   done
 }
 

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -5,7 +5,6 @@ set -ex
 # VARIABLES #
 #############
 
-CEPH_RELEASES=(nautilus octopus)
 
 
 #############

--- a/src/daemon/demo.sh
+++ b/src/daemon/demo.sh
@@ -12,6 +12,7 @@ MDS_PATH="/var/lib/ceph/mds/${CLUSTER}-$MDS_NAME"
 RGW_PATH="/var/lib/ceph/radosgw/${CLUSTER}-rgw.${RGW_NAME}"
 # shellcheck disable=SC2153
 MGR_PATH="/var/lib/ceph/mgr/${CLUSTER}-$MGR_NAME"
+# shellcheck disable=SC2034
 MGR_IP=$MON_IP
 : "${DEMO_DAEMONS:=all}"
 : "${RGW_ENABLE_USAGE_LOG:=true}"
@@ -35,6 +36,7 @@ MGR_IP=$MON_IP
 #######
 function bootstrap_mon {
   if [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
+    # shellcheck disable=SC2034
     MON_PORT=3300
   fi
   # shellcheck disable=SC1091
@@ -73,7 +75,7 @@ function parse_size {
 function bootstrap_osd {
   # Apply the tuning on Nautilus and above only since the values applied are causing the ceph-osd to crash on earlier versions
   if [[ ${OSD_BLUESTORE} -eq 1 ]] && [[ ! "${CEPH_VERSION}" =~ ^(luminous|mimic)$ ]]; then
-    tune_memory $(get_available_ram)
+    tune_memory "$(get_available_ram)"
   fi
 
   if [[ -n "$OSD_DEVICE" ]]; then
@@ -93,7 +95,7 @@ function bootstrap_osd {
   : "${OSD_COUNT:=1}"
 
   for i in $(seq 1 1 "$OSD_COUNT"); do
-    let OSD_ID="$i"-1 || true
+    (( OSD_ID="$i"-1 )) || true
     OSD_PATH="/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}"
 
     if [ ! -e "$OSD_PATH"/keyring ]; then
@@ -162,6 +164,7 @@ function bootstrap_mds {
 #######
 function bootstrap_rgw {
   if [[ "$RGW_FRONTEND_TYPE" == "civetweb" ]]; then
+    # shellcheck disable=SC2153
     RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS port=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"
   elif [[ "$RGW_FRONTEND_TYPE" == "beast" ]]; then
     RGW_FRONTED_OPTIONS="$RGW_FRONTEND_OPTIONS endpoint=$RGW_FRONTEND_IP:$RGW_FRONTEND_PORT"

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -107,7 +107,10 @@ export ANSIBLE_SSH_ARGS="-F $CEPH_ANSIBLE_SCENARIO_PATH/vagrant_ssh_config -o Co
 
 # runs a playbook to configure nodes for testing
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/tests/setup.yml --extra-vars="ceph_docker_registry=$REGISTRY_ADDRESS"
-ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/lvm_setup.yml
+if [[ $CEPH_ANSIBLE_SCENARIO_PATH =~ "all_daemons" ]]; then
+  ANSIBLE_PLAYBOOK_ARGS=(--limit 'osds:!osd2')
+fi
+ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/lvm_setup.yml "${ANSIBLE_PLAYBOOK_ARGS[@]}"
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-master ceph_docker_registry=$REGISTRY_ADDRESS ceph_docker_image=ceph/daemon"
 

--- a/travis-builds/validate_demo_cluster.sh
+++ b/travis-builds/validate_demo_cluster.sh
@@ -41,7 +41,7 @@ function test_demo_mon {
 
 function test_demo_osd {
   # shellcheck disable=SC2046
-  return $(wait_for_daemon "$DOCKER_COMMAND -s | grep -sq '1 osds: 1 up.*, 1 in.*'")
+  return $(wait_for_daemon "$DOCKER_COMMAND -s | grep -sq '2 osds: 2 up.*, 2 in.*'")
 }
 
 function test_demo_rgw {


### PR DESCRIPTION
Because shaman is now providing aarch64 build then there's no guarantee
that the latest centos/8 build query on shaman is x86_64.

This also enable master/pacific aarch64 builds.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>