### PR TITLE
Revert "contrib: fix centos 7 origin"

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -160,11 +160,6 @@ function get_base_image_full_tag () {
   local distro_release ; distro_release="$(extract_distro_release "${flavor}")"
   case $distro in
     centos)
-      if [ "${distro_release}" = "7" ]; then
-        # keep using docker.io/centos:7 because quay.io/centos/centos:7 doesn't
-        # have an arm64 image.
-        default_library="docker.io"
-      fi
       echo "${default_library}/centos:${distro_release}"
       return ;;
     *)


### PR DESCRIPTION
This reverts commit 7cc3401351dd2762312f36cefb2e47451c0695f0.

Because we don't built the Nautilus container image anymore and all
other Ceph releases are based on CentOS 8 then we can revert this change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>