### PR TITLE
[skip ci] daemon-base: move scikit learn to the main install (bp #1845)

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__SCIKIT_LEARN__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__SCIKIT_LEARN__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon-base/__SCIKIT_LEARN__

--- a/ceph-releases/ALL/centos-arm64/daemon-base/__SCIKIT_LEARN__
+++ b/ceph-releases/ALL/centos-arm64/daemon-base/__SCIKIT_LEARN__
@@ -1,0 +1,1 @@
+../../centos/daemon-base/__SCIKIT_LEARN__

--- a/ceph-releases/ALL/centos/8/daemon-base/__SCIKIT_LEARN__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__SCIKIT_LEARN__
@@ -1,0 +1,1 @@
+python3-scikit-learn

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -59,6 +59,5 @@ bash -c ' \
   if [[ __ENV_[BASEOS_TAG]__ -eq 8 ]]; then \
     yum install -y dnf-plugins-core ; \
     yum copr enable -y tchaikov/python-scikit-learn ; \
-    yum install -y python3-scikit-learn ; \
   fi ' && \
 yum install -y __CEPH_BASE_PACKAGES__

--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -17,4 +17,5 @@
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \
-        __CSI_PACKAGES__
+        __CSI_PACKAGES__ \
+        __SCIKIT_LEARN__


### PR DESCRIPTION
This will avoid to have a dedicated dnf install command just for this
package instead of installing it with the other packages.

Backport: #1845

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 50c62733fe9962908c16f14743ac0d9988ccdf06)