### PR TITLE
[skip ci] demo: stop allowing insecure reconnections

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -186,6 +186,9 @@ function start_mon {
       if ! grep -qE "mon warn on pool no redundancy = false" /etc/ceph/"${CLUSTER}".conf; then
           echo "mon warn on pool no redundancy = false" >> /etc/ceph/"${CLUSTER}".conf
       fi
+      if ! grep -qE "auth allow insecure global id reclaim = false" /etc/ceph/"${CLUSTER}".conf; then
+          echo "auth allow insecure global id reclaim = false" >> /etc/ceph/"${CLUSTER}".conf
+      fi
     fi
     /usr/bin/ceph-mon "${DAEMON_OPTS[@]}" -i "${MON_NAME}" --mon-data "$MON_DATA_DIR" --public-addr "${MON_IP}"
 


### PR DESCRIPTION
This set auth_allow_insecure_global_id_reclaim to false otherwise the
ceph status won't be OK:

```console
health: HEALTH_WARN
        mon is allowing insecure global_id reclaim
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>