### PR TITLE
add swidtag files to IBM 7 Dockerfile

### DIFF
--- a/ceph-releases/reef/ubi9-ibm/daemon-base/__ADD__
+++ b/ceph-releases/reef/ubi9-ibm/daemon-base/__ADD__
@@ -1,0 +1,1 @@
+ADD *.swidtag /var/lib/ceph/swidtag/


### PR DESCRIPTION
Description of your changes:
Add Swidtag ADD lines for IBM 7's Dockerfile. We just added this for IBM 6, but needed it in this location as well, since IBM 7 is based on reef

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
