### PR TITLE
ubi: symlink redhat dashboard

### DIFF
--- a/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/ubi8/daemon-base/__DOCKERFILE_INSTALL__
@@ -1,2 +1,3 @@
 microdnf update -y --setopt=install_weak_deps=0 --nodocs && \
-microdnf install -y --setopt=install_weak_deps=0 --nodocs wget unzip util-linux python3-saml python3-setuptools udev device-mapper __CEPH_BASE_PACKAGES__
+microdnf install -y --setopt=install_weak_deps=0 --nodocs wget unzip util-linux python3-saml python3-setuptools udev device-mapper __CEPH_BASE_PACKAGES__ && \
+ln -s /usr/share/ceph/mgr/dashboard/frontend/dist-redhat /usr/share/ceph/mgr/dashboard/frontend/dist


### PR DESCRIPTION
We must select the Red Hat dashboard frontend in Red Hat's `Dockerfile`.

Related: [rhbz#2161868](https://bugzilla.redhat.com/show_bug.cgi?id=2161868)
