### PR TITLE
contrib: add default value to PRERELEASE variable

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -6,6 +6,7 @@ set -Eeuo pipefail
 # script. Dry runs will output commands that they would have executed as info messages.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PRERELEASE="${PRERELEASE:-false}"
 # shellcheck disable=SC1090  # sourcing from a variable here does indeed work
 source "${SCRIPT_DIR}/ceph-build-config.sh"
 


### PR DESCRIPTION
Typical failure seen in CI:

```
+ sudo chgrp jenkins-build /var/run/docker.sock
contrib/build-ceph-base.sh: line 20: PRERELEASE: unbound variable
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```

seems to have been introduced by 60f64185d6ee4a1620a4e475ec29fb91e0b44183
