### PR TITLE
base: add packages

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -15,6 +15,8 @@
         nvme-cli \
         libstoragemgmt \
         systemd-udev \
+        procps-ng \
+        hostname \
         __RADOSGW_PACKAGES__ \
         __GANESHA_PACKAGES__ \
         __ISCSI_PACKAGES__ \


### PR DESCRIPTION
Since we moved to stream 8, `procps-ng` and `hostname` packages
aren't present anymore. This adds them back in the image.
Having `ps` binary doesn't consume a lot of space and is
useful for devel/debug purposes.
(Although `hostname` is added back for ci/testing only, it doesn't hurt
to add it back too)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
