### PR TITLE
[skip ci] workflow: add arm64 container build (bp #1852)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,7 +1,7 @@
 name: container
 on: [pull_request]
 jobs:
-  build:
+  x86_64:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -29,3 +29,14 @@ jobs:
           docker ps -a
           docker logs ceph-demo
           docker exec ceph-demo ceph --cluster test -s
+  arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: setup qemu-static-user
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+      - name: build the ceph container arm64 image
+        run: make RELEASE="demo" BASEOS_REPO=arm64v8/centos DAEMON_BASE_TAG="daemon-base:demo-centos-8-aarch64" DAEMON_TAG="daemon:demo-centos-8-aarch64" FLAVORS="octopus,centos-arm64,8" build


### PR DESCRIPTION
The github workflow infrastructure doesn't offer arm64 nodes but we
can use qemu-user-static [1] to build arm64 container image on x86_64
host.

[1] https://github.com/multiarch/qemu-user-static

Backport: #1852

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit f4561236c60ec62b58780795237e8822248096ff)