### PR TITLE
[skip ci] workflow: add rhcs compose task (bp #1907)

### DIFF
--- a/.github/workflows/rhcs.yml
+++ b/.github/workflows/rhcs.yml
@@ -1,0 +1,11 @@
+name: rhcs
+on: [pull_request]
+jobs:
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: compose the RHCS container image
+        run: ./contrib/compose-rhcs.sh

--- a/travis-builds/validate_demo_cluster.sh
+++ b/travis-builds/validate_demo_cluster.sh
@@ -74,7 +74,7 @@ function test_demo_mgr {
 }
 
 function test_demo_rest_api {
-  key=$($DOCKER_COMMAND restful list-keys | python -c 'import json, sys; print(json.load(sys.stdin)["demo"])')
+  key=$($DOCKER_COMMAND restful list-keys | jq -r .demo)
   docker exec ceph-demo curl -s --connect-timeout 1 -u demo:$key -k https://0.0.0.0:8003/server
   # shellcheck disable=SC2046
   return $(wait_for_daemon "$DOCKER_COMMAND mgr dump | grep -sq 'restful\": \"https://.*:8003'")


### PR DESCRIPTION
This adds a github workflow for testing RHCS compose.

Backport: #1907 

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>