### PR TITLE
Makefile: do not build squid by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ FLAVORS ?= \
 	pacific,centos,8 \
 	quincy,centos,8 \
 	reef,centos,8 \
-	squid,centos,8 \
 	main,centos,8
 
 TAG_REGISTRY ?= ceph


### PR DESCRIPTION
Given that squid isn't available yet at download.ceph.com let's remove it from the FLAVORS list.
