### PR TITLE
ubi8: update content_sets.yml header comments

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/content_sets.yml
+++ b/ceph-releases/ALL/ubi8/daemon-base/content_sets.yml
@@ -1,15 +1,12 @@
-# This is a file defining which content sets (yum repositories) are needed to
-# update content in this image. Data provided here helps determine which images
-# are vulnerable to specific CVEs. Generally you should only need to update this
+# This file defines which Pulp content sets (yum repositories) OSBS needs in
+# order to build this image. This also helps determine which images are
+# vulnerable to specific CVEs. Generally you should only need to update this
 # file when:
 #    1. You start depending on a new product
 #    2. You are preparing new product release and your content sets will change
 #
-# See https://mojo.redhat.com/docs/DOC-1023066 for more information on
-# maintaining this file and the format and examples
-#
-# You should have one top level item for each architecture being built. Most
-# likely this will be x86_64 and ppc64le initially.
+# See https://osbs.readthedocs.io/en/latest/users.html#content-sets for more
+# information on maintaining this file.
 ---
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms


### PR DESCRIPTION
Simplify the comment at the top of OSBS's `content_sets.yml`.

Remove the outdated Mojo link and link to the open-source OSBS documentation instead.

