### PR TITLE
Revert "ubi9-ibm: use beta container registry"

### DIFF
--- a/ceph-releases/reef/ubi9-ibm/__DOCKERFILE_BRANDING__
+++ b/ceph-releases/reef/ubi9-ibm/__DOCKERFILE_BRANDING__
@@ -1,15 +1,15 @@
 ln -s /usr/share/ceph/mgr/dashboard/frontend/dist-ibm /usr/share/ceph/mgr/dashboard/frontend/dist && \
 sed -i \
-  -e "s|registry.redhat.io/rhceph/rhceph-7-rhel9:|icr.io/ibm-ceph-beta/ceph-7-rhel9:|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus:|icr.io/ibm-ceph-beta/prometheus:|" \
-  -e "s|registry.redhat.io/openshift-logging/logging-loki-rhel8:|icr.io/ibm-ceph-beta/logging-loki-rhel8:|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-promtail-rhel9:|icr.io/ibm-ceph-beta/promtail-rhel9:|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus-node-exporter:|icr.io/ibm-ceph-beta/prometheus-node-exporter:|" \
-  -e "s|registry.redhat.io/rhceph/grafana-rhel9:|icr.io/ibm-ceph-beta/grafana-rhel9:|" \
-  -e "s|registry.redhat.io/openshift4/ose-prometheus-alertmanager:|icr.io/ibm-ceph-beta/prometheus-alertmanager:|" \
-  -e "s|registry.redhat.io/rhceph/rhceph-haproxy-rhel9:|icr.io/ibm-ceph-beta/haproxy-rhel9:|" \
-  -e "s|registry.redhat.io/rhceph/keepalived-rhel9:|icr.io/ibm-ceph-beta/keepalived-rhel9:|" \
-  -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:|icr.io/ibm-ceph-beta/snmp-notifier-rhel9:|" \
-  -e "s|registry.redhat.io/rhceph/ceph-nvmeof-rhel9:|icr.io/ibm-ceph-beta/nvmeof-rhel9:|" \
-  -e "s|default='registry.redhat.io'|default='icr.io'|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-7-rhel9:|cp.icr.io/cp/ibm-ceph/ceph-7-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus:|cp.icr.io/cp/ibm-ceph/prometheus:|" \
+  -e "s|registry.redhat.io/openshift-logging/logging-loki-rhel8:|cp.icr.io/cp/ibm-ceph/logging-loki-rhel8:|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-promtail-rhel9:|cp.icr.io/cp/ibm-ceph/promtail-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus-node-exporter:|cp.icr.io/cp/ibm-ceph/prometheus-node-exporter:|" \
+  -e "s|registry.redhat.io/rhceph/grafana-rhel9:|cp.icr.io/cp/ibm-ceph/grafana-rhel9:|" \
+  -e "s|registry.redhat.io/openshift4/ose-prometheus-alertmanager:|cp.icr.io/cp/ibm-ceph/prometheus-alertmanager:|" \
+  -e "s|registry.redhat.io/rhceph/rhceph-haproxy-rhel9:|cp.icr.io/cp/ibm-ceph/haproxy-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/keepalived-rhel9:|cp.icr.io/cp/ibm-ceph/keepalived-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:|cp.icr.io/cp/ibm-ceph/snmp-notifier-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/ceph-nvmeof-rhel9:|cp.icr.io/cp/ibm-ceph/nvmeof-rhel9:|" \
+  -e "s|default='registry.redhat.io'|default='cp.icr.io'|" \
   /usr/share/ceph/mgr/cephadm/module.py && \


### PR DESCRIPTION
This reverts commit 26c185c6730a227e8afae88cfa8b303d6e5c470e.

We shipped the 7.1 Beta, so no longer need to ref the beta registry

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
