### PR TITLE
[skip ci] daemon-base: add missing env var to immutable pkg

### DIFF
--- a/src/daemon-base/__CEPH_IMMUTABLE_OBJECT_CACHE_PACKAGE__
+++ b/src/daemon-base/__CEPH_IMMUTABLE_OBJECT_CACHE_PACKAGE__
@@ -1,1 +1,1 @@
-ceph-immutable-object-cache
+ceph-immutable-object-cache__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
The CEPH_POINT_RELEASE environment variable was missing from the
ceph-immutable-object-cache package name.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>