### PR TITLE
[skip ci] contrib: update quay api pagination parameter

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -154,7 +154,7 @@ function compare_registry_and_github_tags {
   # build an array with the list of tag from the registry
   local page=1
   while response="$(curl --silent --fail --list-only --location \
-                      "https://${REGISTRY}/api/v1/repository/ceph/daemon/tag?page_size=100&page=${page}")"; do
+                      "https://${REGISTRY}/api/v1/repository/ceph/daemon/tag?limit=100&page=${page}")"; do
     local tags_registry ; tags_registry+=$(echo "${response}" | jq -r .tags[].name)
     if [ "$(echo "${response}" | jq -r .has_additional)" == "false" ]; then
       break

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -332,7 +332,7 @@ function get_tags_matching () {
   local version_tag="${1}" repository="${2}"
   # DockerHub API limits page_size to 100, so we must loop through the pages
   # It would be super cool if the DockerHub HTTP API had a filter option ...
-  local tag_list_url="${PUSH_REGISTRY_URL}/repository/${PUSH_LIBRARY}/${repository}/tag?page_size=100"
+  local tag_list_url="${PUSH_REGISTRY_URL}/repository/${PUSH_LIBRARY}/${repository}/tag?limit=100"
   local all_matching_tags=''
   local page=1
   local response


### PR DESCRIPTION
Looks like the pagination parameter wasn't updated during the switch to
quay.io registry.
The `page_size` parameter doesn't exist with quay and we should use `limit`
instead.
The default `limit` value is 50 but let's keep it at 100 as before (it's
also the maximum value supported)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>