### PR TITLE
contrib: publish daemon-base/daemon to quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ceph-container
 ==============
 
-As of August 2021, new ceph/ceph container images are pushed to quay.io registry only.
+As of August 2021, new container images are pushed to quay.io registry only.
 Docker hub won't receive new content for that specific image but current images remain available.
 
 [![Ceph Daemon Stars](https://img.shields.io/docker/stars/ceph/daemon.svg)](https://hub.docker.com/r/ceph/daemon)
@@ -29,13 +29,21 @@ For docker hub registry
 $ curl -s https://registry.hub.docker.com/v2/repositories/ceph/ceph/tags/?page_size=100 | jq '."results"[] .name'
 ```
 
-All tags for ceph/{daemon-base,daemon} can be found on the Docker Hub.
+All tags for ceph/{daemon-base,daemon} can be found on the quay.io registry.
+For the daemon-base tags [visit](https://quay.io/repository/ceph/daemon-base?tab=tags)
+For the daemon tags [visit](https://quay.io/repository/ceph/daemon?tab=tags)
+As an alternative you can still use the docker hub registry but without the most recent images.
 For the daemon-base tags [visit](https://hub.docker.com/r/ceph/daemon-base/tags/).
 For the daemon tags [visit](https://hub.docker.com/r/ceph/daemon/tags/).
 
 Alternatively, you can run the following command (install jq first):
 
+For quay.io registry
+```bash
+$ curl -s -L https://quay.io/api/v1/repository/ceph/daemon/tag?page_size=100 | jq '."tags"[] .name'
 ```
+For docker hub registry
+```bash
 $ curl -s https://registry.hub.docker.com/v2/repositories/ceph/daemon/tags/?page_size=100 | jq '."results"[] .name'
 ```
 

--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -22,16 +22,16 @@ function build_ceph_imgs {
   echo "Build Ceph container image(s)"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
     CENTOS_RELEASE=$(_centos_release "${ceph_release}")
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos build
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" build
   done
   docker images
 }
 
 function push_ceph_imgs {
-  echo "Push Ceph container image(s) to the Docker Hub registry"
+  echo "Push Ceph container image(s) to the registry"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
     CENTOS_RELEASE=$(_centos_release "${ceph_release}")
-    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REPO=centos push
+    make DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" push
   done
 }
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -353,7 +353,8 @@ function wait_for_arm_images {
   fi
   echo "Waiting for ARM64 images to be ready"
   set -e
-  until docker pull "${CONTAINER_REPO_ORGANIZATION}"/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64; do
+  CENTOS_RELEASE=$(_centos_release "${CEPH_RELEASES[-1]}")
+  until docker pull "${CONTAINER_REPO_ORGANIZATION}"/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-"${CENTOS_RELEASE}"-aarch64; do
     echo -n .
     sleep 1
   done

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -369,9 +369,6 @@ function create_registry_manifest {
   rm -rvf ~/.docker/manifests
   for image in daemon-base daemon; do
     for ceph_release in "${CEPH_RELEASES[@]}"; do
-      if [ "${ceph_release}" == "master" ]; then
-        continue
-      fi
       TARGET_RELEASE="${CONTAINER_REPO_ORGANIZATION}/${image}:${RELEASE}-${ceph_release}-centos-$(_centos_release "${ceph_release}")"
       DOCKER_IMAGES="$TARGET_RELEASE ${TARGET_RELEASE}-x86_64"
 


### PR DESCRIPTION
- registry namespace and repositories remain the same than docker.io [1][2]
- define the registry name explicitly for login, pull and push operations
- update registry API endpoint calls for quay registry [3] 
- update registry credentials variables to be more generic
- base container images (CentOS) are pulled from quay.io [4] 

[1] https://quay.io/repository/ceph/daemon-base
[2] https://quay.io/repository/ceph/daemon
[3] https://docs.quay.io/api/
[4] https://quay.io/repository/centos/centos

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>