### PR TITLE
Revert "ubi9: exclude s390x"

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/container.yaml
+++ b/ceph-releases/ALL/ubi9/daemon-base/container.yaml
@@ -1,9 +1,6 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
-platforms:
-  not: s390x
-
 compose:
   packages: []
   pulp_repos: true


### PR DESCRIPTION
We've settled the s390x build failure in
https://tracker.ceph.com/issues/56492

This reverts commit cd3197c6921abcb2846691906cdc67cf46557213.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit f77ca5de7910f1e3de260a1218c757954afd8327)
