### PR TITLE
Revert tag repo logic

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -11,7 +11,7 @@ jobs:
         run: make BASEOS_REGISTRY=quay.io/centos BASEOS_TAG=stream8 RELEASE="demo" FLAVORS="main,centos,8" IMAGES_TO_BUILD="daemon-base demo" build
 
       - name: run the ceph demo container
-        run: docker run -d --privileged --name ceph-demo -v /mnt/ceph:/var/lib/ceph -e RGW_FRONTEND_TYPE=beast -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=ceph -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_PORT=5001 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=github -e OSD_COUNT=3 quay.io/ceph/demo:demo-main-centos-stream8-x86_64
+        run: docker run -d --privileged --name ceph-demo -v /mnt/ceph:/var/lib/ceph -e RGW_FRONTEND_TYPE=beast -e DEBUG=verbose -e RGW_FRONTEND_PORT=8000 -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e CLUSTER=ceph -e CEPH_DEMO_UID=demo -e CEPH_DEMO_ACCESS_KEY=G1EZ5R4K6IJ7XUQKMAED -e CEPH_DEMO_SECRET_KEY=cNmUrqpBKjCMzcfqG8fg4Qk07Xkoyau52OmvnSsz -e CEPH_DEMO_BUCKET=foobar -e SREE_PORT=5001 -e DATA_TO_SYNC=/etc/modprobe.d -e DATA_TO_SYNC_BUCKET=github -e OSD_COUNT=3 ceph/demo:demo-main-centos-stream8-x86_64
 
       - name: run the demo validation
         run: |

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ FLAVORS ?= \
 	reef,centos,8 \
 	main,centos,8
 
-TAG_REGISTRY ?= quay.io
-TAG_REPO ?= ceph
+TAG_REGISTRY ?= ceph
 
 # By default the RELEASE version is the git branch name
 # Could be overrided by user at build time

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -300,7 +300,7 @@ function push_ceph_imgs_latest {
       IFS="," read -r ceph_branch distro distro_release <<< "${CONTAINER_FLAVOR}"
     fi
     # local_tag should match with daemon_img defined in maint-lib/makelib.mk
-    local_tag=${CONTAINER_REPO_ORGANIZATION}/ceph/daemon-base:${RELEASE}-${CEPH_VERSION}-${distro}-stream${distro_release}-${HOST_ARCH}
+    local_tag=${CONTAINER_REPO_ORGANIZATION}/daemon-base:${RELEASE}-${CEPH_VERSION}-${distro}-stream${distro_release}-${HOST_ARCH}
     full_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${RELEASE}-${distro}-stream${distro_release}-${HOST_ARCH}-devel
     branch_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${BRANCH}
     sha1_repo_tag=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -40,16 +40,16 @@ $(shell bash -c 'set -eu ; \
 	\
 	daemon_base_img="$$(val_or_default "$(DAEMON_BASE_TAG)" \
 		"daemon-base:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
-	if [ -n "$(TAG_REGISTRY)" ]; then daemon_base_img="$(TAG_REGISTRY)/$(TAG_REPO)/$$daemon_base_img" ; fi ; \
+	if [ -n "$(TAG_REGISTRY)" ]; then daemon_base_img="$(TAG_REGISTRY)/$$daemon_base_img" ; fi ; \
 	set_var DAEMON_BASE_IMAGE  "$$daemon_base_img" ; \
 	\
 	daemon_img="$$(val_or_default "$(DAEMON_TAG)" \
 			"daemon:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
-	if [ -n "$(TAG_REGISTRY)" ]; then daemon_img="$(TAG_REGISTRY)/$(TAG_REPO)/$$daemon_img" ; fi ; \
+	if [ -n "$(TAG_REGISTRY)" ]; then daemon_img="$(TAG_REGISTRY)/$$daemon_img" ; fi ; \
 	set_var DAEMON_IMAGE       "$$daemon_img" ; \
 	demo_img="$$(val_or_default "$(DEMO_TAG)" \
 			"demo:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \
-	if [ -n "$(TAG_REGISTRY)" ]; then demo_img="$(TAG_REGISTRY)/$(TAG_REPO)/$$demo_img" ; fi ; \
+	if [ -n "$(TAG_REGISTRY)" ]; then demo_img="$(TAG_REGISTRY)/$$demo_img" ; fi ; \
 	set_var DEMO_IMAGE       "$$demo_img" ; \
 	'
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Reverts the logic in https://github.com/ceph/ceph-container/commit/15054d97b0fcf406542d9c1ea6cc6897f45ad732 and https://github.com/ceph/ceph-container/commit/032e6221e4e6e92333be9cec067e569ea41270f9.

The addition of the tag repo was not reflected in quay.io, which means that we keep trying to push images to non-existent repos like https://quay.io/ceph/ceph/daemon-base that don't exist (https://quay.io/ceph/daemon-base is the true repo path).

We can revisit this change if we also change the logic in quay.io to match.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
