### PR TITLE
Makefile: temporarily disable quincy builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
-	quincy,centos,9 \
 	reef,centos,9 \
 	main,centos,9
 


### PR DESCRIPTION
As long as `ceph-release` rpm is not available at [1], quincy builds will fail.

Let's disable Quincy builds until this issue is addressed.

[1] https://download.ceph.com/rpm-quincy/el9//noarch/
