### PR TITLE
ceph-releases/ALL/centos: pip install scikit-learn

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -59,4 +59,5 @@ bash -c ' \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
 yum install -y __GPERFTOOLS_LIBS__ && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum install -y __CEPH_BASE_PACKAGES__ && \
+python3 -m pip install -U scikit-learn==0.19.2


### PR DESCRIPTION
The mgr failure prediction module needs this, and there is no package
for centos or EPEL (or plans to produce one).

Signed-off-by: Sage Weil <sage@newdream.net>