### PR TITLE
Makefile: use podman instead of docker

### DIFF
--- a/src/daemon-base/Makefile
+++ b/src/daemon-base/Makefile
@@ -21,10 +21,10 @@
 .PHONY: build push clean
 
 build:
-	@echo === docker build $(DAEMON_BASE_IMAGE)
-	@docker build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
+	@echo === podman build $(DAEMON_BASE_IMAGE)
+	@podman build --pull $(BUILD_ARGS) --tag $(DAEMON_BASE_IMAGE) .
 
-push: ; @docker push $(DAEMON_BASE_IMAGE)
+push: ; @podman push $(DAEMON_BASE_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@docker rmi $(DAEMON_BASE_IMAGE) || true
+	@podman rmi $(DAEMON_BASE_IMAGE) || true

--- a/src/daemon/Makefile
+++ b/src/daemon/Makefile
@@ -21,10 +21,10 @@
 .PHONY: build push clean
 
 build:
-	@echo === docker build $(DAEMON_IMAGE)
-	@docker build $(BUILD_ARGS) -t $(DAEMON_IMAGE) .
+	@echo === podman build $(DAEMON_IMAGE)
+	@podman build $(BUILD_ARGS) -t $(DAEMON_IMAGE) .
 
-push: ; @docker push $(DAEMON_IMAGE)
+push: ; @podman push $(DAEMON_IMAGE)
 clean:
 # Don't fail if can't clean; user may have removed the image
-	@docker rmi $(DAEMON_IMAGE) || true
+	@podman rmi $(DAEMON_IMAGE) || true


### PR DESCRIPTION
Switch the Makefile operations to use `podman` instead of `docker`. Avoid the need for the `moby-engine` package or `podman`/`docker` aliases.