### PR TITLE
daemon-base: add missing spaces

### DIFF
--- a/ceph-releases/ALL/opensuse/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/ceph-releases/ALL/opensuse/daemon-base/__CEPH_BASE_PACKAGES__
@@ -6,7 +6,7 @@
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
         ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
-        __CEPH_MGR_PACKAGES__\
+        __CEPH_MGR_PACKAGES__ \
         kmod \
         lvm2 \
         __RADOSGW_PACKAGES__ \

--- a/ceph-releases/luminous/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/ceph-releases/luminous/daemon-base/__CEPH_BASE_PACKAGES__
@@ -6,7 +6,7 @@
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
         ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
-        __CEPH_MGR_PACKAGES__\
+        __CEPH_MGR_PACKAGES__ \
         kmod \
         lvm2 \
         gdisk \

--- a/ceph-releases/mimic/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/ceph-releases/mimic/daemon-base/__CEPH_BASE_PACKAGES__
@@ -6,7 +6,7 @@
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
         ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
-        __CEPH_MGR_PACKAGES__\
+        __CEPH_MGR_PACKAGES__ \
         kmod \
         lvm2 \
         gdisk \

--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -6,7 +6,7 @@
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
         __CEPHFS_PACKAGES__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
-        __CEPH_MGR_PACKAGES__\
+        __CEPH_MGR_PACKAGES__ \
         __CEPH_GRAFANA_PACKAGES__ \
         kmod \
         lvm2 \


### PR DESCRIPTION
Add missing space so that package names are not
clobbered together.

Otherwise we would obtain things like:
```
[docker_build]  [91mError: Unable to find a match: python3-samlceph-grafana-dashboards-16.2.6
```