### PR TITLE
build: Prevent `error: db5 error` errors

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -88,4 +88,6 @@ bash -c ' \
     yum copr enable -y tchaikov/python-scikit-learn ; \
     yum copr enable -y tchaikov/python3-asyncssh ; \
   fi ' && \
+systemctl stop packagekit.service ; \
+rm -f /sysroot/var/lib/rpm/__db00* ; \
 yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
https://access.redhat.com/solutions/6962401
https://access.redhat.com/solutions/5884221

Passed: https://jenkins.ceph.com/job/ceph-dev-container-only/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos8,DIST=centos8,MACHINE_SIZE=gigantic/10/console

Signed-off-by: David Galloway <dgallowa@redhat.com>