### PR TITLE
[skip ci] centos-arm64/8: enable ceph-iscsi packages

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__ISCSI_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__ISCSI_PACKAGES__
@@ -1,0 +1,1 @@
+../../../centos/daemon-base/__ISCSI_PACKAGES__


### PR DESCRIPTION
Since we have tcmu-runner package available on shaman for arm64 which was
the last piece missing to be able to install ceph-iscsi, then we can
enable the ceph-iscsi installation on the arm64 architecture as well.
This is done only on CentOS 8 distribution.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>