### PR TITLE
add ceph-node-proxy package to ubi9-based IBM images

### DIFF
--- a/ceph-releases/ALL/ubi9-ibm/daemon-base/__CEPH_NODE_PROXY_PACKAGE__
+++ b/ceph-releases/ALL/ubi9-ibm/daemon-base/__CEPH_NODE_PROXY_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-node-proxy__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
This adds the ceph-node-proxy RPM package to the ubi9-based IBM Ceph downstream image.
