### PR TITLE
[skip ci] daemon-base/centos: specify arch for tcmu url (bp #1839)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -29,7 +29,7 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi ; \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/tcmu-runner.repo ; \
+    curl -s -L $(curl -s "https://shaman.ceph.com/api/search/?project=tcmu-runner&distros=centos/__ENV_[BASEOS_TAG]__/$(arch)&ref=master&sha1=latest" | jq -r .[0].chacra_url)repo > /etc/yum.repos.d/tcmu-runner.repo ; \
     if [[ "${CEPH_VERSION}" =~ master ]]; then \
       curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/ceph-iscsi.repo ; \
     elif [[ "${CEPH_VERSION}" =~ nautilus|octopus|pacific ]]; then \


### PR DESCRIPTION
This is the same behaviour than the ceph build present on shaman but
for tcmu-runner this time.

Backport: #1839

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit f05750cd1ab4d7c5a5d4643e8110ddd8677281f6)