### PR TITLE
build squid release by default

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,8 +8,6 @@ jobs:
         ceph_release: [quincy, reef, squid, main]
         exclude:
           - os: 9
-            ceph_release: squid
-          - os: 9
             ceph_release: quincy
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 FLAVORS ?= \
 	quincy,centos,9 \
 	reef,centos,9 \
+	squid,centos,9 \
 	main,centos,9
 
 TAG_REGISTRY ?= ceph

--- a/contrib/build-push-ceph-container-imgs.sh
+++ b/contrib/build-push-ceph-container-imgs.sh
@@ -51,7 +51,7 @@ OSD_FLAVOR=${OSD_FLAVOR:=default}
 
 if [ -z "$CEPH_RELEASES" ]; then
   # NEVER change 'main' position in the array, this will break the 'latest' tag
-  CEPH_RELEASES=(main quincy reef)
+  CEPH_RELEASES=(main quincy reef squid)
 fi
 
 HOST_ARCH=$(uname -m)

--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -13,8 +13,8 @@ trap 'exit $?' ERR
 # These build scripts don't need to have the aarch64 part of the distro specified
 # I.e., specifying 'luminous,centos-arm64,7' is not necessary for aarch64 builds; these scripts
 #       will do the right build. See configurable CENTOS_AARCH64_FLAVOR_DISTRO below
-X86_64_FLAVORS_TO_BUILD="${X86_64_FLAVORS_TO_BUILD:-pacific,centos,8 quincy,centos,8 reef,centos,8}"
-AARCH64_FLAVORS_TO_BUILD="${AARCH64_FLAVORS_TO_BUILD:-pacific,centos,8 quincy,centos,8 reef,centos,8}"
+X86_64_FLAVORS_TO_BUILD="${X86_64_FLAVORS_TO_BUILD:- quincy,centos,9 reef,centos,9 squid,centos,9}"
+AARCH64_FLAVORS_TO_BUILD="${AARCH64_FLAVORS_TO_BUILD:- quincy,centos,9 reef,centos,9 squid,centos,9}"
 
 # Allow running this script with the env var ARCH='aarch64' to build arm images
 # ARCH='x86_64'


### PR DESCRIPTION
These changes will make the project build Ceph Squid by default in addition to quincy, reef and main
