### PR TITLE
[skip ci] contrib: add missing stream prefix on daemon arm64

### DIFF
--- a/contrib/build-push-ceph-container-imgs-arm64.sh
+++ b/contrib/build-push-ceph-container-imgs-arm64.sh
@@ -23,7 +23,7 @@ function build_ceph_imgs {
   echo "Build Ceph container image(s)"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
     CENTOS_RELEASE=$(_centos_release "${ceph_release}")
-    make BASEOS_TAG=stream"${CENTOS_RELEASE}" DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" build
+    make BASEOS_TAG=stream"${CENTOS_RELEASE}" DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" build
   done
   docker images
 }
@@ -32,7 +32,7 @@ function push_ceph_imgs {
   echo "Push Ceph container image(s) to the Docker Hub registry"
   for ceph_release in "${CEPH_RELEASES[@]}"; do
     CENTOS_RELEASE=$(_centos_release "${ceph_release}")
-    make BASEOS_TAG=stream"${CENTOS_RELEASE}" DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" push
+    make BASEOS_TAG=stream"${CENTOS_RELEASE}" DAEMON_BASE_TAG=daemon-base:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 DAEMON_TAG=daemon:"$RELEASE"-"${ceph_release}"-centos-stream"${CENTOS_RELEASE}"-aarch64 RELEASE="${RELEASE}" FLAVORS="${ceph_release},centos-arm64,${CENTOS_RELEASE}" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" push
   done
 }
 

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -329,7 +329,8 @@ function wait_for_arm_images {
   fi
   echo "Waiting for ARM64 images to be ready"
   set -e
-  until docker pull ceph/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-7-aarch64; do
+  CENTOS_RELEASE=$(_centos_release "${CEPH_RELEASES[-1]}")
+  until docker pull "${CONTAINER_REPO_ORGANIZATION}"/daemon:"$RELEASE"-"${CEPH_RELEASES[-1]}"-centos-stream"${CENTOS_RELEASE}"-aarch64; do
     echo -n .
     sleep 1
   done


### PR DESCRIPTION
The arm64 ceph/daemon container image isn't using the stream prefix
compared to the amd64 build.
This also updates the pull command to reflect that change required for
the manifest creation.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit f17a6f6b34971988aa1651ee691d98cf834aec85)
