### PR TITLE
centos-arm64: fix gperftools libs file

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon-base/__GPERFTOOLS_LIBS__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__GPERFTOOLS_LIBS__


### PR DESCRIPTION
The CentOS 8 arm64 configuration wasn't updated with 4c4b735.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>