### PR TITLE
daemon-base: centos: Use correct arch for tcmu-runner

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -29,7 +29,13 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi ; \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/tcmu-runner.repo ; \
+    ARCH=$(arch) ; \
+    TCMU_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=tcmu-runner&distros=__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/${ARCH}&sha1=latest" | jq -r .[0].url) ; \
+    echo "[tcmu-runner]" >> /etc/yum.repos.d/tcmu-runner.repo ; \
+    echo "name=tcmu-runner" >> /etc/yum.repos.d/tcmu-runner.repo ; \
+    echo "baseurl=${TCMU_URL}${ARCH}" >> /etc/yum.repos.d/tcmu-runner.repo ; \
+    echo "gpgcheck=0" >> /etc/yum.repos.d/tcmu-runner.repo ; \
+    echo "enabled=1" >> /etc/yum.repos.d/tcmu-runner.repo  ; \
     if [[ "${CEPH_VERSION}" =~ master ]]; then \
       curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo > /etc/yum.repos.d/ceph-iscsi.repo ; \
     elif [[ "${CEPH_VERSION}" =~ nautilus|octopus|pacific ]]; then \


### PR DESCRIPTION
Basically same as 4b458a4b.  We've been fine up until this point because an x86_64 build was the most recent for over a year.  Then an aarch64 version of tcmu-runner got built and messed everything up.

With arch (which this PR does)
```
dgalloway@p50 ~ ()$ curl -s "https://shaman.ceph.com/api/search/?project=tcmu-runner&distros=centos/8/x86_64&sha1=latest" | jq -r .[0].url
https://4.chacra.ceph.com/r/tcmu-runner/master/06d64ab78c2898c032fe5be93f9ae6f64b199d5b/centos/8/flavors/default/
```


Without arch (previous behavior)
```
dgalloway@p50 ~ ()$ curl -s "https://shaman.ceph.com/api/search/?project=tcmu-runner&distros=centos/8&sha1=latest" | jq -r .[0].url
https://2.chacra.ceph.com/r/tcmu-runner/master/06d64ab78c2898c032fe5be93f9ae6f64b199d5b/centos/8/flavors/default/
```

That particular repo on 2.chacra.ceph.com does not have x86 packages.

Signed-off-by: David Galloway <dgallowa@redhat.com>