### PR TITLE
tests: drop octopus/el7 from ALL_BUILDABLE_FLAVORS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ include maint-lib/makelib.mk
 
 # All flavor options that can be passed to FLAVORS
 ALL_BUILDABLE_FLAVORS := \
-	octopus,centos,7 \
 	octopus,centos,8 \
 	pacific,centos,8 \
 	quincy,centos,8 \


### PR DESCRIPTION
We don't build this image anymore for a while.
It's making any new PRs in this project fail.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
