### PR TITLE
cephfs: add cephfs-shell package

### DIFF
--- a/src/daemon-base/__CEPHFS_PACKAGES__
+++ b/src/daemon-base/__CEPHFS_PACKAGES__
@@ -1,3 +1,4 @@
 ceph-mds__ENV_[CEPH_POINT_RELEASE]__ \
 cephfs-mirror__ENV_[CEPH_POINT_RELEASE]__ \
-cephfs-top__ENV_[CEPH_POINT_RELEASE]__
+cephfs-top__ENV_[CEPH_POINT_RELEASE]__ \
+cephfs-shell__ENV_[CEPH_POINT_RELEASE]__


### PR DESCRIPTION
This adds `cephfs-shell` package into the Ceph container image as this tool can be useful when managing CephFS.

Fixes: #2211
