### PR TITLE
bump ganesha version in main containers to 5.7

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -4,7 +4,7 @@ bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     if [[ "${CEPH_VERSION}" == master || "${CEPH_VERSION}" == main ]]; then \
       ARCH=$(arch); if [[ "${ARCH}" == "aarch64" ]]; then ARCH="arm64"; fi ; \
-      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.5/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=${ARCH}" -o /etc/yum.repos.d/ganesha.repo ; \
+      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.7/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=${ARCH}" -o /etc/yum.repos.d/ganesha.repo ; \
     elif  [[ "${CEPH_VERSION}" == reef ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
nfs-ganesha 5.7 is now being built and pushed to
https://shaman.ceph.com/builds/nfs-ganesha/, but we're still only using 5.5 builds.
5.7 should also have the new cmount_path feature so let's use that.
