### PR TITLE
Revert "Makefile: temporarily disable quincy builds"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 
 # When updating these defaults, be sure to check that ALL_BUILDABLE_FLAVORS is updated
 FLAVORS ?= \
+	quincy,centos,9 \
 	reef,centos,9 \
 	main,centos,9
 


### PR DESCRIPTION
This reverts commit 851d67f16f03b5aa11c0c7f397d040bb0ad11e74 as `ceph-release` is now available at [1].

[1] https://download.ceph.com/rpm-quincy/el9/noarch/
