### PR TITLE
compose-rhcs: fix a bug in generated tags

### DIFF
--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -39,16 +39,16 @@ $(shell bash -c 'set -eu ; \
 	set_var RELEASE            "$(RELEASE)" ; \
 	\
 	daemon_base_img="$$(val_or_default "$(DAEMON_BASE_TAG)" \
-		"daemon-base:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
+		"daemon-base:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
 	if [ -n "$(TAG_REGISTRY)" ]; then daemon_base_img="$(TAG_REGISTRY)/$$daemon_base_img" ; fi ; \
 	set_var DAEMON_BASE_IMAGE  "$$daemon_base_img" ; \
 	\
 	daemon_img="$$(val_or_default "$(DAEMON_TAG)" \
-			"daemon:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
+			"daemon:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
 	if [ -n "$(TAG_REGISTRY)" ]; then daemon_img="$(TAG_REGISTRY)/$$daemon_img" ; fi ; \
 	set_var DAEMON_IMAGE       "$$daemon_img" ; \
 	demo_img="$$(val_or_default "$(DEMO_TAG)" \
-			"demo:$(RELEASE)-$$CEPH_VERSION-$$BASEOS_REPO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
+			"demo:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
 	if [ -n "$(TAG_REGISTRY)" ]; then demo_img="$(TAG_REGISTRY)/$$demo_img" ; fi ; \
 	set_var DEMO_IMAGE       "$$demo_img" ; \
 	'


### PR DESCRIPTION
when we run the script `compose-rhcs.sh` it generates the following output:

```
 $ VERSION=6 ./contrib/compose-rhcs.sh

...

  DAEMON_BASE_IMAGE : ceph/daemon-base:fix-tags-quincy-ubi9/ubi-minimal-latest-x86_64
  DAEMON_IMAGE      : ceph/daemon:fix-tags-quincy-ubi9/ubi-minimal-latest-x86_64
  DEMO_IMAGE        : ceph/demo:fix-tags-quincy-ubi9/ubi-minimal-latest-x86_64
```

The tags generated are wrong.

This commits makes it generate better tags:

```
$ VERSION=6 ./contrib/compose-rhcs.sh

...

  DAEMON_BASE_IMAGE : ceph/daemon-base:fix-tags-quincy-ubi9-ibm-latest-x86_64
  DAEMON_IMAGE      : ceph/daemon:fix-tags-quincy-ubi9-ibm-latest-x86_64
  DEMO_IMAGE        : ceph/demo:fix-tags-quincy-ubi9-ibm-latest-x86_64

```
