### PR TITLE
base: add sssd-client to centos 8 and ubi9 images

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls

--- a/ceph-releases/ALL/ubi9/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/ubi9/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls

--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace sssd-client
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client


### PR DESCRIPTION
The latest Ceph builds don't contain sssd-client along with the
nfs-ganesha packages. The upstream builds are from CentOS 8, which has
overrides defined. Add sssd-client to these overrides as well

Also add the package to the RHEL-based ubi9.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
