### PR TITLE
ubi9: add aarch64 content sets for squid

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/daemon-base/content_sets.yml
+++ b/ceph-releases/squid/ubi9-ibm/daemon-base/content_sets.yml
@@ -23,3 +23,8 @@ s390x:
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-8-tools-for-rhel-9-s390x-rpms
   - codeready-builder-for-rhel-9-s390x-rpms
+aarch64:
+  - rhel-9-for-aarch64-baseos-rpms
+  - rhel-9-for-aarch64-appstream-rpms
+  - rhceph-8-tools-for-rhel-9-aarch64-rpms
+  - codeready-builder-for-rhel-9-aarch64-rpms

--- a/ceph-releases/squid/ubi9-redhat/daemon-base/content_sets.yml
+++ b/ceph-releases/squid/ubi9-redhat/daemon-base/content_sets.yml
@@ -23,3 +23,8 @@ s390x:
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-8-tools-for-rhel-9-s390x-rpms
   - codeready-builder-for-rhel-9-s390x-rpms
+aarch64:
+  - rhel-9-for-aarch64-baseos-rpms
+  - rhel-9-for-aarch64-appstream-rpms
+  - rhceph-8-tools-for-rhel-9-aarch64-rpms
+  - codeready-builder-for-rhel-9-aarch64-rpms


### PR DESCRIPTION
We're adding support for aarch64 in a future release. Define the content sets for OSBS here.