### PR TITLE
[skip ci] ubi8: enable cephfs-mirror package (bp #1880)

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__CEPHFS_PACKAGES__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__CEPHFS_PACKAGES__
@@ -1,1 +1,0 @@
-ceph-mds__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
The cephfs-mirror package is now available in RHCS 5.

Backport: #1880 
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1951100

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>