### PR TITLE
distro: use CentOS Stream 8 instead of deprecated CentOS 8

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: build the ceph container image
-        run: make RELEASE="demo" FLAVORS="master,centos,8" build
+        run: make RELEASE="demo" FLAVORS="master,centos,stream8" build
 
       - name: run the ceph demo container
         run: docker run -d --privileged --name ceph-demo -v /mnt/ceph:/var/lib/ceph -e RGW_FRONTEND_TYPE=beast -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=ceph -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_PORT=5001 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=github -e OSD_COUNT=2 ceph/daemon:demo-master-centos-8-x86_64 demo
@@ -39,4 +39,4 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: build the ceph container arm64 image
-        run: make RELEASE="demo" BASEOS_REPO=arm64v8/centos DAEMON_BASE_TAG="daemon-base:demo-centos-8-aarch64" DAEMON_TAG="daemon:demo-centos-8-aarch64" FLAVORS="master,centos-arm64,8" build
+        run: make RELEASE="demo" BASEOS_REPO=arm64v8/centos DAEMON_BASE_TAG="daemon-base:demo-centos-8-aarch64" DAEMON_TAG="daemon:demo-centos-8-aarch64" FLAVORS="master,centos-arm64,stream8" build

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DAEMON_BASE_TAG ?= ""
 DAEMON_TAG ?= ""
 
 # These values are given sane defaults if they are unset. Otherwise, they get the value specified.
-BASEOS_REGISTRY ?= ""
+BASEOS_REGISTRY ?= "quay.io/centos"
 BASEOS_REPO ?= ""
 BASEOS_TAG ?= ""
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	octopus,centos,8 \
-	pacific,centos,8 \
-	master,centos,8
+	octopus,centos,stream8 \
+	pacific,centos,stream8 \
+	master,centos,stream8
 
 TAG_REGISTRY ?= ceph
 
@@ -48,9 +48,9 @@ include maint-lib/makelib.mk
 # All flavor options that can be passed to FLAVORS
 ALL_BUILDABLE_FLAVORS := \
 	octopus,centos,7 \
-	octopus,centos,8 \
-	pacific,centos,8 \
-	master,centos,8
+	octopus,centos,stream8 \
+	pacific,centos,stream8 \
+	master,centos,stream8
 
 # ==============================================================================
 # Build targets

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="octopus,centos,8 pacific,centos,8"
-AARCH64_FLAVORS_TO_BUILD="octopus,centos,8 pacific,centos,8"
+X86_64_FLAVORS_TO_BUILD="octopus,centos,stream8 pacific,centos,stream8"
+AARCH64_FLAVORS_TO_BUILD="octopus,centos,stream8 pacific,centos,stream8"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -63,7 +63,7 @@ fi
 
 cd "$WORKSPACE"
 # we test the latest stable release of Ceph in priority
-FLAVOR="master,centos,8"
+FLAVOR="master,centos,stream8"
 
 # build everything that was touched to make sure build succeeds
 mapfile -t FLAVOR_ARRAY < <(make flavors.modified)


### PR DESCRIPTION
CentOS 8 has been deprecated, and the contents of the repositories is
removed from the mirror network. Installing packages in a CentOS 8
container image is not possible anymore.

CentOS Stream 8 is the only CentOS 8 variant that is maintained.

See-also: https://centos.org/cl-vs-cs/
