### PR TITLE
Revert "squid: Update contrib/build-push-ceph-container-imgs.sh with …

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -51,7 +51,7 @@ OSD_FLAVOR=${OSD_FLAVOR:=default}
 
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'main' position in the array, this will break the 'latest' tag
-  CEPH_RELEASES=(main pacific quincy reef squid)
+  CEPH_RELEASES=(main pacific quincy reef)
 fi
 
 HOST_ARCH=$(uname -m)


### PR DESCRIPTION
…the new release"

This reverts commit e51f1c7ca6fd4e2fa3eea407716e8ad3fe7e7fff.

This change doesn't make sense as no squid RPMs are available at the moment. Given that it makes the jenkins job fail, let's revert it.
