### PR TITLE
daemon-base: add cephfs-top package

### DIFF
--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -4,6 +4,7 @@
         ceph-common__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-mon__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
+        cephfs-top__ENV_[CEPH_POINT_RELEASE]__ \
         __CEPHFS_PACKAGES__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
         __CEPH_MGR_PACKAGES__\


### PR DESCRIPTION
This adds the `cephfs-top` package in the daemon-base image.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2168965
