### PR TITLE
ceph-build-config.sh: filter out deleted tags

### DIFF
--- a/contrib/ceph-build-config.sh
+++ b/contrib/ceph-build-config.sh
@@ -343,7 +343,7 @@ function get_tags_matching () {
   while response="$(curl --silent --fail --list-only --location \
                       "${tag_list_url}&page=${page}")"; do
     local matching_tags ; matching_tags="$(echo "${response}" | \
-              jq -r ".tags[] | select(.name | match(\"${version_tag}\")) | .name")"
+              jq -r ".tags[] | select(.end_ts == null) | select(.name | match(\"${version_tag}\")) | .name")"
     # jq: From the results of the curl, select all images with a name matching the matcher, and then
     # output the name. Exits success w/ empty string if no matches found.
     if [ -n "${matching_tags}" ]; then


### PR DESCRIPTION
Deleted tags still show up in the REST API.  They have a non-null end_ts field.  Since those images can't be pulled, they should not be listed as currently available, and should not affect the search for the latest available tag when checking from the build.

<!-- Please take a look at our [Contributing](/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-container! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
