### PR TITLE
ubi9: exclude ppc64le for squid

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/daemon-base/container.yaml
+++ b/ceph-releases/squid/ubi9-ibm/daemon-base/container.yaml
@@ -1,6 +1,9 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
+platforms:
+  not: ppc64le
+
 compose:
   packages: []
   pulp_repos: true

--- a/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
+++ b/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
@@ -1,6 +1,9 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
+platforms:
+  not: ppc64le
+
 compose:
   packages: []
   pulp_repos: true


### PR DESCRIPTION
We cannot build squid on RHEL 9 on ppc64le yet due to https://tracker.ceph.com/issues/66306

Revert this change when that issue is resolved and we can build squid on ppc64le.