### PR TITLE
quincy: Use nfs-ganesha 4

### DIFF
--- a/ceph-releases/ALL/centos-arm64/9/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos-arm64/9/daemon-base/__DOCKERFILE_INSTALL__
@@ -12,7 +12,7 @@ bash -c ' \
     elif  [[ "${CEPH_VERSION}" == quincy ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
-      echo "baseurl=https://buildlogs.centos.org/centos/\$releasever/storage/\$basearch/nfsganesha-4/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://mirror.stream.centos.org/SIGs/\$releasever-stream/storage/\$basearch/nfsganesha-4/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
     elif [[ "${CEPH_VERSION}" == pacific ]]; then \

--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -2,10 +2,16 @@ yum install -y epel-release && \
 yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
-    if [[ "${CEPH_VERSION}" =~ master|main|quincy|reef|squid ]]; then \
+    if [[ "${CEPH_VERSION}" =~ master|main|reef|squid ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "baseurl=https://buildlogs.centos.org/centos/\$releasever-stream/storage/\$basearch/nfsganesha-5/" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
+    elif [[ "${{CEPH_VERSION}}" == quincy ]]; then \
+      echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
+      echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
+      echo "baseurl=https://mirror.stream.centos.org/SIGs/\$releasever-stream/storage/\$basearch/nfsganesha-4/" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
       echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
     elif [[ "${CEPH_VERSION}" == pacific ]]; then \


### PR DESCRIPTION
This should unbreak the 17.2.8 build.

There is a more elegant solution to this overall issue here (https://github.com/ceph/ceph-container/pull/2169) but a lot has changed since then and paths, versions, etc. need to be verified.
Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
