### PR TITLE
tox: replace whitelist_externals with allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = ceph_ansible-{all_daemons,lvm_osds,collocation}
 skipsdist = True
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     pip


### PR DESCRIPTION
typical error:
`ceph_ansible-all_daemons: failed with bash is not allowed, use allowlist_externals to allow it`

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
(cherry picked from commit 4cdff4af98ca3b2d99ffeabcd71a87adb22a5499)
