### PR TITLE
contrib: give example values in VERSION error message

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -17,7 +17,7 @@ case "${VERSION}" in
     CEPH_RELEASE=quincy
     ;;
     *)
-    echo "ERROR: VERSION must be set to a valid version."
+    echo "ERROR: VERSION must be set to 4, 5, or 6."
     exit 1
 esac
 


### PR DESCRIPTION
Print the list of valid versions when the user did not set one.