### PR TITLE
[skip ci] contrib: add pacific to ceph/ceph namespace

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -50,7 +50,7 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ "${CEPH_VERSION}" =~ master|pacific ]] || ${CEPH_DEVEL}; then \
+  if [[ "${CEPH_VERSION}" =~ master ]] || ${CEPH_DEVEL}; then \
     ARCH=$(arch); \
     if [[ "${ARCH}" == "aarch64" ]]; then \
       ARCH="arm64"; \

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8"
-AARCH64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8"
+X86_64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8 pacific,centos,8"
+AARCH64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8 pacific,centos,8"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
This commit adds the Ceph Pacific release to the ceph/ceph registry
namespace.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>