### PR TITLE
build: fix centos latest

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -72,6 +72,9 @@ bash -c ' \
     if [[ "${OSD_FLAVOR}" == "crimson" ]]; then \
      CRIMSON_PACKAGES="ceph-crimson-osd__ENV_[CEPH_POINT_RELEASE]__";\
     fi ;\
+    if [[ "${CEPH_REF}" == "octopus" ]]; then \
+     RELEASE_VER=1 ;\
+    fi ;\
   else \
     RELEASE_VER=1 ;\
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -28,19 +28,6 @@ if command -v apt-get &>/dev/null; then
   sudo ln -sf "$(command -v python3.6)" /usr/bin/python3
 else
   sudo yum install -y docker xfsprogs
-  if ! command -v python3.6 &>/dev/null; then
-    sudo yum -y groupinstall development
-    sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
-    sudo yum -y install python36u
-  fi
-  sudo ln -sf "$(command -v python3.6)" /usr/bin/python3
-
-  if ! systemctl status docker >/dev/null; then
-    # daemon doesn't start automatically after being installed
-    sudo systemctl restart docker
-  fi
-  # Allow running `docker` without sudo
-  sudo chgrp "$(whoami)" /var/run/docker.sock
 fi
 
 if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
@@ -96,7 +83,7 @@ docker tag "${daemon_image}" localhost:5000/ceph/daemon:latest-master
 # this avoids a race condition between the tagging and the push
 # which causes this to sometimes fail when run by jenkins
 sleep 5
-docker --debug push localhost:5000/ceph/daemon:latest-master
+docker push --tls-verify=false localhost:5000/ceph/daemon:latest-master
 
 cd "$CEPH_ANSIBLE_SCENARIO_PATH"
 bash "$TOXINIDIR"/ceph-ansible/tests/scripts/vagrant_up.sh --no-provision --provider="$VAGRANT_PROVIDER"


### PR DESCRIPTION
The last build failed:
https://2.jenkins.ceph.com/job/ceph-container-build-push-imgs-devel-nightly/1003/consoleFull

With:

```
[91mcurl: (22) The requested URL returned error: 404 Not Found
[0m[91merror: skipping
https://chacra.ceph.com/r/ceph/octopus/d46a73d6d0a67a79558054a3a5a72cb561724974/centos/8/flavors/default//noarch/ceph-release-1-0.el8.noarch.rpm
- transfer failed
```

Looking at the repo page, we can see that
ceph-release-1-0.el8.noarch.rpm does not exist but
/ceph-release-1-1.el8.noarch.rpm is present.

I'm not sure why/where things started to change. Also previous
successful builds were pointing to 3.chacra.ceph.com and now simply
chacra.ceph.com, I'm not sure what the difference is.

See this successful build: Retrieving
https://3.chacra.ceph.com/r/ceph/octopus/065c9d29f7426c283cf80fed433ed59efc43fe5e/centos/8/flavors/default//noarch/ceph-release-1-0.el8.noarch.rpm

Which did:

```
Retrieving
https://3.chacra.ceph.com/r/ceph/octopus/065c9d29f7426c283cf80fed433ed59efc43fe5e/centos/8/flavors/default//noarch/ceph-release-1-0.el8.noarch.rpm
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
