### PR TITLE
Remove docs package installation from building layers of the image

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/8/daemon/__DOCKERFILE_INSTALL__
@@ -1,6 +1,6 @@
 echo 'Install packages' && \
-      yum install -y --setopt=install_weak_deps=False wget unzip util-linux python3-setuptools udev device-mapper && \
-      yum install -y --setopt=install_weak_deps=False --enablerepo=powertools __DAEMON_PACKAGES__ && \
+      yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs wget unzip util-linux python3-setuptools udev device-mapper && \
+      yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs --enablerepo=powertools __DAEMON_PACKAGES__ && \
     # Centos 8 doesn't have confd/etcdctl/kubectl packages, so install them from web
     __WEB_INSTALL_CONFD__ && \
     __WEB_INSTALL_ETCDCTL__ && \


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

This commit try to make sure we are not installing `docs` packages in the container image and thus an attempt to not contribute extra space with the docs rpms atleast. 


Update #
#1998 

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
