### PR TITLE
remove `gating.yaml`

### DIFF
--- a/ceph-releases/ALL/ubi8-ibm/daemon/gating.yaml
+++ b/ceph-releases/ALL/ubi8-ibm/daemon/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/ALL/ubi8-redhat/daemon/gating.yaml
+++ b/ceph-releases/ALL/ubi8-redhat/daemon/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/ALL/ubi8/gating.yaml
+++ b/ceph-releases/ALL/ubi8/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/ALL/ubi9-ibm/daemon-base/gating.yaml
+++ b/ceph-releases/ALL/ubi9-ibm/daemon-base/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/nautilus/ubi8/gating.yaml
+++ b/ceph-releases/nautilus/ubi8/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/quincy/ubi9-redhat/daemon-base/gating.yaml
+++ b/ceph-releases/quincy/ubi9-redhat/daemon-base/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}

--- a/ceph-releases/reef/ubi9-redhat/daemon-base/gating.yaml
+++ b/ceph-releases/reef/ubi9-redhat/daemon-base/gating.yaml
@@ -1,7 +1,0 @@
---- !Policy
-id: "cvp-external"
-product_versions:
- - cvp
-decision_context: cvp_default
-rules:
- - !PassingTestCaseRule {test_case_name: rhceph-cvp-test.default.external1}


### PR DESCRIPTION
Remove `gating.yaml` from the tree. This is a follow-up to PR https://github.com/ceph/ceph-container/pull/2081