### PR TITLE
contrib/build-push-ceph-container-imgs.sh: undo kubic repo hack

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -292,19 +292,23 @@ function push_ceph_imgs_latest {
     branch_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${BRANCH}
     sha1_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then
-      sha1_flavor_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}-${OSD_FLAVOR}
-      docker tag "$local_tag" "$sha1_flavor_repo_tag"
-      docker push "$sha1_flavor_repo_tag"
+      if [[ "${HOST_ARCH}" == "x86_64" ]]; then
+        sha1_flavor_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}-${OSD_FLAVOR}
+        docker tag "$local_tag" "$sha1_flavor_repo_tag"
+        docker push "$sha1_flavor_repo_tag"
+      fi
     elif [[ "${distro_release}" == "7" ]]; then
       docker tag "$local_tag" "$full_repo_tag"
       docker push "$full_repo_tag"
     else
       docker tag "$local_tag" "$full_repo_tag"
-      docker tag "$local_tag" "$branch_repo_tag"
-      docker tag "$local_tag" "$sha1_repo_tag"
       docker push "$full_repo_tag"
-      docker push "$branch_repo_tag"
-      docker push "$sha1_repo_tag"
+      if [[ "${HOST_ARCH}" == "x86_64" ]] ; then
+        docker tag "$local_tag" "$branch_repo_tag"
+        docker tag "$local_tag" "$sha1_repo_tag"
+        docker push "$branch_repo_tag"
+        docker push "$sha1_repo_tag"
+      fi
     fi
     return
   fi


### PR DESCRIPTION
There's a reasonable chance that podman 2 fixes the issue in
https://github.com/containers/libpod/issues/5306 (the bug
seems to imply that 1.9.1 has the fix), and the kubic
repo causes problems because of podman-catatonit, sometimes
called just "catatonit", and its dependencies on and of podman-docker.

Signed-off-by: Dan Mick <dmick@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
