### PR TITLE
base: add iproute package

### DIFF
--- a/src/daemon-base/__UTIL_PACKAGES__
+++ b/src/daemon-base/__UTIL_PACKAGES__
@@ -1,2 +1,3 @@
 procps-ng \
-        hostname
+hostname \
+iproute


### PR DESCRIPTION
This makes the ip command available.

Fixes:https://bugzilla.redhat.com/show_bug.cgi?id=2245975