### PR TITLE
ubi8: correct product version number

### DIFF
--- a/ceph-releases/ALL/ubi8/__DOCKERFILE_PREINSTALL__
+++ b/ceph-releases/ALL/ubi8/__DOCKERFILE_PREINSTALL__
@@ -6,7 +6,7 @@ RUN echo "Red Hat Ceph Storage Server 5 (Container)" > /etc/redhat-storage-relea
 EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 
 # Atomic specific labels
-LABEL version="6"
+LABEL version="5"
 
 # Build specific labels
 LABEL com.redhat.component="rhceph-container"


### PR DESCRIPTION
For ubi8, the product version number is 5, not 6.