### PR TITLE
edit /etc/security/limits.conf after installing ceph

### DIFF
--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -31,8 +31,8 @@ RUN \
     # Typical workflow: add new repos; refresh repos; install packages; package-manager clean;
     #   download and install packages from web, cleaning any files as you go.
     # Installs should support install of ganesha for luminous
-    __QAT_ACCELERATION__
     __DOCKERFILE_INSTALL__ && \
+    __QAT_ACCELERATION__
     # Clean container, starting with record of current size (strip / from end)
     INITIAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
     #


### PR DESCRIPTION
The `pam` RPM (and `/etc/security` directory) is not present in the ubi9-minimal base images. For minimal images, `pam` is only available after we install ceph.

Edit the `/etc/security/limits.conf` file after ceph (and pam) is installed.

This fixes this error introduced in https://github.com/ceph/ceph-container/pull/2194:

```
/bin/sh: line 1: /etc/security/limits.conf: No such file or directory
```