### PR TITLE
update push_ceph_imgs() function

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -267,7 +267,7 @@ function build_ceph_imgs {
 declare -F push_ceph_imgs ||
 function push_ceph_imgs {
   echo "Push Ceph container image(s) to the registry"
-  make BASEOS_TAG=stream8 RELEASE="$RELEASE" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" push.parallel
+  make BASEOS_TAG=stream"${CENTOS_RELEASE}" RELEASE="$RELEASE" BASEOS_REGISTRY="${CONTAINER_REPO_HOSTNAME}/centos" BASEOS_REPO=centos TAG_REGISTRY="${CONTAINER_REPO_ORGANIZATION}" IMAGES_TO_BUILD="daemon-base demo" push.parallel
 }
 
 declare -F push_ceph_imgs_latest ||


### PR DESCRIPTION
`stream8` is hardcoded, let's use the same logic as in `build_ceph_imgs()`.
Also, do not try to push `daemon` images as we no longer build them by default.
