### PR TITLE
ubi9: disable aarch64 for Red Hat OSBS build and remove references to RH aarch64 CDN repository

### DIFF
--- a/ceph-releases/squid/ubi9-ibm/daemon-base/content_sets.yml
+++ b/ceph-releases/squid/ubi9-ibm/daemon-base/content_sets.yml
@@ -23,8 +23,3 @@ s390x:
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-8-tools-for-rhel-9-s390x-rpms
   - codeready-builder-for-rhel-9-s390x-rpms
-aarch64:
-  - rhel-9-for-aarch64-baseos-rpms
-  - rhel-9-for-aarch64-appstream-rpms
-  - rhceph-8-tools-for-rhel-9-aarch64-rpms
-  - codeready-builder-for-rhel-9-aarch64-rpms

--- a/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
+++ b/ceph-releases/squid/ubi9-redhat/daemon-base/container.yaml
@@ -1,6 +1,9 @@
 # https://osbs.readthedocs.io/en/latest/users.html#compose
 ---
 
+platforms:
+  not: aarch64
+
 compose:
   packages: []
   pulp_repos: true

--- a/ceph-releases/squid/ubi9-redhat/daemon-base/content_sets.yml
+++ b/ceph-releases/squid/ubi9-redhat/daemon-base/content_sets.yml
@@ -23,8 +23,3 @@ s390x:
   - rhel-9-for-s390x-appstream-rpms
   - rhceph-8-tools-for-rhel-9-s390x-rpms
   - codeready-builder-for-rhel-9-s390x-rpms
-aarch64:
-  - rhel-9-for-aarch64-baseos-rpms
-  - rhel-9-for-aarch64-appstream-rpms
-  - rhceph-8-tools-for-rhel-9-aarch64-rpms
-  - codeready-builder-for-rhel-9-aarch64-rpms


### PR DESCRIPTION
The `rhceph-8-tools-for-rhel-9-aarch64-rpms` repository does not exist on `cdn.redhat.com`. ODCS will not use RPMs from that Pulp repo. Remove the references from `content_sets.yml`.

We will build the aarch64-enabled container at IBM, not Red Hat. We can disable aarch64 in the ubi9-redhat `container.yaml` file.
