### PR TITLE
ubi9: re-enable ppc64le for squid

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/daemon-base/container.yaml
+++ b/ceph-releases/squid/ubi9-ibm/daemon-base/container.yaml
@@ -1,9 +1,6 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
-platforms:
-  not: ppc64le
-
 compose:
   packages: []
   pulp_repos: true

--- a/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
+++ b/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
@@ -1,9 +1,6 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
-platforms:
-  not: ppc64le
-
 compose:
   packages: []
   pulp_repos: true


### PR DESCRIPTION
This reverts commit 55ad0f204a1d654ee565abf874aecad0cc209d0e.

We've resolved https://tracker.ceph.com/issues/66306 with https://github.com/ceph/ceph/pull/59558 .