### PR TITLE
chore: remove docker binary provided by docker-ce-cli

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: switch to podman
-        run: sudo apt-get remove moby-cli moby-engine moby-buildx moby-compose moby-runc moby-containerd && sudo apt-get install -y podman-docker
+        run: sudo apt-get remove moby-cli moby-engine moby-buildx moby-compose moby-runc moby-containerd docker-ce-cli && sudo apt-get install -y podman-docker
 
       - name: setup qemu-static-user
         run: sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:
Remove docker binary provided by docker-ce-cli as it is conflicting with "podman-docker" package resulting in failing ARM builds

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
