### PR TITLE
(stable-7.0) base: add sssd-client to NFS-Ganesha packages

### DIFF
--- a/ceph-releases/ALL/centos/8/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/centos/8/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls

--- a/ceph-releases/ALL/ubi9/daemon-base/__GANESHA_PACKAGES__
+++ b/ceph-releases/ALL/ubi9/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls

--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace sssd-client

--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace sssd-client
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client


### PR DESCRIPTION
In order for NFS-Ganesha to use System Security Services Daemon
(SSSD)[1], it requires the sssd-client packages to be installed. This
should add less than 500 kB to the image.

NFS-Ganesha can use SSSD for user ID management. SSSD supports LDAP,
Active Directory, and FreeIPA. Notably, SSSD is the primary tool used
to allow FreeIPA support.

[1] https://sssd.io

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>
(cherry picked from commit 8eed9ba52d99aaffd691bd1aa56fd3ac3bb267d5)