### PR TITLE
ubi9-redhat: add ceph-node-proxy RPM

### DIFF
--- a/ceph-releases/ALL/ubi9-redhat/daemon-base/__CEPH_NODE_PROXY_PACKAGE__
+++ b/ceph-releases/ALL/ubi9-redhat/daemon-base/__CEPH_NODE_PROXY_PACKAGE__
@@ -1,0 +1,1 @@
+ceph-node-proxy__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
There's no good reason for not including this package in RH Ceph container image too given that even though this feature is focusing on IBM specific hardware, it might be possible it works with more hardware (soon).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2268114
