### PR TITLE
[skip ci] centos/daemon-base: do not use BASEOS_REPO env var (bp #1859)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -16,9 +16,9 @@ bash -c ' \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
   fi ; \
   if [ -n "__ISCSI_PACKAGES__" ]; then \
-    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo ; \
+    curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/centos/__ENV_[BASEOS_TAG]__/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo ; \
     if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
-      curl -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/__ENV_[BASEOS_REPO]__/__ENV_[BASEOS_TAG]__/repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
+      curl -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/centos/__ENV_[BASEOS_TAG]__/repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     elif [[ "${CEPH_VERSION}" == nautilus ]]; then \
       curl -L https://download.ceph.com/ceph-iscsi/3/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     else \


### PR DESCRIPTION
There's no need to use BASEOS_REPO environment variable in the docker install
file because the value should always be "centos".
This is actually breaking the shaman URLs when using a custom base container
image value via BASEOS_REPO.
A good exemple is when trying to build arm64 container image on a x86_64
host which requires to se BASEOS_REPO to a specific namespace (arm64v8/centos)
instead of using the default implicit architecture detection (via the host
architecture).
Note that we were already using the "centos" value for other shaman URLs like
ceph core or ceph-iscsi.

Backport: #1859

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit bb23ba9ab6490a5caca70892f2b771e34b549455)