### PR TITLE
[skip ci] contrib/rhcs: set upstream branch explicitly (bp #1940)

### DIFF
--- a/contrib/commit-rhcs.sh
+++ b/contrib/commit-rhcs.sh
@@ -39,11 +39,10 @@ trap cleanup EXIT QUIT INT TERM
 step "Updating local repository"
 git fetch || fatal 'Cannot fetch the remote repository'
 git reset --hard "origin/$CURRENT_GIT_BRANCH" || fatal "Cannot reset the local directory !"
-#shellcheck disable=SC2001
-DOWNSTREAM_BRANCH_VERSION=$(echo "$CURRENT_GIT_BRANCH" | sed 's/ceph-\(.*\)-rhel.*/\1/g')
+UPSTREAM_BRANCH_VERSION="stable-6.0"
 
-step "Cloning ceph-container $DOWNSTREAM_BRANCH_VERSION"
-git clone https://github.com/ceph/ceph-container.git -b "stable-$DOWNSTREAM_BRANCH_VERSION" "$CEPH_CONTAINER_DIR"
+step "Cloning ceph-container ${UPSTREAM_BRANCH_VERSION}"
+git clone https://github.com/ceph/ceph-container.git -b "${UPSTREAM_BRANCH_VERSION}" "$CEPH_CONTAINER_DIR"
 
 step "Composing RHCS"
 pushd "$CEPH_CONTAINER_DIR"


### PR DESCRIPTION
Since the upstream branch doesn't follow the downstream RHCS branch
then we can set it statically.

Backport: #1940

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 568f79dd5172d6dac57729cd2b20a9c9b2fe565a)