### PR TITLE
nfs-ganesha: work around build issue

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -3,7 +3,7 @@ yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     if [[ "${CEPH_VERSION}" == master || "${CEPH_VERSION}" == main ]]; then \
-      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
+      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.3.2/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
     elif  [[ "${CEPH_VERSION}" == reef ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
nfs-ganesha builds are broken because of [1].
let's pin to V5.3.2 for now. This is intended to be reverted when
[2] is merged.
    
[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/da4245a9796cf5ca3e5eed8e4fc7b88a0c486e4e
[2] https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/557171