### PR TITLE
centos: add 'ceph' to prerelease paths on download.ceph.com

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -94,7 +94,7 @@ bash -c ' \
   else \
     RELEASE_VER=1 ;\
     if [[ __ENV_[PRERELEASE]__ = true ]] ; then \
-      REPO_URL="https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
+      REPO_URL="https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/ceph/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
     else \
       REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
     fi \
@@ -105,7 +105,7 @@ bash -c ' \
   # ago in the ceph build
   #
   if [[ __ENV_[PRERELEASE]__ = true ]] ; then \
-    sed -i "s;http://download.ceph.com/;https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/;" /etc/yum.repos.d/ceph.repo ; \
+    sed -i "s;http://download.ceph.com/;https://__ENV_[PRERELEASE_USERNAME]__:__ENV_[PRERELEASE_PASSWORD]__@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
     dnf clean expire-cache ; \
   fi && \
   if [[ __ENV_[DISTRO_VERSION]__ -eq 8 ]]; then \

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -227,7 +227,7 @@ function get_ceph_download_url () {
       error "get_ceph_download_url - unknown distro '${distro}''"
   esac
   if [ "$PRERELEASE" = true ] ; then
-    echo "https://$PRERELEASE_USERNAME:$PRERELEASE_PASSWORD@download.ceph.com/prerelease/${flavor_path}/${arch}/"
+    echo "https://$PRERELEASE_USERNAME:$PRERELEASE_PASSWORD@download.ceph.com/prerelease/ceph/${flavor_path}/${arch}/"
   else
     echo "https://download.ceph.com/${flavor_path}/${arch}/"
   fi


### PR DESCRIPTION
prerelease now used for other projects (ceph-iscsi)

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
