### PR TITLE
Revert "ubi8: ignore absent pulp repositories"

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon/container.yaml
+++ b/ceph-releases/ALL/ubi8/daemon/container.yaml
@@ -4,4 +4,3 @@
 compose:
   packages: []
   pulp_repos: true
-  ignore_absent_pulp_repos: true


### PR DESCRIPTION
This reverts commit 59450b60137b2e9daaedac95ca750946fbeefc6e.

RH release engineering has created these repositories now, so it's safe to tell ODCS to use them.