### PR TITLE
contrib/rhcs.md: fix VERSION argument

### DIFF
--- a/contrib/rhcs.md
+++ b/contrib/rhcs.md
@@ -21,7 +21,7 @@ final `Dockerfile` that developers can build or commit to dist-git. This
 command generates that downstream Red Hat UBI-based `Dockerfile`:
 
 ```
-UBI_VERSION=9 ./contrib/compose-rhcs.sh
+VERSION=6 ./contrib/compose-rhcs.sh
 ```
 
 ## Yum repositories


### PR DESCRIPTION
Document the product `VERSION` argument that we implemented in 81fb72da67716266052ccbf80a257947903a37c5 . Users should not set `UBI_VERSION` outside this script.