### PR TITLE
gperftools: install from epel-testing for ceph (bp #1817)

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,0 +1,1 @@
+--enablerepo='epel-testing' gperftools-libs

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -58,4 +58,5 @@ bash -c ' \
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
+yum install -y __GPERFTOOLS_LIBS__ && \
 yum install -y __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,0 +1,1 @@
+gperftools-libs

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -114,7 +114,7 @@ ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-an
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/tests/functional/setup.yml
 ansible-playbook -vv -i "$CEPH_ANSIBLE_SCENARIO_PATH"/hosts "$TOXINIDIR"/ceph-ansible/site-container.yml.sample --extra-vars="ceph_docker_image_tag=latest-pacific ceph_docker_registry=$REGISTRY_ADDRESS ceph_docker_image=ceph/daemon"
 
-py.test --reruns 5 --reruns-delay 10 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
+py.test --reruns 20 --reruns-delay 3 -n 8 --sudo -v --connection=ansible --ansible-inventory="$CEPH_ANSIBLE_SCENARIO_PATH"/hosts --ssh-config="$CEPH_ANSIBLE_SCENARIO_PATH"/vagrant_ssh_config "$TOXINIDIR"/ceph-ansible/tests/functional/tests
 
 # teardown
 #################################################################################


### PR DESCRIPTION
This commit makes any build against el8 fetch gperftools from
epel-testing which provides 2.7 instead of epel which provides 2.8.

Backport: #1817 
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1933792
Related Tracker: https://tracker.ceph.com/issues/49618#note-5

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>