### PR TITLE
daemon-base: install python3-scikit-learn on el8

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -55,6 +55,11 @@ bash -c ' \
     RELEASE_VER=1 ;\
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
-  rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
+  rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" && \
+  if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
+    yum install -y dnf-plugins-core ; \
+    yum copr enable -y tchaikov/python-scikit-learn ; \
+    yum install -y python3-scikit-learn ; \
+  fi ' && \
 yum install -y __GPERFTOOLS_LIBS__ && \
 yum install -y __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
* add copr repo for python3-scikit-learn packages
* install python3-scikit-learn package

the mgr failure prediction module needs this, and there is no package
packaged for CentOS8 or EPEL8.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1844636
Backport: #1821

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 9a3e9fd32682b07b7d846c4636734e368ff6b1b4)