### PR TITLE
[skip ci] daemon: fix confd ceph template (bp #1895)

### DIFF
--- a/src/daemon/confd/templates/ceph.conf.tmpl
+++ b/src/daemon/confd/templates/ceph.conf.tmpl
@@ -9,9 +9,9 @@
 {{range gets "/mon/*"}}
   {{base .Key}} = {{.Value}}{{end}}
 {{range gets "/mon_host/*"}}
-    [mon.{{base .Key}}]
-      host = {{base .Key}}
-      mon_addr = {{.Value}}{{end}}
+[mon.{{base .Key}}]
+  host = {{base .Key}}
+  mon_addr = {{.Value}}{{end}}
 
 [osd]
 {{range gets "/osd/*"}}


### PR DESCRIPTION
The extra spaces before the mon.xxx section aren't needed and generate
a config file error starting the Octopus release.

global_init: error reading config file. parse error: expected '<eoi>'
in line 12 at position 1

Backport: #1895
Closes: #1751

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 4138a4f2ff814bda0c1839a71ec858821ec9b809)