### PR TITLE
[skip ci] workflow: add timeout on ceph command (bp #1916)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,7 +28,7 @@ jobs:
           docker ps
           docker ps -a
           docker logs ceph-demo
-          docker exec ceph-demo ceph --cluster test -s
+          docker exec ceph-demo ceph --connect-timeout 3 --cluster test -s
   arm64:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In case of ceph monitor failure but the container is still up then
the ceph command will timeout only after 300s.
Adding --connect-timeout parameter to have the job in failure earlier.

Backport: #1916

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 4d96298d43ed77d80efdb44c23a181c2021ebba7)