### PR TITLE
[skip ci] contrib: Unmask docker service if needed

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -89,6 +89,7 @@ function install_docker {
     sudo apt-get update
     sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
   fi
+  sudo systemctl unmask docker
   sudo systemctl start docker
   sudo systemctl status --no-pager docker
   sudo chgrp "$(whoami)" /var/run/docker.sock

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -579,6 +579,7 @@ function install_docker {
     return
   fi
   sudo apt-get install -y --force-yes docker.io containerd
+  sudo systemctl unmask docker
   sudo systemctl start docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock


### PR DESCRIPTION
To be honest, I don't know why this is needed.  Not sure what changed on the builders or in docker that makes the service sometimes masked.

Signed-off-by: David Galloway <dgallowa@redhat.com>
