### PR TITLE
daemon-base: add required pkgs for rgw lua scripting support

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -88,4 +88,4 @@ bash -c ' \
     yum copr enable -y tchaikov/python-scikit-learn ; \
     yum copr enable -y tchaikov/python3-asyncssh ; \
   fi ' && \
-yum install -y --setopt=install_weak_deps=False __CEPH_BASE_PACKAGES__
+yum install -y --setopt=install_weak_deps=False --enablerepo=powertools __CEPH_BASE_PACKAGES__

--- a/ceph-releases/ALL/centos/daemon-base/__RADOSGW_PACKAGES__
+++ b/ceph-releases/ALL/centos/daemon-base/__RADOSGW_PACKAGES__
@@ -1,1 +1,1 @@
-ceph-radosgw__ENV_[CEPH_POINT_RELEASE]__ libradosstriper1__ENV_[CEPH_POINT_RELEASE]__
+ceph-radosgw__ENV_[CEPH_POINT_RELEASE]__ libradosstriper1__ENV_[CEPH_POINT_RELEASE]__ gcc lua-devel luarocks


### PR DESCRIPTION
This adds gcc, luarocks and lua-devel as they are required for the lua scripting feature support in RGW.

Fixes: #2116
