### PR TITLE
ubi8: change base-image to ubi8-minimal

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,3 +1,3 @@
-yum update -y --setopt=install_weak_deps=False && \
-yum install -y --setopt=install_weak_deps=False wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
-yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__
+microdnf update -y --setopt=install_weak_deps=0 && \
+microdnf install -y --setopt=install_weak_deps=0 wget unzip util-linux python3-saml python3-setuptools udev device-mapper && \
+microdnf install -y --setopt=install_weak_deps=0 __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_POSTINSTALL_CLEANUP__
@@ -1,5 +1,5 @@
 echo 'Postinstall cleanup' && \
- ( yum clean all && \
+ ( microdnf clean all && \
    rpm -q __CEPH_BASE_PACKAGES__ && \
-   sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \
+   #sed -i 's/enabled=.*/enabled=1/g' /etc/yum/pluginconf.d/subscription-manager.conf && \
    rm -f /etc/profile.d/lang.sh )

--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -1,4 +1,4 @@
-RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
+#RUN sed -i 's/enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
 
 RUN rm -f /etc/yum.repos.d/ubi.repo
 

--- a/contrib/compose-rhcs.sh
+++ b/contrib/compose-rhcs.sh
@@ -6,7 +6,8 @@ set -e
 # VARIABLES #
 #############
 
-STAGING_DIR=staging/pacific-ubi8-latest-x86_64/
+RHEL_VER=${1:-8}
+STAGING_DIR=staging/pacific-ubi${RHEL_VER}-latest-x86_64/
 DAEMON_DIR=$STAGING_DIR/daemon
 DAEMON_BASE_DIR=${DAEMON_DIR}-base/
 DOCKERFILE_DAEMON=$DAEMON_DIR/Dockerfile
@@ -57,7 +58,7 @@ clean_staging() {
 }
 
 make_staging() {
-  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi8/ubi FLAVORS=pacific,ubi8,latest || fatal "Cannot build rhel8"
+  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi${RHEL_VER}/ubi-minimal FLAVORS=pacific,ubi${RHEL_VER},latest || fatal "Cannot build rhel${RHEL_VER}"
 }
 
 success() {

--- a/contrib/compose-rhcs.sh
+++ b/contrib/compose-rhcs.sh
@@ -39,16 +39,16 @@ create_compose_directory() {
   if [ -d "$COMPOSED_DIR" ]; then
     rm -rf "${COMPOSED_DIR:?}"
   fi
-  mkdir -p $COMPOSED_DIR
+  mkdir -p "$COMPOSED_DIR"
 }
 
 import_content() {
-  rsync -a --exclude "__*__" --exclude "*.bak" --exclude "*.md" "$1"/* $COMPOSED_DIR/ || fatal "Cannot rsync"
+  rsync -a --exclude "__*__" --exclude "*.bak" --exclude "*.md" "$1"/* "$COMPOSED_DIR"/ || fatal "Cannot rsync"
 }
 
 # Select the end of the daemon Dockerfile to complete the daemon-base's one
 merge_content() {
-  grep -B1 -A1000 "# Add ceph-container files" $DOCKERFILE_DAEMON >> $COMPOSED_DIR/Dockerfile || fatal "Cannot find starting point in $DOCKERFILE_DAEMON"
+  grep -B1 -A1000 "# Add ceph-container files" "$DOCKERFILE_DAEMON" >> "$COMPOSED_DIR"/Dockerfile || fatal "Cannot find starting point in $DOCKERFILE_DAEMON"
 }
 
 clean_staging() {
@@ -58,7 +58,7 @@ clean_staging() {
 }
 
 make_staging() {
-  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi${RHEL_VER}/ubi-minimal FLAVORS=pacific,ubi${RHEL_VER},latest || fatal "Cannot build rhel${RHEL_VER}"
+  make BASEOS_REGISTRY=registry.redhat.io BASEOS_REPO=ubi"${RHEL_VER}"/ubi-minimal FLAVORS=pacific,ubi"${RHEL_VER}",latest || fatal "Cannot build rhel${RHEL_VER}"
 }
 
 success() {
@@ -76,7 +76,7 @@ clean_staging
 make_staging
 check_staging_exist
 create_compose_directory
-import_content $DAEMON_DIR
-import_content $DAEMON_BASE_DIR
+import_content "$DAEMON_DIR"
+import_content "$DAEMON_BASE_DIR"
 merge_content
 success


### PR DESCRIPTION
1) Changed compose-rhcs.sh and the relevant DISTRO files to generate Dockerfile based on ubi8/ubi-minimal.
2) compose-rhcs.sh - new optional parameter to set the base-image version with default value of 8.

Notes:
-- to build the image follow the steps in contrib/rhcs.md
-- subscription-manager is currently not installed on the image

Updates: #2004
Signed-off-by: tshacked <tshacked@redhat.com>
