### PR TITLE
build: Request appropriate arch for nfs-ganesha repo

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -3,7 +3,7 @@ yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     if [[ "${CEPH_VERSION}" == master || "${CEPH_VERSION}" == main ]]; then \
-      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo" -o /etc/yum.repos.d/ganesha.repo ; \
+      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
     elif  [[ "${CEPH_VERSION}" == quincy ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
If an arm64 build passes but the x86 one fails, shaman will return the arm64 repo for an x86 build.  This results in errors like:
```
No match for argument: nfs-ganesha
No match for argument: nfs-ganesha-ceph
No match for argument: nfs-ganesha-rgw
No match for argument: nfs-ganesha-rados-grace
No match for argument: nfs-ganesha-rados-urls
Error: Unable to find a match: nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls
```

Signed-off-by: David Galloway <dgallowa@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
