### PR TITLE
contrib/rhcs.md: use "main" branch

### DIFF
--- a/contrib/rhcs.md
+++ b/contrib/rhcs.md
@@ -16,7 +16,7 @@ to fetch the base image.
 
 ## Composing the Dockerfile
 
-> **_NOTE:_**  Please ensure you're working on the `stable-7.0` branch of the ceph-container project. That corresponds to the RH Ceph Storage 6 product. The `main` branch of ceph-container does not work with RH Ceph Storage 6 today.
+> **_NOTE:_**  Please ensure you're working on the `main` branch of the ceph-container project. That corresponds to the RH Ceph Storage 6 product.
 
 The `ceph-container` project uses a series of template files to create the
 final `Dockerfile` that developers can build or commit to dist-git. This


### PR DESCRIPTION
`stable-7.0` does not exist. Explain that users should use the `main` branch for now.