### PR TITLE
tests: Use old increment method

### DIFF
--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -52,7 +52,8 @@ if [ "${containers_to_remove}" ]; then
   NUM_CONTAINERS=$(docker ps -a -q | wc -l)
   until [ "$ATTEMPTS" -eq 5 ] || [ "$NUM_CONTAINERS" -eq 0 ]; do
     docker rm -f "$@" "${containers_to_remove}"
-    ((ATTEMPTS++))
+    # shellcheck disable=SC2219
+    let "ATTEMPTS=ATTEMPTS+1"
     NUM_CONTAINERS=$(docker ps -a -q | wc -l)
   done
   if [ "$ATTEMPTS" -eq 5 ]; then


### PR DESCRIPTION
Jenkins adds spaces which makes the function exit 1.

Fixes:
```
++ docker ps -a -q
+ containers_to_remove=10eb12ab5f5e
+ '[' 10eb12ab5f5e ']'
+ ATTEMPTS=0
++ docker ps -a -q
++ wc -l
+ NUM_CONTAINERS=1
+ '[' 0 -eq 5 ']'
+ '[' 1 -eq 0 ']'
+ docker rm -f 10eb12ab5f5e
10eb12ab5f5ef303c62c71bfe3b04d7b33f42d50289f415b1665e1b2e72cce09
+ (( ATTEMPTS++ ))
ERROR: InvocationError for command /usr/bin/bash tests/tox.sh (exited with code 1)
```

Signed-off-by: David Galloway <dgallowa@redhat.com>
