### PR TITLE
[skip ci] centos/ubi: disable weak dependencies (bp #1890)

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -29,7 +29,7 @@ bash -c ' \
       curl -L https://download.ceph.com/ceph-iscsi/2/rpm/el__ENV_[BASEOS_TAG]__/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ; \
     fi ; \
   fi' && \
-yum update -y && \
+yum update -y --setopt=install_weak_deps=False && \
 rpm --import 'https://download.ceph.com/keys/release.asc' && \
 bash -c ' \
   if [[ "${CEPH_VERSION}" =~ master|^wip* ]]; then \
@@ -40,4 +40,4 @@ bash -c ' \
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[BASEOS_TAG]__/"; \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[BASEOS_TAG]__.noarch.rpm" ' && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 echo 'Install packages' && \
-      yum install -y wget unzip util-linux python-setuptools udev device-mapper && \
-      yum install -y __DAEMON_PACKAGES__ && \
+      yum install -y --setopt=install_weak_deps=False wget unzip util-linux python-setuptools udev device-mapper && \
+      yum install -y --setopt=install_weak_deps=False __DAEMON_PACKAGES__ && \
     # Centos 7 doesn't have confd/forego packages, so install them from web
     __WEB_INSTALL_CONFD__ && \
     __WEB_INSTALL_FOREGO__

--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
-yum update -y && \
-yum install -y wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
-yum install -y __CEPH_BASE_PACKAGES__
+yum update -y --setopt=install_weak_deps=False && \
+yum install -y --setopt=install_weak_deps=False wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
+yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
The weak dependencies were already disable for ubi8 so we can do this
for CentOS too (even if we don't have the same weak deps during the
ceph packages between upstream and downstream ceph install).
This also disables the weak deps during the container image update and
daemon package install step.

On the daemon-base image this reduces the container image size by 30MB
uncompressed.

Backport: #1890
Closes: #1874

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 6c8af8169a3b4a49abf72e72eb897df5ae3d1e9e)