### PR TITLE
ubi8: remove mon and osd repos from content_sets.yml

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/content_sets.yml
+++ b/ceph-releases/ALL/ubi8/daemon-base/content_sets.yml
@@ -15,17 +15,11 @@ x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
   - rhceph-6-tools-for-rhel-8-x86_64-rpms
-  - rhceph-6-mon-for-rhel-8-x86_64-rpms
-  - rhceph-6-osd-for-rhel-8-x86_64-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
   - rhceph-6-tools-for-rhel-8-ppc64le-rpms
-  - rhceph-6-mon-for-rhel-8-ppc64le-rpms
-  - rhceph-6-osd-for-rhel-8-ppc64le-rpms
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
   - rhceph-6-tools-for-rhel-8-s390x-rpms
-  - rhceph-6-mon-for-rhel-8-s390x-rpms
-  - rhceph-6-osd-for-rhel-8-s390x-rpms


### PR DESCRIPTION
These Pulp repos will not exist for RH Ceph Storage 6. We'll only keep the "tools" repository.