### PR TITLE
ganesha: ensure /var/run/ganesha is created

### DIFF
--- a/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
+++ b/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
@@ -3,4 +3,5 @@ sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/'
 # validate the sed command worked as expected
 grep -sqo "udev_sync = 0" /etc/lvm/lvm.conf && \
 grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf && \
-grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf
+grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf && \
+mkdir /var/run/ganesha


### PR DESCRIPTION
as of nfs-ganesha 4, the default path for the pidfile becomes
`/var/run/ganesha/ganesha.pid`

If this directory doesn't exist, nfs-ganesha doesn't start.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
