### PR TITLE
contrib: add default value to TEST_BUILD_ONLY variable

### DIFF
--- a/contrib/build-ceph-base.sh
+++ b/contrib/build-ceph-base.sh
@@ -7,6 +7,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PRERELEASE="${PRERELEASE:-false}"
+TEST_BUILD_ONLY="${TEST_BUILD_ONLY:-false}"
 # shellcheck disable=SC1090  # sourcing from a variable here does indeed work
 source "${SCRIPT_DIR}/ceph-build-config.sh"
 


### PR DESCRIPTION
Typical failure seen in CI:

```
contrib/build-ceph-base.sh: line 98: TEST_BUILD_ONLY: unbound variable
```

seems to have been introduced by 60f64185d6ee4a1620a4e475ec29fb91e0b44183
