### PR TITLE
contrib: build/push wait for arm build for stable

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -201,6 +201,8 @@ function create_head_or_point_release {
 
   # shellcheck disable=SC2181
   if $TAGGED_HEAD; then
+    # wait for the arm64 image for the manifest creation as we only have one image to build
+    BUILD_ARM=true
     # checkout tag's code
     # using [*] but [0] would work too, also the array's length should be 1 anyway
     # this code is only activated if length is 1 so we are safe


### PR DESCRIPTION
For tagged head release (like v6.0.4, v5.0.11, etc..) then we can wait
for the arm build to be finished before starting the manifest creation.
Because we only have one arm image to build, we won't have to wait so
much before retrieving that image from the amd64 job.
Before this change, the manifest was only created with the amd64 image
and then updated manually outside of the CI.
Let's avoid that.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>