### PR TITLE
ubi9: set ignore_absent_pulp_repos

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/container.yaml
+++ b/ceph-releases/ALL/ubi9/daemon-base/container.yaml
@@ -4,3 +4,4 @@
 compose:
   packages: []
   pulp_repos: true
+  ignore_absent_pulp_repos: true


### PR DESCRIPTION
ODCS fails to compose because it cannot find the `rhceph-6-tools-for-rhel-9-*-rpms` repositories in Pulp yet.

(Revert this when release engineering has created these repositories.)