### PR TITLE
reef/ubi9: rename dashboard container to grafana

### DIFF
--- a/ceph-releases/reef/ubi9-ibm/__DOCKERFILE_BRANDING__
+++ b/ceph-releases/reef/ubi9-ibm/__DOCKERFILE_BRANDING__
@@ -5,7 +5,7 @@ sed -i \
   -e "s|registry.redhat.io/openshift-logging/logging-loki-rhel8:|cp.icr.io/cp/ibm-ceph/logging-loki-rhel8:|" \
   -e "s|registry.redhat.io/rhceph/rhceph-promtail-rhel9:|cp.icr.io/cp/ibm-ceph/promtail-rhel9:|" \
   -e "s|registry.redhat.io/openshift4/ose-prometheus-node-exporter:|cp.icr.io/cp/ibm-ceph/prometheus-node-exporter:|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-7-dashboard-rhel9:|cp.icr.io/cp/ibm-ceph/ceph-7-dashboard-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/grafana-rhel9:|cp.icr.io/cp/ibm-ceph/grafana-rhel9:|" \
   -e "s|registry.redhat.io/openshift4/ose-prometheus-alertmanager:|cp.icr.io/cp/ibm-ceph/prometheus-alertmanager:|" \
   -e "s|registry.redhat.io/rhceph/rhceph-haproxy-rhel9:|cp.icr.io/cp/ibm-ceph/haproxy-rhel9:|" \
   -e "s|registry.redhat.io/rhceph/keepalived-rhel9:|cp.icr.io/cp/ibm-ceph/keepalived-rhel9:|" \


### PR DESCRIPTION
We're going to ship this grafana container to a repository with a name that more accurately describes what this image is.