### PR TITLE
drop 'pacific' from CEPH_RELEASES env var

### DIFF
--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -51,7 +51,7 @@ OSD_FLAVOR=${OSD_FLAVOR:=default}
 
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'main' position in the array, this will break the 'latest' tag
-  CEPH_RELEASES=(main pacific quincy reef)
+  CEPH_RELEASES=(main quincy reef)
 fi
 
 HOST_ARCH=$(uname -m)


### PR DESCRIPTION
pacific is EOL, there's no need to leave it in `CEPH_RELEASES` env var.
