### PR TITLE
Revert "ubi9: reinstall systemd package"

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi9/daemon-base/__DOCKERFILE_PREINSTALL__
@@ -15,7 +15,3 @@ LABEL description="Red Hat Ceph Storage 6"
 LABEL summary="Provides the latest Red Hat Ceph Storage 6 on RHEL 9 in a fully featured and supported base image."
 LABEL io.k8s.display-name="Red Hat Ceph Storage 6 on RHEL 9"
 LABEL io.openshift.tags="rhceph ceph"
-
-# Workaround for https://bugzilla.redhat.com/2102821 :
-RUN microdnf -y --setopt=install_weak_deps=0 --nodocs update systemd && \
-    microdnf -y --setopt=install_weak_deps=0 --nodocs reinstall systemd


### PR DESCRIPTION
The ubi9-minimal image no longer has the systemd package. The container maintainer has added a check to the build process to make sure it will not reappear.

This reverts commit cb46d8bdeeaebf07f2fcfbfd53f8621334028c15.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 03effa3cad3ecea8d6c274609b041401ec74bf44)
