### PR TITLE
contrib/build-push-ceph-container-imgs.sh: restart if start fails

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -90,7 +90,7 @@ function install_docker {
     sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes docker-ce
   fi
   sudo systemctl unmask docker
-  sudo systemctl start docker
+  sudo systemctl start docker || sudo systemctl restart docker
   sudo systemctl status --no-pager docker
   sudo chgrp "$(whoami)" /var/run/docker.sock
 }


### PR DESCRIPTION
```
dgalloway@smithi056:~$ sudo su - jenkins-build
$ sudo systemctl start docker
Job for docker.service failed because the control process exited with error code.
See "systemctl status docker.service" and "journalctl -xe" for details.

$ sudo systemctl restart docker
$ sudo systemctl status docker
* docker.service - Docker Application Container Engine
   Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2021-04-19 23:04:51 UTC; 6s ago
     Docs: https://docs.docker.com
 Main PID: 1892 (dockerd)
    Tasks: 25
   CGroup: /system.slice/docker.service
           `-1892 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
```

Signed-off-by: David Galloway <dgallowa@redhat.com>