### PR TITLE
content_sets.yml: add codeready-builder repositories

### DIFF
--- a/ceph-releases/reef/ubi9-ibm/daemon-base/content_sets.yml
+++ b/ceph-releases/reef/ubi9-ibm/daemon-base/content_sets.yml
@@ -12,11 +12,14 @@ x86_64:
   - rhel-9-for-x86_64-baseos-rpms
   - rhel-9-for-x86_64-appstream-rpms
   - rhceph-7-tools-for-rhel-9-x86_64-rpms
+  - codeready-builder-for-rhel-9-x86_64-rpms
 ppc64le:
   - rhel-9-for-ppc64le-baseos-rpms
   - rhel-9-for-ppc64le-appstream-rpms
   - rhceph-7-tools-for-rhel-9-ppc64le-rpms
+  - codeready-builder-for-rhel-9-ppc64le-rpms
 s390x:
   - rhel-9-for-s390x-baseos-rpms
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-7-tools-for-rhel-9-s390x-rpms
+  - codeready-builder-for-rhel-9-s390x-rpms

--- a/ceph-releases/reef/ubi9-redhat/daemon-base/content_sets.yml
+++ b/ceph-releases/reef/ubi9-redhat/daemon-base/content_sets.yml
@@ -12,11 +12,14 @@ x86_64:
   - rhel-9-for-x86_64-baseos-rpms
   - rhel-9-for-x86_64-appstream-rpms
   - rhceph-7-tools-for-rhel-9-x86_64-rpms
+  - codeready-builder-for-rhel-9-x86_64-rpms
 ppc64le:
   - rhel-9-for-ppc64le-baseos-rpms
   - rhel-9-for-ppc64le-appstream-rpms
   - rhceph-7-tools-for-rhel-9-ppc64le-rpms
+  - codeready-builder-for-rhel-9-ppc64le-rpms
 s390x:
   - rhel-9-for-s390x-baseos-rpms
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-7-tools-for-rhel-9-s390x-rpms
+  - codeready-builder-for-rhel-9-s390x-rpms


### PR DESCRIPTION
For RH Ceph Storage 7.1 and IBM Storage Ceph 7.1, the `ceph-mgr-dashboard` package developers recently added a dependency on `python3-grpcio-tools`. This requires `libprotoc.so.25` from the `protobuf-compiler` package. `protobuf-compiler` is not in baseos or appstream. It is only in the codeready-builder repositories.

Related: [rhbz#2262984](https://bugzilla.redhat.com/show_bug.cgi?id=2262984)