### PR TITLE
ubi9: reinstall systemd package

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi9/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -15,3 +15,7 @@ LABEL description="Red Hat Ceph Storage 6"
 LABEL summary="Provides the latest Red Hat Ceph Storage 6 on RHEL 9 in a fully featured and supported base image."
 LABEL io.k8s.display-name="Red Hat Ceph Storage 6 on RHEL 9"
 LABEL io.openshift.tags="rhceph ceph"
+
+# Workaround for https://bugzilla.redhat.com/2102821 :
+RUN microdnf -y --setopt=install_weak_deps=0 --nodocs update systemd && \
+    microdnf -y --setopt=install_weak_deps=0 --nodocs reinstall systemd


### PR DESCRIPTION
The ubi9 base image deletes libsystemd from the systemd package. To fix
this and reinstate the libsystemd shared library, we must reinstall the
systemd package.

We can revert this change when the ubi9-minimal image does not ship a
broken systemd package.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2114004

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit cb46d8bdeeaebf07f2fcfbfd53f8621334028c15)
