### PR TITLE
contrib: fix centos 7 origin

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -160,6 +160,11 @@ function get_base_image_full_tag () {
   local distro_release ; distro_release="$(extract_distro_release "${flavor}")"
   case $distro in
     centos)
+      if [ "${distro_release}" = "7" ]; then
+        # keep using docker.io/centos:7 because quay.io/centos/centos:7 doesn't
+        # have an arm64 image.
+        default_library="docker.io"
+      fi
       echo "${default_library}/centos:${distro_release}"
       return ;;
     *)


### PR DESCRIPTION
5b5e7f9 changed the source registry for the CentOS base container images.

Unfortunately the CentOS 7 image on quay.io/centos/centos registry is
amd64 only and not a multiarch manifest like docker.io/centos (with five
different architectures).
This sucks and as a solution we will stick to docker.io registry for the
CentOS 7 container image.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>