### PR TITLE
squid: add nginx container substitution for ibm

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/__DOCKERFILE_BRANDING__
+++ b/ceph-releases/squid/ubi9-ibm/__DOCKERFILE_BRANDING__
@@ -11,5 +11,6 @@ sed -i \
   -e "s|registry.redhat.io/rhceph/keepalived-rhel9:|cp.icr.io/cp/ibm-ceph/keepalived-rhel9:|" \
   -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:|cp.icr.io/cp/ibm-ceph/snmp-notifier-rhel9:|" \
   -e "s|registry.redhat.io/rhceph/ceph-nvmeof-rhel9:|cp.icr.io/cp/ibm-ceph/nvmeof-rhel9:|" \
+  -e "s|registry.redhat.io/rhel9/nginx-124:|cp.icr.io/cp/ibm-ceph/nginx-124-rhel9:|" \
   -e "s|default='registry.redhat.io'|default='cp.icr.io'|" \
   /usr/share/ceph/mgr/cephadm/module.py && \


### PR DESCRIPTION
cephadm in Squid has a new `DEFAULT_NGINX_IMAGE`.

For RH Ceph Storage 8.0, we use the nginx image in Red Hat's registry.

For IBM Storage Ceph 8.0, we will cross-ship this image to IBM's registry.