### PR TITLE
[skip ci] contrib/build-push-ceph-container-imgs.sh: delete trailing manifests

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -365,6 +365,7 @@ function create_registry_manifest {
   enable_experimental_docker_cli
   # This should normally work, by the time we get here the arm64 image should have been built and pushed
   # IIRC docker manisfest will fail if the image does not exist
+  rm -rvf ~/.docker/manifests
   for image in daemon-base daemon; do
     for ceph_release in "${CEPH_RELEASES[@]}"; do
       if [ "${ceph_release}" == "master" ]; then


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-container/issues/1869

Signed-off-by: David Galloway <dgallowa@redhat.com>