### PR TITLE
don't strip and gzexe binaries in CLEAN stage

### DIFF
--- a/ceph-releases/ALL/centos/8/__DOCKERFILE_CLEAN_COMMON__
+++ b/ceph-releases/ALL/centos/8/__DOCKERFILE_CLEAN_COMMON__
@@ -14,15 +14,6 @@ rm -rf \
     # rm -f /usr/bin/ceph-dencoder && \
     if [ -f /usr/bin/ceph-dencoder ]; then gzip -9 /usr/bin/ceph-dencoder; fi && \
     # TODO: What other ceph stuff needs removed/stripped/zipped here?
-    # TODO: There was some overlap between this and the ceph clean? Where does it belong?
-    #       If it's idempotent, it can *always* live here, even if it doesn't always apply
-    # TODO: Should we even strip ceph libs at all?
-    bash -c ' \
-      function ifstrip () { if compgen -g "$1"; then strip -s "$1"; fi } && \
-      ifstrip /usr/lib{,64}/ceph/erasure-code/* && \
-      ifstrip /usr/lib{,64}/rados-classes/* && \
-      ifstrip /usr/lib{,64}/python*/{dist,site}-packages/{rados,rbd,rgw}.*.so && \
-      ifstrip /usr/bin/{crushtool,monmaptool,osdmaptool}' && \
     # Photoshop files inside a container ?
     rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* && \
     # Some logfiles are not empty, there is no need to keep them

--- a/src/__DOCKERFILE_CLEAN_COMMON__
+++ b/src/__DOCKERFILE_CLEAN_COMMON__
@@ -14,15 +14,6 @@ rm -rf \
     # rm -f /usr/bin/ceph-dencoder && \
     if [ -f /usr/bin/ceph-dencoder ]; then gzip -9 /usr/bin/ceph-dencoder; fi && \
     # TODO: What other ceph stuff needs removed/stripped/zipped here?
-    # TODO: There was some overlap between this and the ceph clean? Where does it belong?
-    #       If it's idempotent, it can *always* live here, even if it doesn't always apply
-    # TODO: Should we even strip ceph libs at all?
-    bash -c ' \
-      function ifstrip () { if compgen -g "$1"; then strip -s "$1"; fi } && \
-      ifstrip /usr/lib{,64}/ceph/erasure-code/* && \
-      ifstrip /usr/lib{,64}/rados-classes/* && \
-      ifstrip /usr/lib{,64}/python*/{dist,site}-packages/{rados,rbd,rgw}.*.so && \
-      ifstrip /usr/bin/{crushtool,monmaptool,osdmaptool}' && \
     # Photoshop files inside a container ?
     rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* && \
     # Some logfiles are not empty, there is no need to keep them

--- a/src/daemon/__DOCKERFILE_CLEAN_DAEMON__
+++ b/src/daemon/__DOCKERFILE_CLEAN_DAEMON__
@@ -1,16 +1,7 @@
 # Let's remove easy stuff
     rm -f /usr/bin/{etcd-tester,etcd-dump-logs} && \
-    # Let's compress fat binaries but keep them executable
-    # As we don't run them often, the performance penalty isn't that big
-    for binary in /usr/local/bin/{confd,kubectl} /usr/bin/etcdctl; do \
-      if [ -f "$binary" ]; then gzexe $binary && rm -f ${binary}~; fi; \
-    done && \
     # Remove etcd since all we need is etcdctl
     rm -f /usr/bin/etcd && \
-    # Strip binaries
-    bash -c ' \
-      function ifstrip () { if compgen -g "$1"; then strip -s "$1"; fi } && \
-      ifstrip /usr/local/bin/{confd,kubectl}' && \
     # Uncomment below line for more detailed debug info
     # find / -xdev -type f -exec du -c {} \; |sort -n && \
     echo "CLEAN DAEMON DONE!"


### PR DESCRIPTION
This commit removes some attempts to make the final image smaller,
because they introduce other problems and have very little impact on the
overall image-size and just adds complexity.

Regarding `gzexe`:
gzexe is a tool that compresses binaries and wrap the
compressed data inside a shellscript. This will then automatically
decompress into a temporary file and execute that data whenever the
wrapper-shellscript is called.
ceph-container has been using this to compress `confd`, `kubectl`, and
`etcdctl` (and previously also `forego`). A critical problem here is that the
wrapper script cleans after itself with a subshell like this:

`(sleep 5; rm -fr "$gztmpdir") 2>/dev/null &`

The entrypoints/scenario-scrips sets traps on a list of signals, among
them SIGCHLD. So whenever the entrypoint has the desired scenario, if
the timing is right, the subshell of gzexe will exit, and thus trigger a
SIGCHLD and cause the entire docker image to shut down. There are a few
issues filed against this problem, when using etcd or confd such as:
https://github.com/ceph/ceph-container/issues/1443

Regarding `strip` of binaries:
There is a fatal bug in the bash-function `ifstrip` that's present in
the `__DOCKERFILE_CLEAN_*__` scripts, and has been there since 2018
atleast. This bug also prohibits any binaries to be stripped, becuase
the function `compgen -g "$1"` is invalid for all arguments we feed it,
and the function will never reach the `strip -s` stage.
The manual for `compgen` states that `-g` options is used to lookup
groups (from /etc/group)! And giving filenames to it, will result in an
error. For example:

```
[root@local /]# grep "^a" /etc/group
adm:x:4:
audio:x:63:
[root@local /]# compgen -g a
adm
audio
[root@local /]# compgen -g /usr/ls
[root@local /]# echo $?
1
```

The suspicion is that the original author intended to actually use
`compgen -G` (capital G). Which has the desired(?) usage. That option
will actually check if a globpattern expands to possible completions, so
that the bash-function ifstrip wouldn't call `strip -s` on nonexisting
files/directories. `compgen -G` seems more or less the same as using
`[[-f <filename>]]`, but works on globs without invoking a lot of
recursion/looping, so it's quite a clever trick. However, since this has
never worked due to the bug and no binaries has ever been stripped since
2018, lets remove it to simplify the cleanup-stage a bit.

During trials we found that the binaries we try to strip in he files
don't reduce much anyhow, only a few kilobytes (except for kubectl which
actually strips rather well). And the `confd` binary is (as of 0.16)
compressed with UPX already, and running `strip` on that will fail.

Signed-off-by: Björn Zettergren <bjorn.zettergren@deltaprojects.com>