### PR TITLE
tweaks: use full-line commands to sed

### DIFF
--- a/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
+++ b/src/__DOCKERFILE_POSTINSTALL_TWEAKS__
@@ -1,7 +1,10 @@
 # disable sync with udev since the container can not contact udev
-sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/' -e 's/obtain_device_list_from_udev = 1/obtain_device_list_from_udev = 0/' /etc/lvm/lvm.conf && \
+echo "About to edit lvm.conf" && \
+sed -i -e 's/^\([[:space:]#]*udev_rules =\) 1$/\1 0/' -e 's/^\([[:space:]#]*udev_sync =\) 1$/\1 0/' -e 's/^\([[:space:]#]*obtain_device_list_from_udev =\) 1$/\1 0/' /etc/lvm/lvm.conf && \
+echo "About to validate lvm.conf edits" && \
 # validate the sed command worked as expected
 grep -sqo "udev_sync = 0" /etc/lvm/lvm.conf && \
 grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf && \
 grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf && \
+echo "Edits validated OK" && \
 mkdir -p /var/run/ganesha


### PR DESCRIPTION
A safety tweak to make sure we only edit whole lines that match; also handle commented-out lines.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.

(neither of those things necessary here, I think)