### PR TITLE
[skip ci] contrib: drop nautilus release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	nautilus,centos,7 \
 	octopus,centos,8 \
 	pacific,centos,8 \
 	master,centos,8
@@ -48,8 +47,6 @@ include maint-lib/makelib.mk
 
 # All flavor options that can be passed to FLAVORS
 ALL_BUILDABLE_FLAVORS := \
-	nautilus,centos,7 \
-	nautilus,centos,8 \
 	octopus,centos,7 \
 	octopus,centos,8 \
 	pacific,centos,8 \

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -45,7 +45,7 @@ OSD_FLAVOR=${OSD_FLAVOR:=default}
 
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'master' position in the array, this will break the 'latest' tag
-  CEPH_RELEASES=(master nautilus octopus pacific)
+  CEPH_RELEASES=(master octopus pacific)
 fi
 
 HOST_ARCH=$(uname -m)

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8 pacific,centos,8"
-AARCH64_FLAVORS_TO_BUILD="nautilus,centos,7 octopus,centos,8 pacific,centos,8"
+X86_64_FLAVORS_TO_BUILD="octopus,centos,8 pacific,centos,8"
+AARCH64_FLAVORS_TO_BUILD="octopus,centos,8 pacific,centos,8"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
Nautilus 14.2.22 was the latest release and likely the last one.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>