### PR TITLE
base: add sssd-client to NFS-Ganesha packages

### DIFF
--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace sssd-client


### PR DESCRIPTION
In order for NFS-Ganesha to use System Security Services Daemon
(SSSD)[1], it requires the sssd-client packages to be installed. This
should add less than 500 kB to the image.

NFS-Ganesha can use SSSD for user ID management. SSSD supports LDAP,
Active Directory, and FreeIPA. Notably, SSSD is the primary tool used
to allow FreeIPA support.

[1] https://sssd.io

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
