### PR TITLE
squid: add oauth2 container substitution for ibm

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/__DOCKERFILE_BRANDING__
+++ b/ceph-releases/squid/ubi9-ibm/__DOCKERFILE_BRANDING__
@@ -12,5 +12,6 @@ sed -i \
   -e "s|registry.redhat.io/rhceph/snmp-notifier-rhel9:|cp.icr.io/cp/ibm-ceph/snmp-notifier-rhel9:|" \
   -e "s|registry.redhat.io/rhceph/ceph-nvmeof-rhel9:|cp.icr.io/cp/ibm-ceph/nvmeof-rhel9:|" \
   -e "s|registry.redhat.io/rhel9/nginx-124:|cp.icr.io/cp/ibm-ceph/nginx-124-rhel9:|" \
+  -e "s|registry.redhat.io/rhceph/oauth2-proxy-rhel9:|cp.icr.io/cp/ibm-ceph/oauth2-proxy-rhel9:|" \
   -e "s|default='registry.redhat.io'|default='cp.icr.io'|" \
   /usr/share/ceph/mgr/cephadm/module.py && \


### PR DESCRIPTION
cephadm in Squid will have a new `DEFAULT_OAUTH2_PROXY` image.

Add the substitution statement for IBM Storage Ceph 8.0 so that the ibm-ceph container points at the appropriate image registry.