### PR TITLE
remove gating.yaml

### DIFF
--- a/ceph-releases/ALL/ubi9/daemon-base/gating.yaml
+++ b/ceph-releases/ALL/ubi9/daemon-base/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}


### PR DESCRIPTION
We were never able to get this gating test to work properly, and the CVP team is asking us to remove this now so we don't consume test resources.