### PR TITLE
src/daemon-base: re-add udevadm to the container image

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -14,6 +14,7 @@
         smartmontools \
         nvme-cli \
         libstoragemgmt \
+        systemd-udev \
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \


### PR DESCRIPTION
Description of your changes:

Since the recent change to stream8 as a base image to build ceph/ceph
containers various orchestration have started to fail since the udevadm
binary is not present in this image.
Adding systemd-udev which contains the binary.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->


Which issue is resolved by this Pull Request:
Resolves https://github.com/ceph/ceph-container/issues/1984

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
