### PR TITLE
Dockerfile: remove Sree for ubi8 based image

### DIFF
--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -52,9 +52,8 @@ ADD *.sh check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenar
 ADD ceph.defaults /opt/ceph-container/etc/
 # ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
-# Copye sree web interface for cn
-# We use COPY instead of ADD for tarball so that it does not get extracted automatically at build time
-COPY Sree-0.2.tar.gz /opt/ceph-container/tmp/sree.tar.gz
+
+__DOCKERFILE_COPY_SREE__
 
 # Modify the entrypoint
 RUN bash "/opt/ceph-container/bin/generate_entrypoint.sh" && \

--- a/src/daemon/__DOCKERFILE_COPY_SREE__
+++ b/src/daemon/__DOCKERFILE_COPY_SREE__
@@ -1,0 +1,3 @@
+# Copye sree web interface for cn
+# We use COPY instead of ADD for tarball so that it does not get extracted automatically at build time
+COPY Sree-0.2.tar.gz /opt/ceph-container/tmp/sree.tar.gz


### PR DESCRIPTION
this is only needed for ceph-nano, which has never been productized
downstream.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2020150

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
