### PR TITLE
[skip ci][stable-6.0] centos/arm: add python3-saml package

### DIFF
--- a/ceph-releases/ALL/centos-arm64/8/daemon-base/__CEPH_MGR_PACKAGES__
+++ b/ceph-releases/ALL/centos-arm64/8/daemon-base/__CEPH_MGR_PACKAGES__
@@ -1,0 +1,1 @@
+../../../centos/8/daemon-base/__CEPH_MGR_PACKAGES__


### PR DESCRIPTION
This was missing from the CentOS arm64 configuration.

Backport: #1953 

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 29640fb4116cc6c4c082488b1314c9b804e5a76b)