### PR TITLE
contrib: update manifest-tool to 1.0.3

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -492,7 +492,7 @@ function add_tag () {
 # Manifests
 #===================================================================================================
 
-MANIFEST_TOOL_VERSION="v0.8.0"
+MANIFEST_TOOL_VERSION="v1.0.3"
 MANIFEST_TOOL_LOCATION="/tmp/manifest-tool-${MANIFEST_TOOL_VERSION}"
 # Manifest tool: https://github.com/estesp/manifest-tool
 # `docker manifest` command exists but is experiemental and not present in all environments;
@@ -500,8 +500,8 @@ MANIFEST_TOOL_LOCATION="/tmp/manifest-tool-${MANIFEST_TOOL_VERSION}"
 function download_manifest_tool () {
   if [[ ! -x "${MANIFEST_TOOL_LOCATION}" ]]; then
     info "Manifest tool is not downloaded. Downloading it now."
-    curl --silent --location \
-      "https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-${BUILD_SERVER_GOARCH}" > "${MANIFEST_TOOL_LOCATION}"
+    curl --silent --location --output "${MANIFEST_TOOL_LOCATION}" \
+      "https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_TOOL_VERSION}/manifest-tool-linux-${BUILD_SERVER_GOARCH}"
     chmod +x "${MANIFEST_TOOL_LOCATION}"
   fi
 }


### PR DESCRIPTION
The 0.8.0 release is 3 years old and since we switched to the quay.io
registry I've seen some error in the CI on manifest-tool (which I wasn't
able to reproduce).
In any case, this updates manifest-tool to the latest stable release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>