### PR TITLE
Code cleanup: Move cephfs-top package to CEPHFS package list

### DIFF
--- a/src/daemon-base/__CEPHFS_PACKAGES__
+++ b/src/daemon-base/__CEPHFS_PACKAGES__
@@ -1,2 +1,3 @@
 ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
-cephfs-mirror__ENV_[CEPH_POINT_RELEASE]__
+cephfs-mirror__ENV_[CEPH_POINT_RELEASE]__ \
+cephfs-top__ENV_[CEPH_POINT_RELEASE]__

--- a/src/daemon-base/__CEPH_BASE_PACKAGES__
+++ b/src/daemon-base/__CEPH_BASE_PACKAGES__
@@ -4,7 +4,6 @@
         ceph-common__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-mon__ENV_[CEPH_POINT_RELEASE]__  \
         ceph-osd__ENV_[CEPH_POINT_RELEASE]__ \
-        cephfs-top__ENV_[CEPH_POINT_RELEASE]__ \
         __CEPHFS_PACKAGES__ \
         rbd-mirror__ENV_[CEPH_POINT_RELEASE]__  \
         __CEPH_MGR_PACKAGES__\


### PR DESCRIPTION
Currently `cephfs-top` is a part of the ceph base packages. This is to move it to be alongside the rest of the cephfs packages. This will allow for changing cephfs packages (enabling and disabling as well) based on release/distribution/etc

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.

Signed-off-by: Joseph Mundackal<jmundackal@bloomberg.net>
