### PR TITLE
centos: make the grpc copr repo available by default

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -112,8 +112,6 @@ bash -c ' \
     yum install -y dnf-plugins-core ; \
     yum copr enable -y tchaikov/python-scikit-learn ; \
     yum copr enable -y tchaikov/python3-asyncssh ; \
-    if [[ "${OSD_FLAVOR}" == "crimson" ]] ; then \
-      yum copr enable -y ceph/grpc ; \
-    fi ; \
+    yum copr enable -y ceph/grpc ; \
   fi ' && \
 yum install -y --setopt=install_weak_deps=False --enablerepo=powertools __CEPH_BASE_PACKAGES__


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
