### PR TITLE
add rpcbind to ganesha packages

### DIFF
--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon rpcbind


### PR DESCRIPTION
The `rpcbind` package provides the `rpcinfo` tool which can be used to determine the health status of a running NFS-Ganesha server daemon.

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
