### PR TITLE
ceph-releases/main/centos: use V5.5 of nfs-ganesha to build centos 8

### DIFF
--- a/ceph-releases/main/centos/__GANESHA_REPO__
+++ b/ceph-releases/main/centos/__GANESHA_REPO__
@@ -1,1 +1,1 @@
-curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
+curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.5/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Following https://github.com/ceph/ceph-build/pull/2161, which changes the nfs-ganesha jenkins job to periodically build V5.5 instead of "next", we can update the container script to build with V5.5.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
