### PR TITLE
start_mon: fix mon addition with ipv6

### DIFF
--- a/src/daemon/start_mon.sh
+++ b/src/daemon/start_mon.sh
@@ -169,10 +169,11 @@ function start_mon {
       ceph-mon --setuser ceph --setgroup ceph --cluster "${CLUSTER}" -i "${MON_NAME}" --inject-monmap "$MONMAP" --keyring "$MON_KEYRING" --mon-data "$MON_DATA_DIR"
     fi
     if [[ "$CEPH_DAEMON" != demo ]]; then
-      v2v1=$(ceph-conf -c /etc/ceph/"${CLUSTER}".conf 'mon host' | tr ',' '\n' | grep -c "${MON_IP}")
+      MON_IP_NO_BRACKETS=$(echo "$MON_IP" | tr -d '[]')
+      v2v1=$(ceph-conf -c /etc/ceph/"${CLUSTER}".conf 'mon host' | tr ',' '\n' | grep -c "${MON_IP_NO_BRACKETS}")
       # in case of v2+v1 configuration : [v2:xxxx:3300,v1:xxxx:6789]
       if [ "${v2v1}" -eq 2 ]; then
-        timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}" || true
+        timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP_NO_BRACKETS}" || true
       # with v2 only : [v2:xxxx:3300]
       else
         timeout 7 ceph "${CLI_OPTS[@]}" mon add "${MON_NAME}" "${MON_IP}":"${MON_PORT}" || true


### PR DESCRIPTION
When bootstrapping a new monitor using ipv6 address with v2+v1 protocol
this command fails because of the brackets wrapping the ipv6 address:

```
++/opt/ceph-container/bin/start_mon.sh:172: start_mon(): ceph-conf -c /etc/ceph/ceph.conf 'mon host'
++/opt/ceph-container/bin/start_mon.sh:172: start_mon(): tr , '\n'
++/opt/ceph-container/bin/start_mon.sh:172: start_mon(): grep -c '[2620:52:0:880:225:90ff:fefc:1a98]'
+/opt/ceph-container/bin/start_mon.sh:172: start_mon(): v2v1=10
+/opt/ceph-container/bin/start_mon.sh:174: start_mon(): '[' 10 -eq 2 ']'
+/opt/ceph-container/bin/start_mon.sh:178: start_mon(): timeout 7 ceph --cluster ceph mon add magna115 '[2620:52:0:880:225:90ff:fefc:1a98]:3300'
```

eg:
```
[root@magna115 ~]# ceph-conf -c /etc/ceph/ceph.conf 'mon host' | tr ',' '\n' | tr -d '[]' | grep "[2620:52:0:880:225:90ff:fefc:1a98]"
v2:2620:52:0:880:225:90ff:fefc:26d2:3300
v1:2620:52:0:880:225:90ff:fefc:26d2:6789
v2:2620:52:0:880:225:90ff:fefc:1cca:3300
v1:2620:52:0:880:225:90ff:fefc:1cca:6789
v2:2620:52:0:880:225:90ff:fefb:d5ae:3300
v1:2620:52:0:880:225:90ff:fefb:d5ae:6789
v2:2620:52:0:880:225:90ff:fefb:d634:3300
v1:2620:52:0:880:225:90ff:fefb:d634:6789
v2:2620:52:0:880:225:90ff:fefc:1a98:3300
v1:2620:52:0:880:225:90ff:fefc:1a98:6789
```

it matches 10 occurences where it should match only 2.

eg:
```
[root@magna115 ~]# ceph-conf -c /etc/ceph/ceph.conf 'mon host' | tr ',' '\n' | grep "2620:52:0:880:225:90ff:fefc:1a98"
[v2:[2620:52:0:880:225:90ff:fefc:1a98]:3300
v1:[2620:52:0:880:225:90ff:fefc:1a98]:6789]
[root@magna115 ~]#
```

the consequence is that we don't enter in the right condition so it adds
the new monitor with v2 only syntax into the monitor map.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1967493

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
