### PR TITLE
[skip ci] centos/pacific: packages from download.ceph.com

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -58,7 +58,7 @@ if [[ "${CEPH_VERSION}" == nautilus ]]; then \
   fi ; \
 fi && \
 bash -c ' \
-  if [[ "${CEPH_VERSION}" =~ master|pacific ]] || ${CEPH_DEVEL}; then \
+  if [[ "${CEPH_VERSION}" =~ master ]] || ${CEPH_DEVEL}; then \
     ARCH=$(arch); \
     if [[ "${ARCH}" == "aarch64" ]]; then \
       ARCH="arm64"; \


### PR DESCRIPTION
We now have packages for the pacific release on download.ceph.com so
we can stop to use shaman (except for the devel build).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 20cb635043d86d971f028e2bf2824446440b5557)