### PR TITLE
Revert "gperftools: install from epel-testing" (bp #1831)

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,1 +1,0 @@
-../../../centos/8/daemon-base/__GPERFTOOLS_LIBS__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,1 +1,0 @@
-../../centos/daemon-base/__GPERFTOOLS_LIBS__

--- a/ceph-releases/ALL/centos/8/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,1 +1,0 @@
---enablerepo='epel-testing' gperftools-libs

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -61,5 +61,4 @@ bash -c ' \
     yum copr enable -y tchaikov/python-scikit-learn ; \
     yum install -y python3-scikit-learn ; \
   fi ' && \
-yum install -y __GPERFTOOLS_LIBS__ && \
 yum install -y __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon-base/__GPERFTOOLS_LIBS__
+++ b/ceph-releases/ALL/centos/daemon-base/__GPERFTOOLS_LIBS__
@@ -1,1 +1,0 @@
-gperftools-libs


### PR DESCRIPTION
This reverts commits 4c4b735e251847c21869414e9d5a843ef1e7215f and
e2d54e961ffedf75484f4922f255352477e30cb4 since gperftools has been
downgrade to 2.7 in epel 8 stable.

Backport: #1831

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 86da1a47133ecf7a6d66d318bc637c7ed1f0073a)