### PR TITLE
base: add sg3_utils package

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -15,6 +15,7 @@
         nvme-cli \
         libstoragemgmt \
         systemd-udev \
+        sg3_utils \
         procps-ng \
         hostname \
         __RADOSGW_PACKAGES__ \


### PR DESCRIPTION
This adds the sg3_utils package.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit b3b102f4a1545840f05cf743e5983e90b084ec75)
