### PR TITLE
contrib/rhcs.md: document BRANDING variable

### DIFF
--- a/contrib/rhcs.md
+++ b/contrib/rhcs.md
@@ -21,7 +21,12 @@ final `Dockerfile` that developers can build or commit to dist-git. This
 command generates that downstream Red Hat UBI-based `Dockerfile`:
 
 ```
-VERSION=6 ./contrib/compose-rhcs.sh
+BRANDING=redhat VERSION=6 ./contrib/compose-rhcs.sh
+```
+
+Or the IBM-branded `Dockerfile`:
+```
+BRANDING=ibm VERSION=6 ./contrib/compose-rhcs.sh
 ```
 
 ## Yum repositories


### PR DESCRIPTION
Explain how to use the `BRANDING` environment variable to choose generating Red Hat's or IBM's `Dockerfile`s.