### PR TITLE
[skip ci] demo/validation: fix mds cluster status check

### DIFF
--- a/travis-builds/validate_demo_cluster.sh
+++ b/travis-builds/validate_demo_cluster.sh
@@ -60,7 +60,7 @@ function test_demo_mds {
   # so we first check if the pools exit, from that we assume that
   # the process will start. We stop waiting after 10 seconds.
   # shellcheck disable=SC2046
-  return $(wait_for_daemon "$DOCKER_COMMAND osd dump | grep -sq cephfs && $DOCKER_COMMAND -s | grep -sq 'up:active'")
+  return $(wait_for_daemon "$DOCKER_COMMAND osd dump | grep -sq cephfs && $DOCKER_COMMAND -s | grep -sq 'mds: 1/1 daemons up'")
 }
 
 function test_demo_rbd_mirror {


### PR DESCRIPTION
The mds daemon status output in the ceph cluster status has changed.

Before:
```console
   mds: cephfs:1 {0=demo=up:active}
```
After:
```console
    mds: 1/1 daemons up
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>