### PR TITLE
[skip ci] contrib: restart docker if start fails

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -580,7 +580,7 @@ function install_docker {
   fi
   sudo apt-get install -y --force-yes docker.io containerd
   sudo systemctl unmask docker
-  sudo systemctl start docker
+  sudo systemctl start docker || sudo systemctl restart docker
   sudo systemctl status docker
   sudo chgrp "$(whoami)" /var/run/docker.sock
 }


### PR DESCRIPTION
58d7bdd only managed the change in the script for building the
daemon-base/daemon container images but not the ceph one.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>