### PR TITLE
ubi9: exclude s390x

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/container.yaml
+++ b/ceph-releases/ALL/ubi9/daemon-base/container.yaml
@@ -1,6 +1,9 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
+platforms:
+  not: s390x
+
 compose:
   packages: []
   pulp_repos: true


### PR DESCRIPTION
We cannot build quincy on RHEL 9 on s390x yet due to a `CheckCxxAtomic` false positive, 
https://tracker.ceph.com/issues/56492

Revert this change when that issue is resolved and we can build quincy on s390x.