### PR TITLE
contrib: increase sleep time for waiting arm build

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -358,7 +358,7 @@ function wait_for_arm_images {
   CENTOS_RELEASE=$(_centos_release "${CEPH_RELEASES[-1]}")
   until docker pull "${CONTAINER_REPO_ORGANIZATION}"/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-"${CENTOS_RELEASE}"-aarch64; do
     echo -n .
-    sleep 1
+    sleep 30
   done
   set +e
 }


### PR DESCRIPTION
We don't need to retry to pull the arm image every second.
Let's increase this to 30s.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>