### PR TITLE
ubi9-ibm: update container image list

### DIFF
--- a/ceph-releases/ALL/ubi9-ibm/__DOCKERFILE_BRANDING__
+++ b/ceph-releases/ALL/ubi9-ibm/__DOCKERFILE_BRANDING__
@@ -1,14 +1,14 @@
 ln -s /usr/share/ceph/mgr/dashboard/frontend/dist-ibm /usr/share/ceph/mgr/dashboard/frontend/dist && \
 sed -i \
-  -e "s|registry.redhat.io/rhceph/rhceph-6-rhel9:latest|cp.icr.io/cp/ibm-ceph/ceph-6-rhel9:latest|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus:v4.10|cp.icr.io/cp/ibm-ceph/prometheus:v4.10|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.10|cp.icr.io/cp/ibm-ceph/prometheus-node-exporter:v4.10|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-6-dashboard-rhel9:latest|cp.icr.io/cp/ibm-ceph/ceph-6-dashboard-rhel9:latest|" \
-  -e "s|registry.redhat.io/openshift-logging/logging-loki-rhel8:v2.6.1|cp.icr.io/cp/ibm-ceph/logging-loki-rhel8:v2.6.1|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-promtail-rhel9:v2.4.0|cp.icr.io/cp/ibm-ceph/promtail-rhel9:v2.4.0|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.10|cp.icr.io/cp/ibm-ceph/prometheus-alertmanager:v4.10|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-haproxy-rhel9:latest|cp.icr.io/cp/ibm-ceph/haproxy-rhel9:latest|" \
-  -e "s|registry.redhat.io/rhceph/keepalived-rhel9:latest|cp.icr.io/cp/ibm-ceph/keepalived-rhel9:latest|" \
-  -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:latest|cp.icr.io/cp/ibm-ceph/snmp-notifier-rhel9:latest|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-6-rhel9:|cp.icr.io/cp/ibm-ceph/ceph-6-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus:|cp.icr.io/cp/ibm-ceph/prometheus:|" \
+  -e "s|registry.redhat.io/openshift-logging/logging-loki-rhel8:|cp.icr.io/cp/ibm-ceph/logging-loki-rhel8:|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-promtail-rhel9:|cp.icr.io/cp/ibm-ceph/promtail-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus-node-exporter:|cp.icr.io/cp/ibm-ceph/prometheus-node-exporter:|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-6-dashboard-rhel9:|cp.icr.io/cp/ibm-ceph/ceph-6-dashboard-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus-alertmanager:|cp.icr.io/cp/ibm-ceph/prometheus-alertmanager:|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-haproxy-rhel9:|cp.icr.io/cp/ibm-ceph/haproxy-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/keepalived-rhel9:|cp.icr.io/cp/ibm-ceph/keepalived-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:|cp.icr.io/cp/ibm-ceph/snmp-notifier-rhel9:|" \
   -e "s|default='registry.redhat.io'|default='cp.icr.io'|" \
   /usr/share/ceph/mgr/cephadm/module.py && \


### PR DESCRIPTION
Update container image list for IBM Storage Ceph 6.

Do not search-and-replace individual tags, because those could change.