### PR TITLE
Revert "centos: add Apache Arrow repository"

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,4 +1,4 @@
-yum install -y epel-release https://apache.jfrog.io/artifactory/arrow/centos/__ENV_[DISTRO_VERSION]__/apache-arrow-release-latest.rpm && \
+yum install -y epel-release && \
 yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
@@ -78,4 +78,4 @@ bash -c ' \
     yum copr enable -y tchaikov/python-scikit-learn ; \
     yum copr enable -y tchaikov/python3-asyncssh ; \
   fi ' && \
-yum install -y --setopt=install_weak_deps=False --enablerepo=powertools __CEPH_BASE_PACKAGES__
+yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
This reverts commit ea259682ec905267bcc07fda4bd546044c26ceb5.

the new plan is to submodule the things we needed from this repo, so it's no longer necessary. and since centos 8 eol, it looks like apache may have removed the /centos/8/ repo

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
