### PR TITLE
tox/tests: use base image from quay.io (bp #1933)

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -43,8 +43,8 @@ else
   sudo chgrp "$(whoami)" /var/run/docker.sock
 fi
 
-if [ -n "${DOCKER_HUB_USERNAME}" ] && [ -n "${DOCKER_HUB_PASSWORD}" ]; then
-  docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
+if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+  docker login -u "${REGISTRY_USERNAME}" -p "${REGISTRY_PASSWORD}" "${REGISTRY}"
 fi
 
 rm -rf "$WORKSPACE"/ceph-ansible || true
@@ -87,7 +87,7 @@ make_output=$(make FLAVORS="$FLAVOR" stage) # Run staging to get DAEMON_IMAGE na
 daemon_image=$(echo "${make_output}" | grep " DAEMON_IMAGE ") # Find DAEMON_IMAGE line
 daemon_image="${daemon_image#*DAEMON_IMAGE*: }" # Remove DAEMON_IMAGE from beginning
 daemon_image="$(echo "${daemon_image}" | tr -s ' ')" # Remove whitespace
-make FLAVORS="$FLAVOR" build.parallel
+make FLAVORS="$FLAVOR" BASEOS_REGISTRY="${REGISTRY}/centos" BASEOS_REPO="centos" build.parallel
 
 # start a local docker registry
 docker run -d -p 5000:5000 --restart=always --name registry registry:2

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv=
   CEPH_ANSIBLE_BRANCH = stable-4.0
   VAGRANT_PROVIDER = {env:VAGRANT_PROVIDER:libvirt}
   CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  REGISTRY = quay.io
 deps=
   ceph_ansible: ansible>=2.9,<2.10
 commands=


### PR DESCRIPTION
Avoid as much as possible to use the docker.io registry so even the centos
base container image should be pulled from the quay.io registry.

Backport: #1933

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 5fa7592977564c90da6e18a1a46207dfa6b759a0)