### PR TITLE
Changes to allow staging/testing a container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ BASEOS_TAG ?= ""
 CEPH_DEVEL ?= false
 OSD_FLAVOR ?= "default"
 
+# Default to not doing prerelease (env var must have a value)
+PRERELEASE ?= false
+PRERELEASE_USERNAME ?= ""
+PRERELEASE_PASSWORD ?= ""
+
 
 # ==============================================================================
 # Internal definitions

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -93,9 +93,21 @@ bash -c ' \
     fi ;\
   else \
     RELEASE_VER=1 ;\
-    REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
+    if [[ __ENV_[PRERELEASE]__ = true ]] ; then \
+      REPO_URL="https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
+    else \
+      REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
+    fi \
   fi && \
   rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[DISTRO_VERSION]__.noarch.rpm" && \
+  #
+  # We have to change this after installing because ceph-release is built long
+  # ago in the ceph build
+  #
+  if [[ __ENV_[PRERELEASE]__ = true ]] ; then \
+    sed -i "s;http://download.ceph.com/;https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/;" /etc/yum.repos.d/ceph.repo ; \
+    dnf clean expire-cache ; \
+  fi && \
   if [[ __ENV_[DISTRO_VERSION]__ -eq 8 ]]; then \
     yum install -y dnf-plugins-core ; \
     yum copr enable -y tchaikov/python-scikit-learn ; \

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="pacific,centos,8 quincy,centos,8 reef,centos,8"
-AARCH64_FLAVORS_TO_BUILD="pacific,centos,8 quincy,centos,8 reef,centos,8"
+X86_64_FLAVORS_TO_BUILD="${X86_64_FLAVORS_TO_BUILD:-pacific,centos,8 quincy,centos,8 reef,centos,8}"
+AARCH64_FLAVORS_TO_BUILD="${AARCH64_FLAVORS_TO_BUILD:-pacific,centos,8 quincy,centos,8 reef,centos,8}"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'
@@ -226,7 +226,11 @@ function get_ceph_download_url () {
     *)
       error "get_ceph_download_url - unknown distro '${distro}''"
   esac
-  echo "https://download.ceph.com/${flavor_path}/${arch}/"
+  if [ "$PRERELEASE" = true ] ; then
+    echo "https://$PRERELEASE_USERNAME:$PRERELEASE_PASSWORD@download.ceph.com/prerelease/${flavor_path}/${arch}/"
+  else
+    echo "https://download.ceph.com/${flavor_path}/${arch}/"
+  fi
 }
 
 # Return a list of the ceph version strings available on the server as:

--- a/maint-lib/makelib.mk
+++ b/maint-lib/makelib.mk
@@ -37,6 +37,9 @@ $(shell bash -c 'set -eu ; \
 	set_var IMAGES_TO_BUILD    "$(IMAGES_TO_BUILD)" ; \
 	set_var STAGING_DIR        "staging/$$CEPH_VERSION$$CEPH_POINT_RELEASE-$$DISTRO-$$DISTRO_VERSION-$$HOST_ARCH" ; \
 	set_var RELEASE            "$(RELEASE)" ; \
+	set_var PRERELEASE         "$(PRERELEASE)" ; \
+	set_var PRERELEASE_USERNAME "$(PRERELEASE_USERNAME)" ; \
+	set_var PRERELEASE_PASSWORD "$(PRERELEASE_PASSWORD)" ; \
 	\
 	daemon_base_img="$$(val_or_default "$(DAEMON_BASE_TAG)" \
 		"daemon-base:$(RELEASE)-$$CEPH_VERSION-$$DISTRO-$$BASEOS_TAG-$$HOST_ARCH")" ; \


### PR DESCRIPTION
New $PRERELEASE variable pulls pkgs from prerelease dir on download.ceph.com (requires PRERELEASE_USERNAME/PRERELEASE_PASSWORD in env) Existing $FORCE_BUILD ignores images on quay.io and builds unconditionally Add ability to pass in desired container flavors
Hack ceph-release after installation, because ceph-release is built
  during ceph build, and doesn't know what we need
Use tempfile to pass tagname back to parent
New $TEST_BUILD_ONLY avoids attempting to push image to quay.io Avoid logging into quay.io if PRERELEASE

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
