### PR TITLE
Revert ganesha6

### DIFF
--- a/ceph-releases/ALL/centos-arm64/9/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos-arm64/9/daemon-base/__DOCKERFILE_INSTALL__
@@ -2,17 +2,17 @@ yum install -y epel-release && \
 yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
-    if [[ "${CEPH_VERSION}" =~ master|main|squid ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|main|reef|squid ]]; then \
       ARCH=$(arch); if [[ "${ARCH}" == "aarch64" ]]; then ARCH="arm64"; fi ; \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-6/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-5/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
-    elif [[ "${CEPH_VERSION}" =~ quincy|reef ]]; then \
+    elif  [[ "${CEPH_VERSION}" == quincy ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-5/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever/storage/\$basearch/nfsganesha-4/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
     elif [[ "${CEPH_VERSION}" == pacific ]]; then \

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -2,13 +2,7 @@ yum install -y epel-release && \
 yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
-    if [[ "${CEPH_VERSION}" =~ master|main|squid ]]; then \
-      echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
-      echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-6/" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
-    elif [[ "${CEPH_VERSION}" =~ quincy|reef ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|main|quincy|reef|squid ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-5/" >> /etc/yum.repos.d/ganesha.repo ; \

--- a/ceph-releases/quincy/__GANESHA_PACKAGES__
+++ b/ceph-releases/quincy/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon rpcbind

--- a/ceph-releases/quincy/centos-arm64/__GANESHA_PACKAGES__
+++ b/ceph-releases/quincy/centos-arm64/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-../../quincy/__GANESHA_PACKAGES__
+../../../src/daemon-base/__GANESHA_PACKAGES__

--- a/ceph-releases/reef/__GANESHA_PACKAGES__
+++ b/ceph-releases/reef/__GANESHA_PACKAGES__
@@ -1,1 +1,0 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon rpcbind

--- a/ceph-releases/reef/centos-arm64/__GANESHA_PACKAGES__
+++ b/ceph-releases/reef/centos-arm64/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-../../reef/__GANESHA_PACKAGES__
+../../../src/daemon-base/__GANESHA_PACKAGES__

--- a/ceph-releases/squid/centos/__GANESHA_PACKAGES__
+++ b/ceph-releases/squid/centos/__GANESHA_PACKAGES__
@@ -1,0 +1,1 @@
+nfs-ganesha-5.5-1.el__ENV_[DISTRO_VERSION]__s nfs-ganesha-ceph-5.5-1.el__ENV_[DISTRO_VERSION]__s nfs-ganesha-rgw-5.5-1.el__ENV_[DISTRO_VERSION]__s nfs-ganesha-rados-grace-5.5-1.el__ENV_[DISTRO_VERSION]__s nfs-ganesha-rados-urls-5.5-1.el__ENV_[DISTRO_VERSION]__s sssd-client dbus-daemon rpcbind

--- a/src/daemon-base/__GANESHA_PACKAGES__
+++ b/src/daemon-base/__GANESHA_PACKAGES__
@@ -1,1 +1,1 @@
-nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon rpcbind gmonitoring
+nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls sssd-client dbus-daemon rpcbind


### PR DESCRIPTION
The recent bump to nfs-ganesha v6 broke squid deployments.
Let's revert these changes until we figure out why it's failing.